### PR TITLE
refactor: remove per-task Progresso tracking from overlay files

### DIFF
--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -83,7 +83,7 @@
     },
     {
       "name": "quick-report",
-      "description": "Compact daily status dashboard. Shows version progress, active tasks with Progresso status, ready-to-start, and blocked tasks. Read-only.",
+      "description": "Compact daily status dashboard. Shows version progress, active tasks with current status, ready-to-start, and blocked tasks. Read-only.",
       "source": "./quick-report"
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ path using this priority:
 }
 ```
 
-**Task overlay files** (progress tracking, Ring source links) are stored as individual files
+**Task overlay files** (Ring source links) are stored as individual files
 in a `tasks/` directory **derived from the tasksFile path**:
 
 ```
@@ -224,9 +224,6 @@ suggests running `/optimus-import`.
 **Task spec:** `docs/pre-dev/tasks/task_001.md`
 **Subtasks:** `docs/pre-dev/subtasks/T-001/`
 
-## Progresso
-- [x] JWT middleware configurado
-- [x] Testes unitários passando
 ```
 
 **docs/tasks/T-002.md**:
@@ -235,10 +232,6 @@ suggests running `/optimus-import`.
 
 ## Fonte
 **Task spec:** `docs/pre-dev/tasks/task_002.md`
-
-## Progresso
-- [ ] Endpoint POST /api/users
-- [ ] Validação de email
 ```
 
 ### Column Specification
@@ -357,12 +350,9 @@ Each task has an overlay file at `docs/tasks/T-NNN.md` containing:
 - **Fonte:** Links to Ring pre-dev source (task spec, subtasks, execution plan).
   Stage agents (build, plan, check) MUST follow these links and read the referenced
   files for objective, acceptance criteria, and implementation details.
-- **Progresso:** Checkboxes tracking implementation progress (`- [x]` / `- [ ]`)
 
 Agents read objective and acceptance criteria from the Ring source (via Fonte links).
 The overlay only tracks operational state — it does NOT duplicate content from Ring.
-Tasks without Ring pre-dev artifacts have an empty `## Progresso` section until
-Ring pre-dev is run.
 
 This split prevents merge conflicts when multiple worktrees work on different tasks —
 each worktree only modifies its own `docs/tasks/T-NNN.md` file.
@@ -376,20 +366,7 @@ Example overlay:
 **Subtasks:** `docs/pre-dev/subtasks/T-020/`
 **Plano:** `docs/pre-dev/subtasks/T-020/PARALLEL-PLAN.md`
 
-## Progresso
-- [x] ST-020-01: Database schema
-- [ ] ST-020-02: API endpoints
-- [ ] ST-020-03: Input validation
 ```
-
-### Progress Tracking
-
-The checkboxes in **Progresso** (in `docs/tasks/T-NNN.md`) are updated by stage agents:
-- **build** marks items as `- [x]` as each is implemented
-- **check** validates that marked items are actually satisfied by reading the Ring source
-  (flags mismatches: `[x]` but not implemented → HIGH, `[ ]` but implemented → MEDIUM)
-
-This ensures the overlay accurately reflects what was delivered at every point in the lifecycle.
 
 ### Version Management
 
@@ -506,8 +483,8 @@ Any status → Cancelado  (via tasks cancel operation)
    Consider removing this dependency via `/optimus-tasks`." This helps the user
    understand the blocker requires a dependency edit, not waiting for completion.
 7. **Expanded confirmation on status change** — when a stage agent is about to change
-   a task's status, it shows the task summary (title, version, and Progresso from
-   `docs/tasks/T-NNN.md`) and asks for explicit confirmation via `AskUser`. This
+   a task's status, it shows the task summary (title and version) and asks for
+   explicit confirmation via `AskUser`. This
    prevents accidental status changes on the wrong task, especially during auto-detect.
 
    **Show expanded confirmation when:**
@@ -706,7 +683,7 @@ Each task gets its own file (e.g., `.optimus/session-T-003.json`).
   "started_at": "2025-01-15T10:30:00Z",
   "updated_at": "2025-01-15T11:45:00Z",
   "phase": "Phase 1: Implementation",
-  "notes": "Implementation in progress, 3 of 5 progress items done"
+  "notes": "Implementation in progress"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Skills are classified as **Administrative** (run anywhere) or **Execution** (req
 | `tasks` | Create, edit, remove, reorder, and cancel tasks in tasks.md. Runs on any branch | `/optimus-tasks` |
 | `batch` | Pipeline orchestrator: chains stages 1-5 for one or more tasks with user checkpoints between stages | `/optimus-batch` |
 | `resolve` | Resolves merge conflicts in tasks.md caused by parallel task execution across feature branches | `/optimus-resolve` |
-| `quick-report` | Compact daily status dashboard. Shows version progress, active tasks with Progresso status, ready-to-start, and blocked tasks. Read-only | `/optimus-quick-report` |
+| `quick-report` | Compact daily status dashboard. Shows version progress, active tasks with current status, ready-to-start, and blocked tasks. Read-only | `/optimus-quick-report` |
 | `help` | Lists all available Optimus skills with descriptions, usage commands, and when to use each one | `/optimus-help` |
 
 ### Execution Skills (stages 1-5)

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -111,7 +111,7 @@ Executes a validated task specification end-to-end: identifies the task, loads c
 
 Execute session state protocol — see AGENTS.md Protocol: Session State. Use stage=`build`, status=`Em Andamento`.
 
-**On stage completion** (after Phase 4 post-execution): delete the session file.
+**On stage completion** (after Phase 3 post-execution): delete the session file.
 
 ### Step 1.3: Validate and Update Task Status
 
@@ -141,10 +141,6 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
        **T-XXX: [title]**
        **Version:** [version from table]
-       **Progresso:**
-       - [ ] [item 1]
-       - [ ] [item 2]
-       ...
 
        Confirm status change?
        ```
@@ -286,35 +282,11 @@ While dev-cycle executes:
 
 ---
 
-## Phase 3: Update Progress Checkboxes
-
-After Phase 2 completes, update the `## Progresso` checkboxes in the overlay file
-to reflect what was actually implemented.
-
-**IMPORTANT:** This step runs AFTER implementation and verification complete but BEFORE
-presenting the final summary. This ensures that when stage-3 (impl-review) runs, the
-checkboxes already reflect what was implemented, preventing false findings.
-
-### Step 3.1: Evaluate and Mark Checkboxes
-
-1. Read `docs/tasks/T-XXX.md` and list all items in `## Progresso` (`- [ ] ...`)
-2. For each item, read the corresponding Ring source (subtask file or acceptance criterion)
-   and verify whether the implementation satisfies it:
-   - If satisfied → mark as `- [x]`
-   - If NOT satisfied → leave as `- [ ]` and warn the user
-3. Commit the updated progress:
-   ```bash
-   git add "$TASKS_DIR/T-XXX.md"
-   git commit -m "chore(tasks): update progress for T-XXX"
-   ```
-
----
-
-## Phase 4: Post-Execution
+## Phase 3: Post-Execution
 
 After implementation completes (via dev-cycle):
 
-### Step 4.1: Test Gap Cross-Reference
+### Step 3.1: Test Gap Cross-Reference
 
 Review any test gaps identified during implementation:
 
@@ -327,7 +299,7 @@ Review any test gaps identified during implementation:
    - Flag as a gap and recommend adding the test to the current task
 4. Do NOT silently skip test gaps because they might be covered later — always verify and ask
 
-### Step 4.2: Present Final Summary
+### Step 3.2: Present Final Summary
 
 Present a structured summary including:
 - Task ID and title
@@ -336,7 +308,7 @@ Present a structured summary including:
 - dev-cycle gate results (all 6 gates)
 - Decisions made during questioning and review phases
 
-### Step 4.3: Commit
+### Step 3.3: Commit
 
 Only after explicit user approval:
 
@@ -345,7 +317,7 @@ Only after explicit user approval:
 3. If clean, stage all relevant files and commit with a descriptive message
 4. Run `git status` to confirm the commit succeeded
 
-### Step 4.4: Push Commits (optional)
+### Step 3.4: Push Commits (optional)
 
 Offer to push commits — see AGENTS.md Protocol: Push Commits.
 
@@ -376,6 +348,5 @@ If the user requests a dry-run (e.g., "dry-run impl T-003", "preview implementat
 - Present the implementation plan and all questions (Step 1.9)
 - **Do NOT change task status** — skip Step 1.3 (status update)
 - **Do NOT execute implementation** — skip Phase 2 entirely
-- **Do NOT update checkboxes** — skip Phase 3
-- **Do NOT commit or push anything** — skip Phase 4 commits
+- **Do NOT commit or push anything** — skip Phase 3 commits
 - Present a summary of: what would be implemented, estimated effort, identified risks

--- a/catalog/system/quick-report.md
+++ b/catalog/system/quick-report.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Compact daily status dashboard. Shows version progress, active tasks with Progresso status, ready-to-start tasks, and blocked tasks. Lightweight alternative to the full report — no git operations, no velocity metrics. Read-only.
+Compact daily status dashboard. Shows version progress, active tasks with current status, ready-to-start tasks, and blocked tasks. Lightweight alternative to the full report — no git operations, no velocity metrics. Read-only.
 
 ## Variables
 

--- a/check/skills/optimus-check/SKILL.md
+++ b/check/skills/optimus-check/SKILL.md
@@ -156,10 +156,6 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
        **T-XXX: [title]**
        **Version:** [version from table]
-       **Progresso:**
-       - [ ] [item 1]
-       - [ ] [item 2]
-       ...
 
        Confirm status change?
        ```
@@ -397,10 +393,7 @@ Required output format:
 
 **Spec Compliance agent** must additionally:
 1. List every acceptance criterion from the Ring source (via `## Fonte` in the overlay) and mark PASS/FAIL/PARTIAL
-2. **Validate checkboxes:** Verify that the `- [x]` items in `## Progresso` match reality.
-   If an item is marked `[x]` but the implementation doesn't satisfy it → flag as HIGH finding.
-   If an item is marked `[ ]` but the implementation satisfies it → flag as MEDIUM finding (checkbox not updated).
-3. List every test ID and verify a corresponding test exists
+2. List every test ID and verify a corresponding test exists
 4. If the task has API endpoints, verify request/response format matches API contracts
 5. If the task has DB changes, verify column types/constraints match the data model
 
@@ -789,7 +782,6 @@ The `--assignee @me` flag assigns the PR to the authenticated GitHub user automa
 The body should include:
 - Task ID and title
 - Objective (from Ring source via `## Fonte` in overlay)
-- Progresso summary
 - Link to the task section in tasks.md
 
 ### Step 12.4: Confirm

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -123,10 +123,6 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
        **T-XXX: [title]**
        **Version:** [version from table]
-       **Progresso:**
-       - [x] [item 1]
-       - [x] [item 2]
-       ...
 
        Confirm close?
        ```

--- a/help/skills/optimus-help/SKILL.md
+++ b/help/skills/optimus-help/SKILL.md
@@ -39,7 +39,7 @@ terminal display when available, otherwise use markdown tables.
 | **report** | `/optimus-report` | Checking project status — shows progress, active/blocked/ready tasks, dependency graph, parallelization opportunities, and velocity metrics. Read-only. |
 | **tasks** | `/optimus-tasks` | Creating, editing, removing, reordering, cancelling, or reopening tasks. Managing versions. Any administrative task management. |
 | **resolve** | `/optimus-resolve` | Resolving merge conflicts in `tasks.md` caused by parallel task execution across feature branches. |
-| **quick-report** | `/optimus-quick-report` | Compact daily status — active tasks with Progresso status, ready-to-start, blocked. No git ops. Read-only. |
+| **quick-report** | `/optimus-quick-report` | Compact daily status — active tasks with current status, ready-to-start, blocked. No git ops. Read-only. |
 | **help** | `/optimus-help` | This skill — discovering what's available. |
 
 ### Execution Skills (task lifecycle, stages 1-5)

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -46,7 +46,7 @@ verification:
     - All Ring pre-dev tasks discovered and presented
     - Proposal shown before any changes
     - tasks.md generated in correct optimus format
-    - Overlay T-NNN.md files created with Fonte + Progresso
+    - Overlay T-NNN.md files created with Fonte links
     - Original Ring files NOT deleted
 ---
 
@@ -54,7 +54,7 @@ verification:
 
 Reads Ring pre-dev artifacts (`docs/pre-dev/tasks/`, `docs/pre-dev/subtasks/`) and creates
 the optimus tracking layer: `tasks.md` (status table) + `T-NNN.md` overlay files (Fonte
-links + Progresso checkboxes). Never copies content from Ring — only references it.
+links). Never copies content from Ring — only references it.
 
 **CRITICAL:** This agent NEVER deletes original files. It creates/updates tasks.md
 and overlay files, leaving Ring pre-dev artifacts untouched.
@@ -215,25 +215,12 @@ For each imported task, create `TASKS_DIR/T-NNN.md`:
 **Subtasks:** `docs/pre-dev/subtasks/T-NNN/`
 **Plano:** `docs/pre-dev/subtasks/T-NNN/PARALLEL-PLAN.md`
 
-| Arquivo | Descricao |
-|---------|-----------|
-| ST-NNN-01-xxx.md | <heading from subtask file> |
-| ST-NNN-02-yyy.md | <heading from subtask file> |
-| ... | ... |
-
-## Progresso
-- [ ] <subtask 1 short title>
-- [ ] <subtask 2 short title>
-- [ ] <subtask 3 short title>
 ```
 
 **Rules for overlay creation:**
 - `## Fonte` links to Ring source files — paths are relative to project root
-- If no subtasks directory exists, omit the Subtasks line and table
+- If no subtasks directory exists, omit the Subtasks line
 - If no PARALLEL-PLAN.md exists, omit that line
-- `## Progresso` items are derived from subtask headings (short titles)
-- If no subtasks exist, derive Progresso from the Ring task spec's acceptance criteria
-- All checkboxes start as `- [ ]`
 
 **IMPORTANT:** The overlay does NOT contain Objetivo or Critérios de Aceite. Agents
 read those from the Ring source via the Fonte links.
@@ -286,6 +273,5 @@ Original Ring files preserved."
 - **NEVER apply changes without user approval** — always present and confirm first
 - **NEVER invent task content** — only extract titles and subtask headings from Ring source
 - Ring pre-dev is the ONLY import source — generic formats (YAML, checklist, index) are not supported
-- If a Ring task has no subtasks, derive Progresso from the task spec's acceptance criteria
 - IDs between optimus and Ring are independent — Optimus T-038 may reference Ring T-020
 - Task IDs must be unique — if duplicates found, warn the user before proceeding

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -138,10 +138,6 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
        **T-XXX: [title]**
        **Version:** [version from table]
-       **Progresso:**
-       - [ ] [item 1]
-       - [ ] [item 2]
-       ...
 
        Confirm status change?
        ```

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -133,10 +133,6 @@ When the user references a task (e.g., "review PR for T-012") or a `tasks.md` ex
 
        **T-XXX: [title]**
        **Version:** [version from table]
-       **Progresso:**
-       - [ ] [item 1]
-       - [ ] [item 2]
-       ...
 
        Confirm status change?
        ```
@@ -194,7 +190,7 @@ Options:
 
 If the user chooses **Create PR**:
 1. Generate PR title from task Tipo + ID + title (e.g., `feat(T-003): add user registration API`)
-2. Generate PR body from Ring source (read via `## Fonte` in `docs/tasks/T-XXX.md`) and Progresso status
+2. Generate PR body from Ring source (read via `## Fonte` in `docs/tasks/T-XXX.md`)
 3. Push the branch if not yet pushed: `git push -u origin $(git branch --show-current)`
 4. Create the PR:
    ```bash

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -44,7 +44,7 @@ verification:
 # Quick Report
 
 Compact daily status dashboard. Parses `tasks.md` and presents a focused overview:
-version progress, active tasks with Progresso status, ready-to-start tasks,
+version progress, active tasks with current status, ready-to-start tasks,
 and blocked tasks.
 
 **CRITICAL:** This agent NEVER modifies any files. It only reads and reports.

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -146,12 +146,12 @@ If the user's invocation matches quick status triggers ("quick status", "what am
 
 1. Parse tasks.md (Phase 1 still runs fully)
 2. Find tasks with status other than `Pendente`, `DONE`, and `Cancelado` (active tasks)
-3. For each active task, read its overlay file (`docs/tasks/T-NNN.md`) and count checked vs total items in `## Progresso`
+3. For each active task, read its overlay file (`docs/tasks/T-NNN.md`) for context
 4. Present ONLY:
 
 ```
 Quick Status:
-  Active: T-XXX — [title] (Em Andamento) — 3/5 criteria done
+  Active: T-XXX — [title] (Em Andamento)
   Next up: T-YYY — [title] (Pendente, ready to start)
 ```
 

--- a/resolve/skills/optimus-resolve/SKILL.md
+++ b/resolve/skills/optimus-resolve/SKILL.md
@@ -88,7 +88,7 @@ For each conflict region, classify its content:
 |-------------|---------------|---------------------|
 | **Task table rows** | Lines matching `\| T-\d+ \|` pattern | Per-task most-advanced-status |
 | **Versions table** | Lines in the `## Versions` section | Merge both — keep all versions; deduplicate by name (if same version name on both sides, keep the one with more advanced status: Ativa > Próxima > Planejada > Backlog > Concluída) |
-| **Task overlay files** | `docs/tasks/T-NNN.md` files | Merge: union of `[x]` checkboxes from both sides in `## Progresso` (Step 2.4) |
+| **Task overlay files** | `docs/tasks/T-NNN.md` files | Merge: keep `## Fonte` section (should be identical on both sides) (Step 2.4) |
 | **Format marker / headers** | First line, `# Tasks`, table headers | Keep either (identical) |
 
 ### Step 1.3: Parse Task Rows From Both Sides
@@ -163,9 +163,6 @@ If one side has `Cancelado` and the other has a non-terminal status:
 For `docs/tasks/T-NNN.md` overlay files that conflict:
 
 1. `## Fonte` section: should be identical on both sides (same Ring source). If different, flag for user decision.
-2. `## Progresso` checkboxes:
-   - If one side has more `[x]` checkboxes → use that version (more work was done)
-   - If both sides changed different checkboxes → merge both (union of `[x]` marks)
 
 ---
 

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -155,83 +155,29 @@ If unclear, ask the user via `AskUser`:
 Create from a template or from scratch?
 ```
 Options:
-- **API Endpoint** — pre-fills Feature tipo, standard API progress items
-- **Bug Fix** — pre-fills Fix tipo, standard debugging progress items
-- **UI Component** — pre-fills Feature tipo, standard frontend progress items
-- **Chore/Infra** — pre-fills Chore tipo, standard infrastructure progress items
-- **Refactor** — pre-fills Refactor tipo, standard refactoring progress items
-- **Documentation** — pre-fills Docs tipo, standard documentation progress items
-- **Test** — pre-fills Test tipo, standard testing progress items
+- **API Endpoint** — pre-fills Feature tipo
+- **Bug Fix** — pre-fills Fix tipo
+- **UI Component** — pre-fills Feature tipo
+- **Chore/Infra** — pre-fills Chore tipo
+- **Refactor** — pre-fills Refactor tipo
+- **Documentation** — pre-fills Docs tipo
+- **Test** — pre-fills Test tipo
 - **From scratch** — manual entry (no template)
 
 #### Built-in Templates
 
-Templates pre-fill `## Progresso` items in the overlay file. When a Ring pre-dev
-reference is linked (Step 2.3.1), the template items are replaced by subtask
-headings from the Ring source.
+Templates pre-fill Tipo and Priority. When a Ring pre-dev reference is linked
+(Step 2.3.1), the overlay will include Fonte links to the Ring source.
 
-**API Endpoint template:**
-- Tipo: `Feature`, Priority: `Alta`
-- Progresso:
-  - [ ] Endpoint implemented with correct HTTP method and path
-  - [ ] Request validation (required fields, types, constraints)
-  - [ ] Success response format matches API contract
-  - [ ] Error responses with appropriate HTTP status codes
-  - [ ] Authentication/authorization enforced
-  - [ ] Unit tests for handler (happy path + error paths)
-  - [ ] Integration tests for repository layer
-  - [ ] Documentation updated (if applicable)
+**API Endpoint template:** Tipo: `Feature`, Priority: `Alta`
+**Bug Fix template:** Tipo: `Fix`, Priority: `Alta`
+**UI Component template:** Tipo: `Feature`, Priority: `Media`
+**Chore/Infra template:** Tipo: `Chore`, Priority: `Media`
+**Refactor template:** Tipo: `Refactor`, Priority: `Media`
+**Documentation template:** Tipo: `Docs`, Priority: `Baixa`
+**Test template:** Tipo: `Test`, Priority: `Media`
 
-**Bug Fix template:**
-- Tipo: `Fix`, Priority: `Alta`
-- Progresso:
-  - [ ] Root cause identified and documented
-  - [ ] Fix implemented with minimal scope
-  - [ ] Regression test added (reproduces the bug, passes after fix)
-  - [ ] No unrelated changes included
-  - [ ] Unit tests passing
-
-**UI Component template:**
-- Tipo: `Feature`, Priority: `Media`
-- Progresso:
-  - [ ] Component renders correctly in all states (empty, loading, error, success)
-  - [ ] Responsive design (mobile, tablet, desktop)
-  - [ ] Accessibility (keyboard navigation, ARIA labels, screen reader)
-  - [ ] Unit tests for component logic
-  - [ ] Visual matches design spec
-
-**Chore/Infra template:**
-- Tipo: `Chore`, Priority: `Media`
-- Progresso:
-  - [ ] Configuration/infrastructure change applied
-  - [ ] No regression in existing functionality
-  - [ ] Documentation updated (if applicable)
-
-**Refactor template:**
-- Tipo: `Refactor`, Priority: `Media`
-- Progresso:
-  - [ ] Refactoring applied without changing external behavior
-  - [ ] All existing tests still pass
-  - [ ] No new warnings introduced
-  - [ ] Code review confirms improvement in readability/maintainability
-
-**Documentation template:**
-- Tipo: `Docs`, Priority: `Baixa`
-- Progresso:
-  - [ ] Documentation written/updated
-  - [ ] Examples included (if applicable)
-  - [ ] Links and references verified
-  - [ ] Spelling and grammar checked
-
-**Test template:**
-- Tipo: `Test`, Priority: `Media`
-- Progresso:
-  - [ ] Test scenarios identified and documented
-  - [ ] Tests implemented and passing
-  - [ ] Coverage improved for target area
-  - [ ] No flaky tests introduced
-
-When a template is selected, pre-fill the Tipo, Priority, and Progresso items.
+When a template is selected, pre-fill the Tipo and Priority.
 The user can then modify any field before confirming.
 
 **Option B: From scratch.** Ask the user for task details using `AskUser` (one question at a time or batch if info provided):
@@ -242,7 +188,7 @@ The user can then modify any field before confirming.
 4. **Estimate** (optional): Task size estimate (`S`, `M`, `L`, `XL`, `2h`, `1d`, etc.). Default: `-`
 5. **Version** (required): Must match a version in the Versions table. Default: the version with Status `Ativa`
 6. **Dependencies** (optional): Comma-separated task IDs (e.g., `T-001, T-003`) or `-` for none
-7. **Progress items** (optional): Checklist items for `## Progresso` in the overlay file. If omitted, Ring pre-dev discovery (Step 2.3.1) will populate them.
+7. **Ring pre-dev reference** (optional): Link to Ring pre-dev task spec. If omitted, Ring pre-dev discovery (Step 2.3.1) will attempt to find a match.
 
 If the user provided some of these in the initial request, use them and ask only for missing fields.
 
@@ -339,7 +285,7 @@ Link to one of these?
 Options:
 - **[N] task_NNN.md** — link this ring task
 - **Show all ring tasks** — list every task for manual selection
-- **None** — create without Ring reference (overlay will have empty Progresso)
+- **None** — create without Ring reference
 
 **If no matches found or `docs/pre-dev/tasks/` does not exist**, ask:
 ```
@@ -347,7 +293,7 @@ No ring pre-dev tasks found. Create task without Ring reference?
 ```
 Options:
 - **Show all ring tasks** — list every task for manual selection (if directory exists)
-- **Create without reference** — overlay with empty Progresso
+- **Create without reference** — overlay with Fonte section only
 
 ### Step 2.4: Add to tasks.md and create overlay file
 
@@ -364,17 +310,11 @@ Options:
    ## Fonte
    **Task spec:** `docs/pre-dev/tasks/task_NNN.md`
    **Subtasks:** `docs/pre-dev/subtasks/T-NNN/`
-
-   ## Progresso
-   - [ ] <subtask 1 short title>
-   - [ ] <subtask 2 short title>
    ```
 
    **If no Ring pre-dev linked:**
    ```markdown
    # T-NNN: <title>
-
-   ## Progresso
    ```
 3. Save both files
 
@@ -411,7 +351,7 @@ Determine which field(s) to edit. Editable fields:
 | Status | **No** | Status is managed ONLY by stage agents |
 | Branch | **No** | Branch is managed ONLY by stage-1 and close |
 | ID | **No** | IDs are immutable |
-| Progress items | Yes | Updates `## Progresso` in `docs/tasks/T-NNN.md` |
+| Ring reference | No | Updates `## Fonte` in `docs/tasks/T-NNN.md` |
 
 **HARD BLOCK:** If the user tries to change Status or Branch, refuse:
 ```
@@ -426,7 +366,7 @@ task, use "reopen T-XXX".
 1. Update the relevant column(s) in the table row in `docs/tasks.md`
 2. If Title changed, also update the heading in `docs/tasks/T-NNN.md`
 3. If Depends changed, validate all references exist and no circular dependencies
-4. If Progress items changed, update `## Progresso` in `docs/tasks/T-NNN.md`
+4. If Ring reference changed, update `## Fonte` in `docs/tasks/T-NNN.md`
 5. Save the file(s)
 
 ### Step 3.2: Confirm
@@ -666,7 +606,7 @@ To resolve, run `/optimus-tasks`:
    ```
    Options:
    - **Bug found** — implementation has a defect
-   - **Incomplete** — not all progress items were actually met
+   - **Incomplete** — not all acceptance criteria were actually met
    - **Requirements changed** — spec was updated after close
    - **Decision reversed** — cancellation decision was reconsidered (only for Cancelado)
    - **Cancel** — keep current status


### PR DESCRIPTION
## Motivacao

Implementacao com agentes eh rapida o suficiente para que o rastreamento de progresso por subtask (checkboxes em `## Progresso` nos arquivos `T-NNN.md`) nao agregue valor. O overhead de manter, atualizar e validar esses checkboxes nao se justifica.

**Progresso de versao** (contagem de tasks por status dentro de uma versao) continua funcionando normalmente.

## O que foi removido

- `## Progresso` section dos templates de overlay (import, tasks)
- Phase 3 (Update Progress Checkboxes) do build
- Validacao de checkboxes do check (spec compliance agent)
- Merge de checkboxes do resolve
- Contagem de progresso per-task do report/quick-report
- Progresso dos dialogs de confirmacao expandida (todos os stages)
- Template progress items do tasks (7 templates simplificados)

## O que foi preservado

- Progresso de versao (tasks por status dentro de uma versao)
- `## Fonte` section (links para Ring source — intocado)
- Toda funcionalidade restante dos overlay files

## Arquivos alterados

15 files: AGENTS.md, 10 skills, README, marketplace.json, catalog