### PR TITLE
fix: resolve .optimus/ state and session paths against main worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -650,17 +650,83 @@ If this command fails (exit code != 0), **STOP** immediately:
 GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before proceeding.
 ```
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
 ### Protocol: Initialize .optimus Directory
 
 **Referenced by:** import, tasks, report (export), quick-report, batch, all stage agents (1-4) for session files
 
 Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and operational/temporary files are gitignored:
+and operational/temporary files are gitignored. Resolve the main worktree first — see
+AGENTS.md Protocol: Resolve Main Worktree Path.
 
 ```bash
-mkdir -p .optimus/sessions .optimus/reports
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n' >> .gitignore
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 ```
 
@@ -675,27 +741,31 @@ Skills reference this as: "Initialize .optimus directory — see AGENTS.md Proto
 **Referenced by:** plan, review
 
 After the status change in state.json (and BEFORE any analysis work begins), increment
-the execution counter for the current stage in `.optimus/stats.json`. This tracks how many
-times each stage ran on each task — useful for spotting spec churn and review cycles.
+the execution counter for the current stage in `.optimus/stats.json` at the main
+worktree. This tracks how many times each stage ran on each task — useful for
+spotting spec churn and review cycles.
 
 **NOTE:** Only increment when NOT in dry-run mode.
 
-1. Read `.optimus/stats.json`. If the file does not exist, start with an empty object `{}`.
-   If the file exists but is corrupted, reset it:
+1. Resolve the main worktree — see Protocol: Resolve Main Worktree Path.
+2. Read `${MAIN_WORKTREE}/.optimus/stats.json`. If the file does not exist, start with
+   an empty object `{}`. If the file exists but is corrupted, reset it:
    ```bash
-   STATS_FILE=".optimus/stats.json"
+   # Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
    if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
      echo "WARNING: stats.json is corrupted. Resetting counters."
      echo '{}' > "$STATS_FILE"
    fi
    ```
-2. If the task ID key does not exist, initialize it:
+3. If the task ID key does not exist, initialize it:
    ```json
    { "plan_runs": 0, "review_runs": 0 }
    ```
-3. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
-4. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
-5. Write the updated JSON back to `.optimus/stats.json` (pretty-printed, sorted keys).
+4. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
+5. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
+6. Write the updated JSON back to `${STATS_FILE}` (pretty-printed, sorted keys).
 
 **NOTE:** stats.json is gitignored — no commit needed.
 
@@ -755,8 +825,9 @@ status change in state.json** (before any work begins). This ensures crash recov
 a record even if the agent fails before producing any output. Do NOT wait until
 "key phase transitions" to write the initial session file.
 
-**Session file location:** `.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `.optimus/sessions/session-T-003.json`).
+**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json`
+(gitignored; always resolved against the main worktree — see Protocol: Resolve Main
+Worktree Path). Each task gets its own file (e.g., `session-T-003.json`).
 
 ```json
 {
@@ -780,7 +851,9 @@ rather than restarting the entire analysis.
 **On stage start (after task ID is known):**
 
 ```bash
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
     echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
@@ -834,7 +907,9 @@ fi
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-mkdir -p .optimus/sessions .optimus/reports
+# (that protocol resolves MAIN_WORKTREE and creates the dirs at the main worktree)
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
 BRANCH_NAME=$(git branch --show-current 2>/dev/null || echo "detached")
 jq -n \
   --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
@@ -843,12 +918,13 @@ jq -n \
   --arg notes "<progress>" \
   '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
     started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > ".optimus/sessions/session-${TASK_ID}.json"
+  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 ```
 
 **On stage completion:** Delete the session file:
 ```bash
-rm -f ".optimus/sessions/session-${TASK_ID}.json"
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 ```
 
 Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
@@ -1341,7 +1417,10 @@ Skills reference this as: "Offer to push commits — see AGENTS.md Protocol: Pus
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -1350,12 +1429,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -1385,7 +1470,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -1413,7 +1499,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -1429,8 +1515,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -420,6 +420,65 @@ each task. If any task appears twice in the chain, a cycle exists. Report ALL ta
 in the cycle so the user can fix it with `/optimus-tasks`.
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch
@@ -481,7 +540,10 @@ Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Prot
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -490,12 +552,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -525,7 +593,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -553,7 +622,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -569,8 +638,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -633,6 +633,65 @@ each task. If any task appears twice in the chain, a cycle exists. Report ALL ta
 in the cycle so the user can fix it with `/optimus-tasks`.
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Convergence Loop (Full Roster Model)
 Applies to: plan, review, pr-check, coderabbit-review, deep-review, deep-doc-review
 
@@ -1131,8 +1190,9 @@ status change in state.json** (before any work begins). This ensures crash recov
 a record even if the agent fails before producing any output. Do NOT wait until
 "key phase transitions" to write the initial session file.
 
-**Session file location:** `.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `.optimus/sessions/session-T-003.json`).
+**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json`
+(gitignored; always resolved against the main worktree — see Protocol: Resolve Main
+Worktree Path). Each task gets its own file (e.g., `session-T-003.json`).
 
 ```json
 {
@@ -1156,7 +1216,9 @@ rather than restarting the entire analysis.
 **On stage start (after task ID is known):**
 
 ```bash
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
     echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
@@ -1210,7 +1272,9 @@ fi
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-mkdir -p .optimus/sessions .optimus/reports
+# (that protocol resolves MAIN_WORKTREE and creates the dirs at the main worktree)
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
 BRANCH_NAME=$(git branch --show-current 2>/dev/null || echo "detached")
 jq -n \
   --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
@@ -1219,12 +1283,13 @@ jq -n \
   --arg notes "<progress>" \
   '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
     started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > ".optimus/sessions/session-${TASK_ID}.json"
+  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 ```
 
 **On stage completion:** Delete the session file:
 ```bash
-rm -f ".optimus/sessions/session-${TASK_ID}.json"
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 ```
 
 Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
@@ -1234,7 +1299,10 @@ Skills reference this as: "Execute session state protocol from AGENTS.md using s
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -1243,12 +1311,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -1278,7 +1352,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -1306,7 +1381,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -1322,8 +1397,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -497,6 +497,65 @@ each task. If any task appears twice in the chain, a cycle exists. Report ALL ta
 in the cycle so the user can fix it with `/optimus-tasks`.
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: Active Version Guard
 
 **Referenced by:** all stage agents (1-4)
@@ -638,7 +697,10 @@ Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol:
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -647,12 +709,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -682,7 +750,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -710,7 +779,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -726,8 +795,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -182,7 +182,14 @@ carry over Depends, Priority, Version, and Estimate into tasks.md.
 "Status" or "Branch" (from an older tasks.md format), migrate them to state.json:
 ```bash
 # For each task with non-Pendente status or non-empty branch in EXISTING_DATA:
-STATE_FILE=".optimus/state.json"
+# Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then echo '{}' > "$STATE_FILE"; fi
 if [ -z "$TASK_ID" ] || [ -z "$LEGACY_STATUS" ]; then
   echo "WARNING: Skipping migration for task with empty ID or status."
@@ -498,12 +505,20 @@ These operations require explicit user confirmation.
 **Referenced by:** import, tasks, report (export), quick-report, batch, all stage agents (1-4) for session files
 
 Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and operational/temporary files are gitignored:
+and operational/temporary files are gitignored. Resolve the main worktree first — see
+AGENTS.md Protocol: Resolve Main Worktree Path.
 
 ```bash
-mkdir -p .optimus/sessions .optimus/reports
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n' >> .gitignore
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 ```
 
@@ -514,11 +529,73 @@ gitignored (operational/temporary state).
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: State Management
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -527,12 +604,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -562,7 +645,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -590,7 +674,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -606,8 +690,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -923,6 +923,65 @@ each task. If any task appears twice in the chain, a cycle exists. Report ALL ta
 in the cycle so the user can fix it with `/optimus-tasks`.
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Convergence Loop (Full Roster Model)
 Applies to: plan, review, pr-check, coderabbit-review, deep-review, deep-doc-review
 
@@ -1153,27 +1212,31 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 **Referenced by:** plan, review
 
 After the status change in state.json (and BEFORE any analysis work begins), increment
-the execution counter for the current stage in `.optimus/stats.json`. This tracks how many
-times each stage ran on each task — useful for spotting spec churn and review cycles.
+the execution counter for the current stage in `.optimus/stats.json` at the main
+worktree. This tracks how many times each stage ran on each task — useful for
+spotting spec churn and review cycles.
 
 **NOTE:** Only increment when NOT in dry-run mode.
 
-1. Read `.optimus/stats.json`. If the file does not exist, start with an empty object `{}`.
-   If the file exists but is corrupted, reset it:
+1. Resolve the main worktree — see Protocol: Resolve Main Worktree Path.
+2. Read `${MAIN_WORKTREE}/.optimus/stats.json`. If the file does not exist, start with
+   an empty object `{}`. If the file exists but is corrupted, reset it:
    ```bash
-   STATS_FILE=".optimus/stats.json"
+   # Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
    if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
      echo "WARNING: stats.json is corrupted. Resetting counters."
      echo '{}' > "$STATS_FILE"
    fi
    ```
-2. If the task ID key does not exist, initialize it:
+3. If the task ID key does not exist, initialize it:
    ```json
    { "plan_runs": 0, "review_runs": 0 }
    ```
-3. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
-4. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
-5. Write the updated JSON back to `.optimus/stats.json` (pretty-printed, sorted keys).
+4. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
+5. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
+6. Write the updated JSON back to `${STATS_FILE}` (pretty-printed, sorted keys).
 
 **NOTE:** stats.json is gitignored — no commit needed.
 
@@ -1508,8 +1571,9 @@ status change in state.json** (before any work begins). This ensures crash recov
 a record even if the agent fails before producing any output. Do NOT wait until
 "key phase transitions" to write the initial session file.
 
-**Session file location:** `.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `.optimus/sessions/session-T-003.json`).
+**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json`
+(gitignored; always resolved against the main worktree — see Protocol: Resolve Main
+Worktree Path). Each task gets its own file (e.g., `session-T-003.json`).
 
 ```json
 {
@@ -1533,7 +1597,9 @@ rather than restarting the entire analysis.
 **On stage start (after task ID is known):**
 
 ```bash
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
     echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
@@ -1587,7 +1653,9 @@ fi
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-mkdir -p .optimus/sessions .optimus/reports
+# (that protocol resolves MAIN_WORKTREE and creates the dirs at the main worktree)
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
 BRANCH_NAME=$(git branch --show-current 2>/dev/null || echo "detached")
 jq -n \
   --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
@@ -1596,12 +1664,13 @@ jq -n \
   --arg notes "<progress>" \
   '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
     started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > ".optimus/sessions/session-${TASK_ID}.json"
+  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 ```
 
 **On stage completion:** Delete the session file:
 ```bash
-rm -f ".optimus/sessions/session-${TASK_ID}.json"
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 ```
 
 Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
@@ -1654,7 +1723,10 @@ Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Prot
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -1663,12 +1735,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -1698,7 +1776,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -1726,7 +1805,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -1742,8 +1821,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -367,6 +367,65 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: Default Scope Resolution
 
 **Referenced by:** report, quick-report
@@ -453,7 +512,10 @@ Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Def
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -462,12 +524,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -497,7 +565,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -525,7 +594,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -541,8 +610,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -436,10 +436,12 @@ Velocity is derived from the `updated_at` timestamps of tasks with status `DONE`
 
 ### Step 9.1: Compute Task Completion History
 
-Read `.optimus/state.json` and extract all tasks with status `DONE`:
+Read the main worktree's `.optimus/state.json` and extract all tasks with status `DONE`:
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ] && jq empty "$STATE_FILE" 2>/dev/null; then
   jq -r 'to_entries[] | select(.value.status == "DONE") | "\(.key) \(.value.updated_at)"' "$STATE_FILE"
 fi
@@ -500,7 +502,9 @@ exist, skip this phase silently.
 ### Step 9.4.1: Load Stats
 
 ```bash
-STATS_FILE=".optimus/stats.json"
+# Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
 if [ -f "$STATS_FILE" ]; then
   if jq empty "$STATS_FILE" 2>/dev/null; then
     cat "$STATS_FILE"
@@ -861,12 +865,20 @@ Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Def
 **Referenced by:** import, tasks, report (export), quick-report, batch, all stage agents (1-4) for session files
 
 Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and operational/temporary files are gitignored:
+and operational/temporary files are gitignored. Resolve the main worktree first — see
+AGENTS.md Protocol: Resolve Main Worktree Path.
 
 ```bash
-mkdir -p .optimus/sessions .optimus/reports
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n' >> .gitignore
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 ```
 
@@ -877,11 +889,73 @@ gitignored (operational/temporary state).
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: State Management
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -890,12 +964,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -925,7 +1005,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -953,7 +1034,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -969,8 +1050,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -124,7 +124,13 @@ re-validating `$STATE_FILE`. This is the ONLY place where resume does integrity 
 on state.json — downstream steps trust this.
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 STATE_JSON=""
 if [ -f "$STATE_FILE" ]; then
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -438,7 +444,8 @@ fi
        workspace. Implemented as:
 
        ```bash
-       STATE_FILE=".optimus/state.json"
+       # STATE_FILE is already resolved from MAIN_WORKTREE in Step 1.4.
+       # See AGENTS.md Protocol: Resolve Main Worktree Path.
        RESET_DONE=0
        # STATE_JSON is already validated in Step 1.4, so STATE_FILE is guaranteed to exist
        # and be parseable here (guarded upstream — no re-validation needed).
@@ -542,13 +549,14 @@ if git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
 fi
 
 # Session file for this task (crash-recovery data from a stage skill)
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+# MAIN_WORKTREE was resolved in Step 1.4 — see AGENTS.md Protocol: Resolve Main Worktree Path.
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ] && jq empty "$SESSION_FILE" 2>/dev/null; then
   SESSION_INFO=$(jq -r '"stage=\(.stage // "?"), phase=\(.phase // "?"), round=\(.convergence_round // 0), updated=\(.updated_at // "?")"' "$SESSION_FILE")
 fi
 
 # Stats.json churn signal — single jq pass for both counters + numeric-safe coercion
-STATS_FILE=".optimus/stats.json"
+STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
 PLAN_RUNS=0
 REVIEW_RUNS=0
 if [ -f "$STATS_FILE" ]; then
@@ -787,6 +795,65 @@ Where:
 3. Derive from Tipo + ID + Title (always works)
 
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
+
+
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
 
 
 ### Protocol: Terminal Identification

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -1070,6 +1070,65 @@ each task. If any task appears twice in the chain, a cycle exists. Report ALL ta
 in the cycle so the user can fix it with `/optimus-tasks`.
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Convergence Loop (Full Roster Model)
 Applies to: plan, review, pr-check, coderabbit-review, deep-review, deep-doc-review
 
@@ -1399,27 +1458,31 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 **Referenced by:** plan, review
 
 After the status change in state.json (and BEFORE any analysis work begins), increment
-the execution counter for the current stage in `.optimus/stats.json`. This tracks how many
-times each stage ran on each task — useful for spotting spec churn and review cycles.
+the execution counter for the current stage in `.optimus/stats.json` at the main
+worktree. This tracks how many times each stage ran on each task — useful for
+spotting spec churn and review cycles.
 
 **NOTE:** Only increment when NOT in dry-run mode.
 
-1. Read `.optimus/stats.json`. If the file does not exist, start with an empty object `{}`.
-   If the file exists but is corrupted, reset it:
+1. Resolve the main worktree — see Protocol: Resolve Main Worktree Path.
+2. Read `${MAIN_WORKTREE}/.optimus/stats.json`. If the file does not exist, start with
+   an empty object `{}`. If the file exists but is corrupted, reset it:
    ```bash
-   STATS_FILE=".optimus/stats.json"
+   # Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
    if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
      echo "WARNING: stats.json is corrupted. Resetting counters."
      echo '{}' > "$STATS_FILE"
    fi
    ```
-2. If the task ID key does not exist, initialize it:
+3. If the task ID key does not exist, initialize it:
    ```json
    { "plan_runs": 0, "review_runs": 0 }
    ```
-3. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
-4. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
-5. Write the updated JSON back to `.optimus/stats.json` (pretty-printed, sorted keys).
+4. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
+5. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
+6. Write the updated JSON back to `${STATS_FILE}` (pretty-printed, sorted keys).
 
 **NOTE:** stats.json is gitignored — no commit needed.
 
@@ -1773,8 +1836,9 @@ status change in state.json** (before any work begins). This ensures crash recov
 a record even if the agent fails before producing any output. Do NOT wait until
 "key phase transitions" to write the initial session file.
 
-**Session file location:** `.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `.optimus/sessions/session-T-003.json`).
+**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json`
+(gitignored; always resolved against the main worktree — see Protocol: Resolve Main
+Worktree Path). Each task gets its own file (e.g., `session-T-003.json`).
 
 ```json
 {
@@ -1798,7 +1862,9 @@ rather than restarting the entire analysis.
 **On stage start (after task ID is known):**
 
 ```bash
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
     echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
@@ -1852,7 +1918,9 @@ fi
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-mkdir -p .optimus/sessions .optimus/reports
+# (that protocol resolves MAIN_WORKTREE and creates the dirs at the main worktree)
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
 BRANCH_NAME=$(git branch --show-current 2>/dev/null || echo "detached")
 jq -n \
   --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
@@ -1861,12 +1929,13 @@ jq -n \
   --arg notes "<progress>" \
   '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
     started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > ".optimus/sessions/session-${TASK_ID}.json"
+  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 ```
 
 **On stage completion:** Delete the session file:
 ```bash
-rm -f ".optimus/sessions/session-${TASK_ID}.json"
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 ```
 
 Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
@@ -1876,7 +1945,10 @@ Skills reference this as: "Execute session state protocol from AGENTS.md using s
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -1885,12 +1957,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -1920,7 +1998,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -1948,7 +2027,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -1964,8 +2043,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."

--- a/scripts/inline-protocols.py
+++ b/scripts/inline-protocols.py
@@ -143,7 +143,8 @@ def inline_protocols() -> None:
     # for protocol references (e.g., State Management references state.json format)
     foundational = {}
     for key in ["File Location", "Valid Status Values (stored in state.json)",
-                 "Task Spec Resolution", "Format Validation"]:
+                 "Task Spec Resolution", "Format Validation",
+                 "Protocol: Resolve Main Worktree Path"]:
         if key in sections:
             foundational[key] = sections[key]
 
@@ -187,6 +188,18 @@ def inline_protocols() -> None:
         needs_state = any("State Management" in k for k in sections_to_inline)
         needs_taskspec = any("TaskSpec" in k for k in sections_to_inline)
         needs_format = any("tasks.md Validation" in k for k in sections_to_inline)
+        # Any protocol that touches .optimus/ gitignored files needs the main-worktree
+        # resolver. Include it whenever State Management, Session State, Increment Stage
+        # Stats, or Initialize .optimus Directory is inlined.
+        needs_worktree_resolver = any(
+            any(trigger in k for trigger in (
+                "State Management",
+                "Session State",
+                "Increment Stage Stats",
+                "Initialize .optimus Directory",
+            ))
+            for k in sections_to_inline
+        )
 
         extra: dict[str, str] = {}
         if needs_state and "File Location" in foundational:
@@ -197,6 +210,10 @@ def inline_protocols() -> None:
             extra["Task Spec Resolution"] = foundational["Task Spec Resolution"]
         if needs_format and "Format Validation" in foundational:
             extra["Format Validation"] = foundational["Format Validation"]
+        if needs_worktree_resolver and "Protocol: Resolve Main Worktree Path" in foundational:
+            # Do not duplicate if already explicitly referenced by the skill.
+            if not any("Resolve Main Worktree Path" in k for k in sections_to_inline):
+                extra["Protocol: Resolve Main Worktree Path"] = foundational["Protocol: Resolve Main Worktree Path"]
 
         content = strip_existing_inline(raw_content).rstrip() + "\n"
 

--- a/scripts/test_worktree_path_resolution.py
+++ b/scripts/test_worktree_path_resolution.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Regression tests for worktree path resolution of .optimus/ operational files.
+
+These tests guard against the "T-037 state drift" incident: gitignored files
+inside `.optimus/` (state.json, stats.json, sessions/, reports/) MUST always
+be resolved against the main worktree — never the current working directory.
+
+A skill running from a linked worktree that uses `".optimus/state.json"` as a
+relative path will write into that linked worktree's isolated copy. When the
+worktree is later removed (e.g., during task closure), the write is silently
+lost and the main worktree's state.json is left stale.
+
+See AGENTS.md "Protocol: Resolve Main Worktree Path" for the fix.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+AGENTS_MD = REPO_ROOT / "AGENTS.md"
+
+# Regex matching bash variable assignments to a relative .optimus/... path.
+# Matches patterns like:
+#   STATE_FILE=".optimus/state.json"
+#   STATS_FILE=".optimus/stats.json"
+#   SESSION_FILE=".optimus/sessions/session-foo.json"
+# Does NOT match escape-sequence examples (ignored via contextual filtering below).
+RELATIVE_ASSIGN_RE = re.compile(
+    r'^\s*(?P<name>[A-Z_]+)="\.optimus/(?P<tail>(?:state\.json|stats\.json|sessions|reports)[^"]*)"',
+    re.MULTILINE,
+)
+
+# Lines that are documentation-only examples and should be exempted.
+# The Protocol: Resolve Main Worktree Path section explicitly shows the WRONG
+# pattern as a contrastive example. We allow exempted occurrences to stay.
+ALLOWED_EXAMPLE_TAGS = [
+    "# WRONG",
+    "`STATE_FILE=\".optimus/state.json\"` created",
+]
+
+
+def _all_doc_files():
+    yield AGENTS_MD
+    yield from sorted(REPO_ROOT.glob("*/skills/*/SKILL.md"))
+
+
+def _is_allowed_example(context_line: str) -> bool:
+    """Lines inside the WRONG-example block are allowed."""
+    return any(tag in context_line for tag in ALLOWED_EXAMPLE_TAGS)
+
+
+class TestWorktreePathResolution:
+    """AGENTS.md and SKILL.md must not contain relative .optimus/ paths
+    (except inside the documented WRONG-example block)."""
+
+    def test_no_relative_optimus_assignments(self):
+        violations: list[str] = []
+        for filepath in _all_doc_files():
+            if not filepath.exists():
+                continue
+            text = filepath.read_text()
+            for match in RELATIVE_ASSIGN_RE.finditer(text):
+                # Find the line containing this match
+                line_start = text.rfind("\n", 0, match.start()) + 1
+                line_end = text.find("\n", match.end())
+                if line_end == -1:
+                    line_end = len(text)
+                line = text[line_start:line_end]
+                # Skip documented "WRONG" example blocks
+                if _is_allowed_example(line):
+                    continue
+                line_no = text.count("\n", 0, match.start()) + 1
+                rel = filepath.relative_to(REPO_ROOT)
+                violations.append(f"{rel}:{line_no}: {line.strip()}")
+        assert violations == [], (
+            "Relative .optimus/ paths found (must resolve against main worktree — "
+            "see AGENTS.md Protocol: Resolve Main Worktree Path):\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+
+    def test_resolve_main_worktree_protocol_exists(self):
+        """AGENTS.md must define the Resolve Main Worktree Path protocol."""
+        text = AGENTS_MD.read_text()
+        assert "### Protocol: Resolve Main Worktree Path" in text, (
+            "Protocol: Resolve Main Worktree Path must exist in AGENTS.md"
+        )
+        # Protocol must explain the `git worktree list --porcelain` recipe
+        assert "git worktree list --porcelain" in text, (
+            "Protocol must document the `git worktree list --porcelain` recipe"
+        )
+
+    def test_state_touching_skills_inline_worktree_protocol(self):
+        """Every SKILL.md that inlines State Management, Session State,
+        Increment Stage Stats, or Initialize .optimus Directory must also
+        inline Protocol: Resolve Main Worktree Path (since those protocols
+        depend on it)."""
+        state_protocols = (
+            "Protocol: State Management",
+            "Protocol: Session State",
+            "Protocol: Increment Stage Stats",
+            "Protocol: Initialize .optimus Directory",
+        )
+        violations: list[str] = []
+        for filepath in sorted(REPO_ROOT.glob("*/skills/*/SKILL.md")):
+            text = filepath.read_text()
+            touches_state = any(f"### {p}" in text for p in state_protocols)
+            if not touches_state:
+                continue
+            has_resolver = "### Protocol: Resolve Main Worktree Path" in text
+            if not has_resolver:
+                rel = filepath.relative_to(REPO_ROOT)
+                violations.append(str(rel))
+        assert violations == [], (
+            "Skills that inline State Management/Session State/Increment Stage Stats/"
+            "Initialize .optimus Directory must also inline Protocol: Resolve Main "
+            "Worktree Path. Run `python3 scripts/inline-protocols.py` to regenerate:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1045,17 +1045,84 @@ each task. If any task appears twice in the chain, a cycle exists. Report ALL ta
 in the cycle so the user can fix it with `/optimus-tasks`.
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** State Management, Session State, Increment Stage Stats, Initialize .optimus Directory, and every skill that reads or writes any file under `.optimus/`.
+
+`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and `.optimus/reports/`
+are **gitignored** (operational/temporary state). Because git does not share ignored files
+across linked worktrees (`git worktree add <dir>`), each worktree has an **independent
+copy** of these files. Reads and writes must always target the **main worktree** — never
+the current working directory.
+
+**Always resolve the main worktree before touching any `.optimus/` operational file:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+```
+
+After resolution, every `.optimus/` path uses `${MAIN_WORKTREE}/.optimus/` as the base:
+
+```bash
+OPTIMUS_DIR="${MAIN_WORKTREE}/.optimus"
+STATE_FILE="${OPTIMUS_DIR}/state.json"
+STATS_FILE="${OPTIMUS_DIR}/stats.json"
+SESSIONS_DIR="${OPTIMUS_DIR}/sessions"
+REPORTS_DIR="${OPTIMUS_DIR}/reports"
+```
+
+**Why this matters (real incident):** A skill executed from a linked worktree (e.g.,
+`<repo>-t-037-oauth2-tenant/`) that used `STATE_FILE=".optimus/state.json"` created the
+file inside that linked worktree. The subsequent `git worktree remove` (during task
+cleanup) deleted the worktree **together with the state.json update**, silently losing
+the status change. The main worktree's `state.json` was never touched, so the task
+remained stuck in `Validando Impl` even after the PR was merged.
+
+**Do NOT** assign paths relative to the current working directory:
+
+```bash
+STATE_FILE=".optimus/state.json"            # WRONG — resolves against $PWD
+mkdir -p .optimus/sessions .optimus/reports # WRONG — creates dirs in $PWD
+```
+
+**DO** resolve the main worktree first, then compose absolute paths:
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+```
+
+**Exception:** Versioned files (`.optimus/config.json`, `.optimus/tasks.md`) are shared
+across worktrees by git itself, so relative paths work for those. This protocol targets
+only the gitignored operational files.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: Initialize .optimus Directory
 
 **Referenced by:** import, tasks, report (export), quick-report, batch, all stage agents (1-4) for session files
 
 Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and operational/temporary files are gitignored:
+and operational/temporary files are gitignored. Resolve the main worktree first — see
+AGENTS.md Protocol: Resolve Main Worktree Path.
 
 ```bash
-mkdir -p .optimus/sessions .optimus/reports
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n' >> .gitignore
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports"
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 ```
 
@@ -1070,7 +1137,10 @@ Skills reference this as: "Initialize .optimus directory — see AGENTS.md Proto
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
 
-All status and branch data is stored in `.optimus/state.json` (gitignored).
+All status and branch data is stored in `.optimus/state.json` (gitignored). This file
+lives at the **main worktree root** — always resolve the main worktree before any
+read or write (see Protocol: Resolve Main Worktree Path). Writing to a linked
+worktree's copy silently loses data when the worktree is later removed.
 
 **Prerequisites:**
 
@@ -1079,12 +1149,18 @@ if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required for state management but not installed."
   # STOP — do not proceed
 fi
+# Resolve main worktree — see Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository."
+  # STOP — do not proceed
+fi
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 ```
 
 **Reading state:**
 
 ```bash
-STATE_FILE=".optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
   if ! jq empty "$STATE_FILE" 2>/dev/null; then
@@ -1114,7 +1190,8 @@ A task with no entry in state.json is implicitly `Pendente`.
 
 ```bash
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+mkdir -p "$(dirname "$STATE_FILE")"
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
@@ -1142,7 +1219,7 @@ fi
 **Removing entry (for Pendente reset):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
 else
@@ -1158,8 +1235,9 @@ fi
 **Listing all tasks with status (for report/quick-report):**
 
 ```bash
-STATE_FILE=".optimus/state.json"
-TASKS_FILE=".optimus/tasks.md"
+# STATE_FILE is resolved in Prerequisites above (against MAIN_WORKTREE).
+# tasks.md is versioned and shared across worktrees, so a relative path is safe.
+TASKS_FILE="${MAIN_WORKTREE}/.optimus/tasks.md"
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."


### PR DESCRIPTION
## Problem

`.optimus/state.json`, `.optimus/stats.json`, `.optimus/sessions/`, and
`.optimus/reports/` are **gitignored** (operational state). Because git does not
propagate ignored files across linked worktrees (`git worktree add`), each
worktree has an **independent copy** of these files.

Every skill that writes state currently assigns paths relative to the current
working directory:

```bash
STATE_FILE=".optimus/state.json"   # resolved against $PWD
```

When a skill runs from a linked worktree (the common case — `/optimus-plan`,
`/optimus-build`, `/optimus-review`, `/optimus-done` all default to the task's
worktree), the write lands in that worktree's isolated copy. The main worktree
is never touched, so other skills and other worktrees see stale state.

## Real incident (T-037)

Reported in `LerianStudio/plugin-br-payments`:

1. Task T-037 was implemented and PR #69 merged.
2. User ran `/optimus-done` from the task's linked worktree
   (`<repo>-t-037-oauth2-tenant/`).
3. optimus-done wrote `T-037 = DONE` to `<worktree>/.optimus/state.json`
   (new, isolated file — the main worktree had no knowledge of it).
4. optimus-done then ran `git worktree remove <path>` as part of cleanup.
5. The worktree was deleted **together with the state.json update**.
6. The main worktree's `state.json` stayed at `Validando Impl` — forever.
7. T-041, T-042, T-044 (which depend on T-037) remained falsely **blocked**
   in every subsequent `/optimus-quick-report` / `/optimus-report`.

`optimus-done` already had an explicit "Edge case — running INSIDE the worktree"
guard for `git worktree remove`, but not for the preceding `state.json` write.
The asymmetry is the bug.

## Fix

1. **New Protocol: Resolve Main Worktree Path** in `AGENTS.md`.
   Documents the recipe and the rationale:
   ```bash
   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
   if [ -z "$MAIN_WORKTREE" ]; then
     echo "ERROR: Cannot determine main worktree — not in a git repository."
     # STOP
   fi
   STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
   ```

2. **Update dependent protocols** to resolve paths against `$MAIN_WORKTREE`:
   - Protocol: State Management
   - Protocol: Session State
   - Protocol: Increment Stage Stats
   - Protocol: Initialize .optimus Directory

3. **Update `scripts/inline-protocols.py`** so any SKILL.md that inlines one of
   the four state-touching protocols automatically also inlines Protocol:
   Resolve Main Worktree Path as a foundational section. This keeps each
   plugin self-contained without each skill having to reference the new
   protocol by name.

4. **Fix four body-scoped bash blocks** outside the INLINE-PROTOCOLS region
   that still used relative paths:
   - `import`: legacy Status/Branch → state.json migration
   - `report`: Phase 9.1 completion history, Phase 9.4.1 churn metrics
   - `resume`: Step 1.4 state.json load, Step 2.x reset-to-Pendente, Step 2.x
     session/stats snapshot

5. **Regression test** in `scripts/test_worktree_path_resolution.py`:
   - Fails if any `STATE_FILE=".optimus/..."` / `STATS_FILE` / `SESSION_FILE`
     relative assignment reappears in `AGENTS.md` or any `SKILL.md` (except
     the one documented `# WRONG` example block inside the resolver protocol).
   - Fails if `AGENTS.md` loses the Resolve Main Worktree Path protocol or
     the `git worktree list --porcelain` recipe.
   - Fails if a state-touching SKILL.md misses the resolver protocol after
     `scripts/inline-protocols.py` runs.

## Not changed

- `.optimus/config.json` and `.optimus/tasks.md` are **versioned** and shared
  across worktrees by git itself — relative paths remain correct for them.
- `Protocol: tasks.md Validation` still uses `.optimus/tasks.md` directly.
- No behavioural change for any happy-path workflow run in the main worktree
  — the resolved path is identical to `$PWD/.optimus/state.json` there.

## Testing

```bash
make lint         # ruff + py_compile + shellcheck — PASS
make test         # 125 existing tests — PASS
make check-inline # inline-protocols.py idempotent — PASS
python3 -m pytest scripts/test_worktree_path_resolution.py -v  # 3 new tests — PASS
```

Also reproduced the bug manually from a linked worktree:
- Before: `STATE_FILE=".optimus/state.json"` → file does not exist (nothing written here).
- After: `STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"` →
  absolute path to the main worktree's state.json (correct).

## Commits

- `fix(state): resolve .optimus/ operational files against main worktree` —
  AGENTS.md + script + new regression test
- `fix(skills): resolve state/stats/session paths in body-scoped bash blocks` —
  import/report/resume non-inlined bash
- `chore(inline): regenerate inlined protocols for worktree fix` —
  `python3 scripts/inline-protocols.py` output for the 10 affected SKILL.md
