### PR TITLE
feat(sync): add Claude Code support for dual-platform sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,14 +134,41 @@ and syncs both in a single run. Platform detection:
 - **Claude Code**: `~/.claude/` directory exists
 
 At least one platform must be available. The script uses a shared marketplace JSON
-(resolved from Droid cache, repo cache, or local repo root) as the source of truth
-for expected plugins.
+as the source of truth for expected plugins, resolved through a 3-tier fallback:
+
+**Marketplace JSON resolution (3-tier fallback):**
+1. **Droid cache:** `~/.factory/marketplaces/optimus/.factory-plugin/marketplace.json` —
+   populated by `droid plugin marketplace add/update`.
+2. **Repo cache:** `~/.optimus/repo/.factory-plugin/marketplace.json` — populated by
+   the script when Claude Code is detected. Droid-only users do **not** get this
+   fallback automatically; they must run `droid plugin marketplace update optimus`
+   to populate Source 1.
+3. **Local repo:** when the script runs from inside a clone of the Optimus repo,
+   the `marketplace.json` next to the script is used.
 
 ### Claude Code specifics
 - Skills are installed at `~/.claude/skills/default/optimus-<name>/SKILL.md`
 - Only `optimus-*` prefixed directories are managed — other skills (e.g., `ring:*`) are never touched
 - Updates use `diff -q` to skip unchanged files (avoids unnecessary writes)
 - Repo cache lives at `~/.optimus/repo/` (configurable via `OPTIMUS_CACHE_DIR`)
+
+**`~/.optimus/repo/` is sync-managed.** The script runs `git fetch` +
+`git reset --hard origin/main` on every sync, discarding any local commits,
+branches, or uncommitted edits. Do not use this directory for hacking on plugins —
+work in your own clone of the repo and run the sync script from there.
+
+#### Environment variables
+
+The sync script honors the following environment variables (defaults sourced
+from the `readonly` declarations at the top of `sync/scripts/sync-user-plugins.sh`):
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `OPTIMUS_REPO_URL` | `https://github.com/alexgarzao/optimus` | Git URL cloned into the repo cache. Override at your own risk — the script trusts whatever this points to. |
+| `OPTIMUS_CACHE_DIR` | `~/.optimus/repo` | Path to the repo cache. |
+| `CLAUDE_SKILLS_DIR` | `~/.claude/skills/default` | Where Claude Code skills are installed. |
+| `OPTIMUS_MARKETPLACE_NAME` | `optimus` | Droid marketplace identifier. |
+| `OPTIMUS_DROID_TIMEOUT` | `60` | Per-call timeout for Droid plugin operations, in seconds. Must be a positive integer. |
 
 ## Plugin Lifecycle
 
@@ -165,6 +192,11 @@ for expected plugins.
 3. Update README.md
 4. Commit, push
 5. Run `/optimus-sync` to remove orphaned plugins and update the rest (both platforms)
+
+**Note:** End users on Claude Code do not get automatic updates. They must run
+`/optimus-sync` to receive removals (the orphan-removal step). Until they sync,
+the obsolete plugin's `SKILL.md` lingers under `~/.claude/skills/default/optimus-<name>/`.
+Consider announcing breaking removals in release notes.
 
 ### Syncing all plugins (for end users)
 Run `/optimus-sync` or `make sync-plugins`. This command:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,33 @@ rationalize these away.
 - Keep the install instructions and skill table up to date
 - Update when adding/removing plugins
 
+## Multi-Platform Support
+
+Optimus skills can be installed on two platforms simultaneously:
+
+| Aspect | Droid (Factory) | Claude Code |
+|--------|-----------------|-------------|
+| **Install mechanism** | `droid plugin install/update/uninstall` | Copy SKILL.md to `~/.claude/skills/default/optimus-<name>/` |
+| **Marketplace** | `~/.factory/marketplaces/optimus/` | `~/.optimus/repo/` (git clone cache) |
+| **Skill discovery** | Plugin registry | Filesystem auto-discovery |
+| **Command aliases** | Supported (`/sp`, `/bd`, etc.) | Not supported (platform limitation) |
+| **Invocation** | `/optimus-<name>` or alias | `/optimus-<name>` only |
+
+The sync script (`sync/scripts/sync-user-plugins.sh`) detects which platforms are available
+and syncs both in a single run. Platform detection:
+- **Droid**: `command -v droid` succeeds
+- **Claude Code**: `~/.claude/` directory exists
+
+At least one platform must be available. The script uses a shared marketplace JSON
+(resolved from Droid cache, repo cache, or local repo root) as the source of truth
+for expected plugins.
+
+### Claude Code specifics
+- Skills are installed at `~/.claude/skills/default/optimus-<name>/SKILL.md`
+- Only `optimus-*` prefixed directories are managed — other skills (e.g., `ring:*`) are never touched
+- Updates use `diff -q` to skip unchanged files (avoids unnecessary writes)
+- Repo cache lives at `~/.optimus/repo/` (configurable via `OPTIMUS_CACHE_DIR`)
+
 ## Plugin Lifecycle
 
 ### Adding a new plugin
@@ -123,26 +150,30 @@ rationalize these away.
 2. Create manifest: `<name>/.factory-plugin/plugin.json`
 3. Add entry to `.factory-plugin/marketplace.json`
 4. Update README.md table
-5. Commit, push, then `droid plugin install <name>@optimus`
+5. Commit, push
+6. **Droid**: `droid plugin install <name>@optimus`
+7. **Claude Code**: Run `/optimus-sync` (auto-installs from repo cache)
 
 ### Updating a plugin
 1. Edit the SKILL.md
 2. Commit, push
-3. Run `/optimus-sync` (or `make sync-plugins`) to update all plugins at once
+3. Run `/optimus-sync` (or `make sync-plugins`) to update all plugins at once on both platforms
 
 ### Removing a plugin
 1. Remove from marketplace.json
 2. Remove directory
 3. Update README.md
 4. Commit, push
-5. Run `/optimus-sync` to remove orphaned plugins and update the rest
+5. Run `/optimus-sync` to remove orphaned plugins and update the rest (both platforms)
 
 ### Syncing all plugins (for end users)
 Run `/optimus-sync` or `make sync-plugins`. This command:
-- Updates the Optimus marketplace
+- Detects available platforms (Droid, Claude Code, or both)
+- Updates the Optimus marketplace (Droid) / repo cache (Claude Code)
 - Installs new plugins that were added
 - Removes orphaned plugins that were removed
-- Updates all existing plugins (with automatic scope conflict resolution)
+- Updates all existing plugins (with automatic scope conflict resolution on Droid, diff-based skip on Claude Code)
+- Shows a per-platform summary
 
 This is the recommended way for end users to stay up to date.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Pendente → Validando Spec → Em Andamento → Validando Impl → DONE
 
 ## Install
 
+### Droid (Factory)
+
 ```bash
 droid plugin marketplace add https://github.com/alexgarzao/optimus
 droid plugin install help@optimus
@@ -56,10 +58,26 @@ droid plugin install help@optimus
 
 Then run `/optimus-sync` to install all plugins at once.
 
+### Claude Code
+
+One-liner bootstrap (resolves the chicken-and-egg problem):
+
+```bash
+git clone --depth 1 https://github.com/alexgarzao/optimus ~/.optimus/repo \
+  && mkdir -p ~/.claude/skills/default/optimus-sync \
+  && cp ~/.optimus/repo/sync/skills/optimus-sync/SKILL.md \
+        ~/.claude/skills/default/optimus-sync/SKILL.md
+```
+
+Then open Claude Code and run `/optimus-sync` — it will install all other plugins automatically.
+
+**Note:** Command aliases (`/sp`, `/bd`, etc.) are not supported on Claude Code.
+Use the full skill name (e.g., `/optimus-plan`, `/optimus-build`).
+
 ### Staying up to date
 
 Run `/optimus-sync` (or `make sync-plugins`) to sync all plugins — installs new,
-updates existing, removes orphaned. This is the recommended way to stay up to date.
+updates existing, removes orphaned. Works for both Droid and Claude Code simultaneously.
 
 ## Quick Start
 

--- a/scripts/test_sync_user_plugins.py
+++ b/scripts/test_sync_user_plugins.py
@@ -32,12 +32,35 @@ def _create_marketplace(tmp_path: Path, plugins: list[str], name: str = "optimus
     mp_file.write_text(f'{{"plugins": [{entries}]}}')
 
 
+DEFAULT_OPTIMUS_REPO_URL = "https://github.com/alexgarzao/optimus"
+
+
 def _create_repo_cache(tmp_path: Path, plugins: list[str],
-                       cache_dir: str | None = None) -> Path:
-    """Create a mock optimus repo cache with SKILL.md files."""
+                       cache_dir: str | None = None,
+                       origin_url: str = DEFAULT_OPTIMUS_REPO_URL,
+                       install_git_mock: bool = True) -> Path:
+    """Create a mock optimus repo cache with SKILL.md files.
+
+    Writes a minimal but functional .git/ dir (config + HEAD + objects/refs)
+    so real `git -C config --get remote.origin.url` returns the configured URL.
+    F26 (post bash refactor) verifies origin URL before using cache.
+
+    install_git_mock=True (default) installs a default mock `git` in tmp_path/bin
+    that handles config/fetch/reset as no-ops returning the right URL — preventing
+    real network calls. Set install_git_mock=False if a test wants to provide its
+    own git mock.
+    """
     repo_dir = Path(cache_dir) if cache_dir else tmp_path / "home" / ".optimus" / "repo"
-    # Create .git dir to mark it as a repo
-    (repo_dir / ".git").mkdir(parents=True, exist_ok=True)
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir(parents=True, exist_ok=True)
+    # Minimum files for git to recognize this as a valid repo.
+    (git_dir / "config").write_text(
+        '[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = false\n'
+        f'[remote "origin"]\n\turl = {origin_url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n'
+    )
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+    (git_dir / "objects").mkdir(exist_ok=True)
+    (git_dir / "refs" / "heads").mkdir(parents=True, exist_ok=True)
     # Create marketplace.json
     mp_dir = repo_dir / ".factory-plugin"
     mp_dir.mkdir(parents=True, exist_ok=True)
@@ -50,24 +73,38 @@ def _create_repo_cache(tmp_path: Path, plugins: list[str],
         (skill_dir / "SKILL.md").write_text(
             f"---\nname: optimus-{plugin}\n---\n# {plugin}\nContent for {plugin}.\n"
         )
+    # Install default git mock so the script's `git fetch` doesn't go to network,
+    # and `git config --get remote.origin.url` returns the configured origin.
+    # Skipped if the test already wrote one or explicitly opts out.
+    if install_git_mock:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        git_mock = bin_dir / "git"
+        if not git_mock.exists():
+            # The script invokes git with `-C <path>` prefix for repo ops
+            # (e.g. `git -C $repo_dir config --get remote.origin.url`).
+            # Strip leading "-C <path>" so we can dispatch on the real subcommand.
+            git_mock.write_text(
+                "#!/usr/bin/env bash\n"
+                'if [ "$1" = "-C" ]; then shift 2; fi\n'
+                'case "$1" in\n'
+                f'  config) echo "{origin_url}"; exit 0 ;;\n'
+                "  fetch|reset|clone) exit 0 ;;\n"
+                "esac\n"
+                "exit 0\n"
+            )
+            git_mock.chmod(0o755)
     return repo_dir
 
 
-def _create_claude_skill(tmp_path: Path, name: str,
-                         content: str = "# placeholder") -> Path:
-    """Create a skill directory in the mock Claude Code skills dir."""
-    skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-    skill_dir = skills_dir / f"optimus-{name}"
-    skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(content)
-    return skill_dir
-
-
 def _ensure_claude_dir(tmp_path: Path) -> Path:
-    """Ensure ~/.claude/ directory exists in mock home."""
-    claude_dir = tmp_path / "home" / ".claude"
-    claude_dir.mkdir(parents=True, exist_ok=True)
-    return claude_dir
+    """Ensure ~/.claude/skills/ directory exists in mock home.
+
+    Per F49, Claude Code detection requires ~/.claude/skills/ (not just ~/.claude/).
+    """
+    claude_skills = tmp_path / "home" / ".claude" / "skills"
+    claude_skills.mkdir(parents=True, exist_ok=True)
+    return claude_skills.parent
 
 
 def _path_without_droid() -> str:
@@ -330,7 +367,7 @@ esac
         _create_marketplace(tmp_path, ["alpha"])
         result = _run_sync(tmp_path)
         assert result.returncode == 0
-        assert "Could not update marketplace" in result.stderr
+        assert "Could not update Droid marketplace" in result.stderr
         assert "Added: 1" in result.stdout
 
 
@@ -478,16 +515,19 @@ class TestClaudeCodeDetection:
         assert "── Droid (Factory) ──" not in result.stdout
 
     def test_skips_claude_code_when_no_dir(self, tmp_path: Path) -> None:
-        """When ~/.claude/ doesn't exist but droid is available, only Droid runs."""
+        """When ~/.claude/skills/ doesn't exist but droid is available, only Droid runs."""
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         _create_marketplace(tmp_path, ["alpha"])
-        # Don't create .claude dir
+        # Don't create .claude/skills/ dir (F49 detection requires it).
         result = _run_sync(tmp_path)
         assert result.returncode == 0
-        assert "Droid" in result.stdout
+        # F32: assert exact section header AND that Droid actually installed something.
+        assert "── Droid (Factory) ──" in result.stdout
         # Claude Code section should not appear
         assert "── Claude Code ──" not in result.stdout
+        log_content = log.read_text()
+        assert "install alpha@optimus" in log_content
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -518,6 +558,8 @@ class TestClaudeCodeSync:
         skill_dir = skills_dir / "optimus-alpha"
         skill_dir.mkdir(parents=True, exist_ok=True)
         (skill_dir / "SKILL.md").write_text("old content")
+        # F11: existing installs need the .optimus-managed marker so update path runs.
+        (skill_dir / ".optimus-managed").touch()
         result = _run_sync(tmp_path, env_extra={
             "OPTIMUS_CACHE_DIR": str(repo_dir),
             "CLAUDE_SKILLS_DIR": str(skills_dir),
@@ -527,7 +569,7 @@ class TestClaudeCodeSync:
         assert "alpha" in (skill_dir / "SKILL.md").read_text()
 
     def test_skips_unchanged_skills(self, tmp_path: Path) -> None:
-        """When source SKILL.md is identical, skip with 'unchanged'."""
+        """When source SKILL.md is identical, skip with 'unchanged' and don't touch the file."""
         _ensure_claude_dir(tmp_path)
         repo_dir = _create_repo_cache(tmp_path, ["alpha"])
         skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
@@ -535,7 +577,12 @@ class TestClaudeCodeSync:
         src_content = (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").read_text()
         skill_dir = skills_dir / "optimus-alpha"
         skill_dir.mkdir(parents=True, exist_ok=True)
-        (skill_dir / "SKILL.md").write_text(src_content)
+        dest = skill_dir / "SKILL.md"
+        dest.write_text(src_content)
+        # F11: existing installs need the .optimus-managed marker.
+        (skill_dir / ".optimus-managed").touch()
+        # F14: capture mtime to verify the unchanged path doesn't rewrite the file.
+        mtime_before = dest.stat().st_mtime_ns
         result = _run_sync(tmp_path, env_extra={
             "OPTIMUS_CACHE_DIR": str(repo_dir),
             "CLAUDE_SKILLS_DIR": str(skills_dir),
@@ -543,16 +590,18 @@ class TestClaudeCodeSync:
         assert result.returncode == 0
         assert "unchanged" in result.stdout.lower()
         assert "Unchanged: 1" in result.stdout
+        assert dest.stat().st_mtime_ns == mtime_before
 
     def test_removes_orphaned_skills(self, tmp_path: Path) -> None:
-        """Skills in dir but not in marketplace get removed."""
+        """Skills in dir but not in marketplace get removed (when marker present)."""
         _ensure_claude_dir(tmp_path)
         repo_dir = _create_repo_cache(tmp_path, ["alpha"])
         skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Create orphaned skill
+        # Create orphaned skill with .optimus-managed marker (F11)
         orphan_dir = skills_dir / "optimus-orphan"
         orphan_dir.mkdir(parents=True, exist_ok=True)
         (orphan_dir / "SKILL.md").write_text("orphan")
+        (orphan_dir / ".optimus-managed").touch()
         result = _run_sync(tmp_path, env_extra={
             "OPTIMUS_CACHE_DIR": str(repo_dir),
             "CLAUDE_SKILLS_DIR": str(skills_dir),
@@ -560,6 +609,26 @@ class TestClaudeCodeSync:
         assert result.returncode == 0
         assert "Removed: 1" in result.stdout
         assert not orphan_dir.exists()
+
+    def test_skips_orphan_without_marker(self, tmp_path: Path) -> None:
+        """F11: orphan dirs lacking .optimus-managed are skipped (user-created safety)."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Orphan WITHOUT marker — should be left alone.
+        orphan_dir = skills_dir / "optimus-orphan"
+        orphan_dir.mkdir(parents=True, exist_ok=True)
+        (orphan_dir / "SKILL.md").write_text("user-created")
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "Removed: 0" in result.stdout
+        assert "skipped" in result.stdout.lower()
+        assert ".optimus-managed marker" in result.stdout
+        assert orphan_dir.exists()
+        assert (orphan_dir / "SKILL.md").read_text() == "user-created"
 
     def test_never_removes_non_optimus_skills(self, tmp_path: Path) -> None:
         """Skills without optimus- prefix must NEVER be touched."""
@@ -601,11 +670,11 @@ class TestClaudeCodeSync:
 
 class TestClaudeCodeRepoCache:
     def test_uses_existing_cache(self, tmp_path: Path) -> None:
-        """When cache dir exists with .git, uses it without cloning."""
+        """When cache dir exists with .git, uses it without cloning, and EXPECTED comes from it."""
         _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        # Mock git to avoid actual network calls
-        _create_mock_bin(tmp_path, "git", 'exit 0')
+        # Cache holds a single plugin "alpha-from-cache" — the expected list must come from here.
+        # Default git mock from _create_repo_cache handles config/fetch/reset as no-ops.
+        repo_dir = _create_repo_cache(tmp_path, ["alpha-from-cache"])
         skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
         result = _run_sync(tmp_path, env_extra={
             "OPTIMUS_CACHE_DIR": str(repo_dir),
@@ -613,20 +682,34 @@ class TestClaudeCodeRepoCache:
         }, exclude_droid=True)
         assert result.returncode == 0
         assert "Updating repo cache" in result.stdout
+        # F33: post-condition — EXPECTED was sourced from the cache.
+        assert (skills_dir / "optimus-alpha-from-cache" / "SKILL.md").exists()
+        assert "alpha-from-cache" in result.stdout
 
     def test_clones_when_no_cache(self, tmp_path: Path) -> None:
-        """When no cache exists, attempts to clone."""
+        """When no cache exists, attempts to clone with exact expected arguments."""
         _ensure_claude_dir(tmp_path)
         cache_dir = tmp_path / "home" / ".optimus" / "repo"
         skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Mock git clone to create the repo cache
+        git_log = tmp_path / "git.log"
+        # Mock git clone to create the repo cache.
+        # F57: use a heredoc so the SKILL.md actually contains literal newlines.
+        # F34: log every git invocation so we can assert exact clone args.
         git_script = f"""
+echo "$@" >> "{git_log}"
 if [ "$1" = "clone" ]; then
-  mkdir -p "{cache_dir}/.git"
-  mkdir -p "{cache_dir}/.factory-plugin"
-  echo '{{"plugins": [{{"name": "alpha"}}]}}' > "{cache_dir}/.factory-plugin/marketplace.json"
-  mkdir -p "{cache_dir}/alpha/skills/optimus-alpha"
-  echo "---\\nname: optimus-alpha\\n---\\n# alpha" > "{cache_dir}/alpha/skills/optimus-alpha/SKILL.md"
+  # Args: clone --depth 1 <url> <dest>
+  dest="${{!#}}"
+  mkdir -p "$dest/.git"
+  mkdir -p "$dest/.factory-plugin"
+  echo '{{"plugins": [{{"name": "alpha"}}]}}' > "$dest/.factory-plugin/marketplace.json"
+  mkdir -p "$dest/alpha/skills/optimus-alpha"
+  cat > "$dest/alpha/skills/optimus-alpha/SKILL.md" <<'EOF'
+---
+name: optimus-alpha
+---
+# alpha
+EOF
   exit 0
 fi
 exit 0
@@ -638,6 +721,12 @@ exit 0
         }, exclude_droid=True)
         assert result.returncode == 0
         assert "Cloning repo cache" in result.stdout
+        # F34: verify exact clone arguments.
+        log_content = git_log.read_text()
+        expected_clone = f"clone --depth 1 {DEFAULT_OPTIMUS_REPO_URL} {cache_dir}"
+        assert expected_clone in log_content, (
+            f"Expected '{expected_clone}' in git log, got:\n{log_content}"
+        )
 
     def test_warns_on_clone_failure(self, tmp_path: Path) -> None:
         """When clone fails, warn and skip Claude Code sync gracefully."""
@@ -650,8 +739,10 @@ exit 0
             "OPTIMUS_CACHE_DIR": str(cache_dir),
             "CLAUDE_SKILLS_DIR": str(skills_dir),
         }, exclude_droid=True)
-        # Should not crash — graceful skip
-        assert "Could not clone repo" in result.stderr or "skipped" in result.stdout.lower()
+        # F5: strict assertions — both the warning and the skip line must appear.
+        assert "Could not clone repo" in result.stderr
+        assert "(skipped)" in result.stdout
+        assert result.returncode in (0, 1)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -693,7 +784,7 @@ class TestDualPlatformSync:
         assert "── Claude Code ──" not in result.stdout
 
     def test_claude_only_when_no_droid(self, tmp_path: Path) -> None:
-        """Without droid CLI, only Claude Code sync runs."""
+        """Without droid CLI, only Claude Code sync runs and installs skills."""
         _ensure_claude_dir(tmp_path)
         repo_dir = _create_repo_cache(tmp_path, ["alpha"])
         skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
@@ -704,6 +795,8 @@ class TestDualPlatformSync:
         assert result.returncode == 0
         assert "── Droid (Factory) ──" not in result.stdout
         assert "── Claude Code ──" in result.stdout
+        # F35: confirm files were actually installed.
+        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
 
     def test_droid_failure_doesnt_block_claude(self, tmp_path: Path) -> None:
         """If Droid sync fails, Claude Code sync still runs."""
@@ -723,3 +816,306 @@ class TestDualPlatformSync:
         assert "── Claude Code ──" in result.stdout
         # Claude Code skill should still be installed
         assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
+
+    def test_claude_failure_doesnt_block_droid(self, tmp_path: Path) -> None:
+        """F3: If Claude Code sync fails, Droid sync still completes installs.
+
+        Symmetric to test_droid_failure_doesnt_block_claude.
+        Claude Code is set up to fail at SKILL.md copy (source missing in cache),
+        so it reports FAIL — but Droid path must still run end-to-end.
+        """
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        _create_marketplace(tmp_path, ["alpha"])
+        _ensure_claude_dir(tmp_path)
+        # Set up repo cache that has marketplace but is missing SKILL.md → Claude fails.
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").unlink()
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        })
+        # Aggregated failure expected (Claude failed)
+        assert result.returncode == 1
+        assert "── Droid (Factory) ──" in result.stdout
+        assert "── Claude Code ──" in result.stdout
+        # Droid must have completed its install.
+        log_content = log.read_text()
+        assert "install alpha@optimus" in log_content
+        # And Claude must have reported the source-not-found failure.
+        assert "source not found" in result.stdout.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# README contract (F4)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestREADMEContract:
+    def test_bootstrap_oneliner_paths_exist(self) -> None:
+        """README bootstrap one-liner relies on these paths existing in the repo."""
+        repo_root = Path(__file__).resolve().parent.parent
+        skill_path = repo_root / "sync" / "skills" / "optimus-sync" / "SKILL.md"
+        assert skill_path.exists(), f"Missing: {skill_path}"
+        skill_md = skill_path.read_text()
+        assert "name: optimus-sync" in skill_md  # frontmatter sanity
+        # The bootstrap also relies on the sync script.
+        assert (repo_root / "sync" / "scripts" / "sync-user-plugins.sh").exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Plugin name validation (F6)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestPluginNameValidation:
+    def test_rejects_plugin_name_with_path_traversal(self, tmp_path: Path) -> None:
+        """Marketplace.json with a name containing '..' must error and not write any files."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        # Hand-craft a marketplace.json with a malicious name.
+        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
+        mp_dir.mkdir(parents=True)
+        (mp_dir / "marketplace.json").write_text(
+            '{"plugins": [{"name": "../../../etc"}]}'
+        )
+        # Ensure target path doesn't exist before sync.
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        result = _run_sync(tmp_path)
+        assert result.returncode == 1
+        assert "Invalid plugin name" in result.stderr
+        # No directory should have been created at the malicious location.
+        assert not (skills_dir / "optimus-../../../etc").exists()
+        assert not (tmp_path / "home" / ".claude" / "skills" / "etc").exists()
+
+    def test_rejects_plugin_name_with_uppercase(self, tmp_path: Path) -> None:
+        """Names like 'MyPlugin' should be rejected by the regex."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
+        mp_dir.mkdir(parents=True)
+        (mp_dir / "marketplace.json").write_text(
+            '{"plugins": [{"name": "MyPlugin"}]}'
+        )
+        result = _run_sync(tmp_path)
+        assert result.returncode == 1
+        assert "Invalid plugin name" in result.stderr
+
+    def test_rejects_plugin_name_with_leading_dash(self, tmp_path: Path) -> None:
+        """Names starting with '-' should be rejected (must start with [a-z0-9])."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
+        mp_dir.mkdir(parents=True)
+        (mp_dir / "marketplace.json").write_text(
+            '{"plugins": [{"name": "-evil"}]}'
+        )
+        result = _run_sync(tmp_path)
+        assert result.returncode == 1
+        assert "Invalid plugin name" in result.stderr
+
+    def test_accepts_valid_plugin_names(self, tmp_path: Path) -> None:
+        """Names matching ^[a-z0-9][a-z0-9_-]*$ are accepted."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        # All valid: lowercase start, contain digits, underscores, hyphens.
+        valid_names = ["plan", "build-2", "optimus_helper", "abc", "x1"]
+        _create_marketplace(tmp_path, valid_names)
+        result = _run_sync(tmp_path)
+        assert result.returncode == 0
+        assert "Invalid plugin name" not in result.stderr
+        for name in valid_names:
+            assert f"+ {name} ... OK" in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Repo cache edge cases (F16)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestRepoCacheEdgeCases:
+    def test_repo_cache_corrupt_no_git(self, tmp_path: Path) -> None:
+        """F16: cache dir exists but lacks .git/ → script tries to clone, fails clearly.
+
+        `git clone` will not clone into a non-empty existing directory. Verify the
+        failure surfaces as a clear warning rather than a silent crash.
+        """
+        _ensure_claude_dir(tmp_path)
+        cache_dir = tmp_path / "home" / ".optimus" / "repo"
+        cache_dir.mkdir(parents=True)
+        # Populate without a .git/ directory — simulates a corrupted/manual cache.
+        (cache_dir / "stray.txt").write_text("not a git repo")
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Mock git clone to fail (mimics real `git clone` into non-empty dir).
+        _create_mock_bin(tmp_path, "git", 'if [ "$1" = "clone" ]; then exit 128; fi; exit 0')
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(cache_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        # Graceful: warns and skips Claude Code; exit code may be 0 (Claude skipped, no failures).
+        assert "Could not clone repo" in result.stderr
+        assert "Cloning repo cache" in result.stdout
+        assert "(skipped)" in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Source 3 marketplace resolution (F17 / F28)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestSourceResolution:
+    def test_resolve_expected_uses_source_3(self, tmp_path: Path) -> None:
+        """F17/F28: when Source 1 and Source 2 are absent, fall back to repo root.
+
+        Source 3 requires AGENTS.md AND sync/scripts/sync-user-plugins.sh at repo_root.
+        We simulate this by copying the script into a fake repo with stub AGENTS.md
+        and a marketplace.json at repo_root/.factory-plugin/marketplace.json.
+        """
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        # Build a fake repo layout.
+        fake_repo = tmp_path / "fake_repo"
+        (fake_repo / "sync" / "scripts").mkdir(parents=True)
+        (fake_repo / ".factory-plugin").mkdir(parents=True)
+        shutil.copy2(SCRIPT, fake_repo / "sync" / "scripts" / "sync-user-plugins.sh")
+        (fake_repo / "AGENTS.md").write_text("# AGENTS")
+        (fake_repo / ".factory-plugin" / "marketplace.json").write_text(
+            '{"plugins": [{"name": "fromsrc3"}]}'
+        )
+        # Source 1: empty .factory cache (dir exists but no marketplace.json).
+        (tmp_path / "home" / ".factory").mkdir(parents=True)
+        # Source 2: nonexistent OPTIMUS_CACHE_DIR.
+        env = os.environ.copy()
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        env["PATH"] = f"{bin_dir}:{env.get('PATH', '/usr/bin')}"
+        env["HOME"] = str(tmp_path / "home")
+        env["OPTIMUS_CACHE_DIR"] = str(tmp_path / "nonexistent")
+        result = subprocess.run(
+            [BASH, str(fake_repo / "sync" / "scripts" / "sync-user-plugins.sh")],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        assert "Added: 1" in result.stdout
+        log_content = log.read_text()
+        assert "install fromsrc3@optimus" in log_content
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Symlink safety on orphan removal (F18)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestSymlinkSafety:
+    def test_symlinked_orphan_removal_safe(self, tmp_path: Path) -> None:
+        """F18: a symlink in the skills dir must NEVER cause the script to delete the target.
+
+        The current bash `find -type d` does NOT follow symlinks, so symlinked entries
+        are not detected as "installed" and are not candidates for orphan removal.
+        That's the safety guarantee: the symlink target stays untouched regardless.
+        F7 (rm -f before cp) is the install-side defense; this asserts the orphan-side
+        property: even if a symlink with .optimus-managed is present, the target survives.
+        """
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        # Create a sensitive directory elsewhere with content + the .optimus-managed
+        # marker (so even if the script were to follow the symlink, it would still
+        # see the marker and could choose to delete — we want to verify it doesn't).
+        sensitive = tmp_path / "sensitive_data"
+        sensitive.mkdir()
+        (sensitive / "secret.txt").write_text("must-survive")
+        (sensitive / ".optimus-managed").touch()
+        orphan_link = skills_dir / "optimus-foo"
+        orphan_link.symlink_to(sensitive)
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        # The target directory and its contents must be intact (primary safety property).
+        assert sensitive.exists()
+        assert (sensitive / "secret.txt").exists()
+        assert (sensitive / "secret.txt").read_text() == "must-survive"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Update-path failure when source not found (F36)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestUpdatePathFailures:
+    def test_source_not_found_reports_fail_in_update(self, tmp_path: Path) -> None:
+        """F36: plugin already installed, but missing from cache → FAIL in update path."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Pre-install alpha locally with marker (simulates prior sync).
+        skill_dir = skills_dir / "optimus-alpha"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text("previously installed")
+        (skill_dir / ".optimus-managed").touch()
+        # Now remove SKILL.md from cache → update path must report FAIL.
+        (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").unlink()
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 1
+        # The * marker indicates update path (not + which is install).
+        assert "* alpha ... FAIL (source not found)" in result.stdout
+        assert "Failed: 1" in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Stale cache via fetch failure (F37)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestStaleCache:
+    def test_warns_on_fetch_failure_existing_cache(self, tmp_path: Path) -> None:
+        """F37: existing valid cache + git fetch fails → cache marked stale, sync proceeds."""
+        _ensure_claude_dir(tmp_path)
+        # install_git_mock=False so we can install our own that fails on fetch.
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"], install_git_mock=False)
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Mock git: handle `-C path` prefix, emit origin URL on config, fail on fetch.
+        git_script = f"""
+if [ "$1" = "-C" ]; then shift 2; fi
+case "$1" in
+  config) echo "{DEFAULT_OPTIMUS_REPO_URL}"; exit 0 ;;
+  fetch) exit 1 ;;
+  reset) exit 0 ;;
+esac
+exit 0
+"""
+        _create_mock_bin(tmp_path, "git", git_script)
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        # Sync still proceeds using cached marketplace.
+        assert result.returncode == 0
+        assert "Could not fetch latest" in result.stderr
+        assert "(cache: stale)" in result.stdout
+        # Confirms cached EXPECTED was used.
+        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Empty marketplace via Source 2 (F38)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestEmptyMarketplaceSource2:
+    def test_fails_on_empty_marketplace_via_source_2(self, tmp_path: Path) -> None:
+        """F38: Source 1 missing, Source 2 (repo cache) empty → exit 1 with 'No plugins found'."""
+        _ensure_claude_dir(tmp_path)
+        # Source 2: repo cache with empty marketplace. Default git mock handles
+        # config/fetch/reset as no-ops returning the right URL.
+        repo_dir = _create_repo_cache(tmp_path, [])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # isolated=True so Source 3 (running from inside repo) can't accidentally satisfy.
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True, isolated=True)
+        assert result.returncode == 1
+        assert "No plugins found" in result.stderr

--- a/scripts/test_sync_user_plugins.py
+++ b/scripts/test_sync_user_plugins.py
@@ -32,20 +32,84 @@ def _create_marketplace(tmp_path: Path, plugins: list[str], name: str = "optimus
     mp_file.write_text(f'{{"plugins": [{entries}]}}')
 
 
+def _create_repo_cache(tmp_path: Path, plugins: list[str],
+                       cache_dir: str | None = None) -> Path:
+    """Create a mock optimus repo cache with SKILL.md files."""
+    repo_dir = Path(cache_dir) if cache_dir else tmp_path / "home" / ".optimus" / "repo"
+    # Create .git dir to mark it as a repo
+    (repo_dir / ".git").mkdir(parents=True, exist_ok=True)
+    # Create marketplace.json
+    mp_dir = repo_dir / ".factory-plugin"
+    mp_dir.mkdir(parents=True, exist_ok=True)
+    entries = ", ".join(f'{{"name": "{p}"}}' for p in plugins)
+    (mp_dir / "marketplace.json").write_text(f'{{"plugins": [{entries}]}}')
+    # Create SKILL.md for each plugin
+    for plugin in plugins:
+        skill_dir = repo_dir / plugin / "skills" / f"optimus-{plugin}"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: optimus-{plugin}\n---\n# {plugin}\nContent for {plugin}.\n"
+        )
+    return repo_dir
+
+
+def _create_claude_skill(tmp_path: Path, name: str,
+                         content: str = "# placeholder") -> Path:
+    """Create a skill directory in the mock Claude Code skills dir."""
+    skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+    skill_dir = skills_dir / f"optimus-{name}"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content)
+    return skill_dir
+
+
+def _ensure_claude_dir(tmp_path: Path) -> Path:
+    """Ensure ~/.claude/ directory exists in mock home."""
+    claude_dir = tmp_path / "home" / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    return claude_dir
+
+
+def _path_without_droid() -> str:
+    """Return system PATH with any directory containing a droid binary removed."""
+    path_dirs = os.environ.get("PATH", "/usr/bin:/bin").split(":")
+    filtered = [d for d in path_dirs if d and not (Path(d) / "droid").exists()]
+    return ":".join(filtered) if filtered else "/usr/bin:/bin"
+
+
 def _run_sync(tmp_path: Path, env_extra: dict[str, str] | None = None,
-              restrict_path: bool = False) -> subprocess.CompletedProcess:
-    """Run the sync script with mocked PATH and HOME."""
+              restrict_path: bool = False,
+              exclude_droid: bool = False,
+              isolated: bool = False) -> subprocess.CompletedProcess:
+    """Run the sync script with mocked PATH and HOME.
+
+    Args:
+        restrict_path: Only use tmp_path/bin as PATH (excludes ALL system binaries).
+        exclude_droid: Remove droid from PATH but keep other system tools.
+        isolated: Copy script to tmp_path so BASH_SOURCE doesn't resolve to the repo.
+    """
     env = os.environ.copy()
     bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
     if restrict_path:
         env["PATH"] = str(bin_dir)
+    elif exclude_droid:
+        env["PATH"] = f"{bin_dir}:{_path_without_droid()}"
     else:
         env["PATH"] = f"{bin_dir}:{env.get('PATH', '/usr/bin')}"
     env["HOME"] = str(tmp_path / "home")
     if env_extra:
         env.update(env_extra)
+
+    script = SCRIPT
+    if isolated:
+        isolated_script = tmp_path / "isolated" / "sync-user-plugins.sh"
+        isolated_script.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(SCRIPT, isolated_script)
+        script = isolated_script
+
     return subprocess.run(
-        [BASH, str(SCRIPT)],
+        [BASH, str(script)],
         capture_output=True,
         text=True,
         env=env,
@@ -70,8 +134,13 @@ esac
 """
 
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# Existing Droid-only tests (adapted for dual-platform)
+# ═══════════════════════════════════════════════════════════════════════════════
+
 class TestDependencyChecks:
-    def test_fails_without_droid(self, tmp_path: Path):
+    def test_fails_without_any_platform(self, tmp_path: Path):
+        """Neither droid nor ~/.claude/ → error."""
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir(exist_ok=True)
         jq_path = shutil.which("jq")
@@ -80,9 +149,10 @@ class TestDependencyChecks:
         else:
             (bin_dir / "jq").write_text("#!/bin/bash\necho jq\n")
             (bin_dir / "jq").chmod(0o755)
+        # No droid, no .claude dir
         result = _run_sync(tmp_path, restrict_path=True)
         assert result.returncode == 1
-        assert "droid CLI is required" in result.stderr
+        assert "No supported platform found" in result.stderr
 
     def test_fails_without_jq(self, tmp_path: Path):
         bin_dir = tmp_path / "bin"
@@ -105,7 +175,7 @@ class TestFirstTimeInstall:
         _create_marketplace(tmp_path, ["alpha", "beta"])
         result = _run_sync(tmp_path)
         assert result.returncode == 0
-        assert "Added:   2" in result.stdout
+        assert "Added: 2" in result.stdout
         assert "alpha ... OK" in result.stdout
         assert "beta ... OK" in result.stdout
         log_content = log.read_text()
@@ -158,7 +228,7 @@ class TestMarketplaceOverride:
         _create_marketplace(tmp_path, ["test"], name="custom")
         result = _run_sync(tmp_path, {"OPTIMUS_MARKETPLACE_NAME": "custom"})
         assert result.returncode == 0
-        assert "Added:   1" in result.stdout
+        assert "Added: 1" in result.stdout
 
 
 class TestErrorPaths:
@@ -166,7 +236,11 @@ class TestErrorPaths:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         (tmp_path / "home" / ".factory").mkdir(parents=True)
-        result = _run_sync(tmp_path)
+        # Use isolated=True so BASH_SOURCE doesn't resolve to the optimus repo,
+        # and set OPTIMUS_CACHE_DIR to a nonexistent path to prevent Source 2 fallback.
+        result = _run_sync(tmp_path, isolated=True, env_extra={
+            "OPTIMUS_CACHE_DIR": str(tmp_path / "nonexistent"),
+        })
         assert result.returncode == 1
         assert "not found" in result.stderr.lower()
 
@@ -236,7 +310,7 @@ esac
         _create_marketplace(tmp_path, ["good", "fail-plugin", "also-good"])
         result = _run_sync(tmp_path)
         assert result.returncode == 1
-        assert "Added:   2" in result.stdout
+        assert "Added: 2" in result.stdout
         assert "Failed:" in result.stdout
 
 
@@ -257,7 +331,7 @@ esac
         result = _run_sync(tmp_path)
         assert result.returncode == 0
         assert "Could not update marketplace" in result.stderr
-        assert "Added:   1" in result.stdout
+        assert "Added: 1" in result.stdout
 
 
 class TestSignalHandling:
@@ -368,7 +442,7 @@ esac
         result = _run_sync(tmp_path)
         assert result.returncode == 0
         assert "Retrying failed plugin operations serially" in result.stdout
-        assert "Added:   1" in result.stdout
+        assert "Added: 1" in result.stdout
         log_content = log.read_text()
         assert "install alpha@optimus #1" in log_content
         assert "install alpha@optimus #2" in log_content
@@ -383,3 +457,269 @@ class TestMalformedMarketplace:
         (mp_dir / "marketplace.json").write_text("{invalid json")
         result = _run_sync(tmp_path)
         assert result.returncode != 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Claude Code detection tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestClaudeCodeDetection:
+    def test_detects_claude_code_when_dir_exists(self, tmp_path: Path) -> None:
+        """When ~/.claude/ exists and no droid, runs Claude Code sync."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "── Claude Code ──" in result.stdout
+        assert "── Droid (Factory) ──" not in result.stdout
+
+    def test_skips_claude_code_when_no_dir(self, tmp_path: Path) -> None:
+        """When ~/.claude/ doesn't exist but droid is available, only Droid runs."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        _create_marketplace(tmp_path, ["alpha"])
+        # Don't create .claude dir
+        result = _run_sync(tmp_path)
+        assert result.returncode == 0
+        assert "Droid" in result.stdout
+        # Claude Code section should not appear
+        assert "── Claude Code ──" not in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Claude Code sync tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestClaudeCodeSync:
+    def test_installs_new_skills(self, tmp_path: Path) -> None:
+        """First-time install copies SKILL.md files to skills dir."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha", "beta"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "Added: 2" in result.stdout
+        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
+        assert (skills_dir / "optimus-beta" / "SKILL.md").exists()
+
+    def test_updates_changed_skills(self, tmp_path: Path) -> None:
+        """When source SKILL.md differs, it gets updated."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Create existing skill with different content
+        skill_dir = skills_dir / "optimus-alpha"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text("old content")
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "Updated: 1" in result.stdout
+        assert "alpha" in (skill_dir / "SKILL.md").read_text()
+
+    def test_skips_unchanged_skills(self, tmp_path: Path) -> None:
+        """When source SKILL.md is identical, skip with 'unchanged'."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Copy the exact same content
+        src_content = (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").read_text()
+        skill_dir = skills_dir / "optimus-alpha"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(src_content)
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "unchanged" in result.stdout.lower()
+        assert "Unchanged: 1" in result.stdout
+
+    def test_removes_orphaned_skills(self, tmp_path: Path) -> None:
+        """Skills in dir but not in marketplace get removed."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Create orphaned skill
+        orphan_dir = skills_dir / "optimus-orphan"
+        orphan_dir.mkdir(parents=True, exist_ok=True)
+        (orphan_dir / "SKILL.md").write_text("orphan")
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "Removed: 1" in result.stdout
+        assert not orphan_dir.exists()
+
+    def test_never_removes_non_optimus_skills(self, tmp_path: Path) -> None:
+        """Skills without optimus- prefix must NEVER be touched."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Create non-optimus skills that must survive
+        for name in ["ring:code-reviewer", "my-custom-skill", "other-tool"]:
+            safe_dir = skills_dir / name
+            safe_dir.mkdir(parents=True, exist_ok=True)
+            (safe_dir / "SKILL.md").write_text(f"safe: {name}")
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        # All non-optimus skills must still exist
+        for name in ["ring:code-reviewer", "my-custom-skill", "other-tool"]:
+            assert (skills_dir / name / "SKILL.md").exists(), f"{name} was incorrectly removed!"
+
+    def test_source_not_found_reports_fail(self, tmp_path: Path) -> None:
+        """When SKILL.md doesn't exist in repo cache, report FAIL."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Remove the SKILL.md from cache to simulate missing source
+        (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").unlink()
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 1
+        assert "source not found" in result.stdout.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Claude Code repo cache tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestClaudeCodeRepoCache:
+    def test_uses_existing_cache(self, tmp_path: Path) -> None:
+        """When cache dir exists with .git, uses it without cloning."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        # Mock git to avoid actual network calls
+        _create_mock_bin(tmp_path, "git", 'exit 0')
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "Updating repo cache" in result.stdout
+
+    def test_clones_when_no_cache(self, tmp_path: Path) -> None:
+        """When no cache exists, attempts to clone."""
+        _ensure_claude_dir(tmp_path)
+        cache_dir = tmp_path / "home" / ".optimus" / "repo"
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Mock git clone to create the repo cache
+        git_script = f"""
+if [ "$1" = "clone" ]; then
+  mkdir -p "{cache_dir}/.git"
+  mkdir -p "{cache_dir}/.factory-plugin"
+  echo '{{"plugins": [{{"name": "alpha"}}]}}' > "{cache_dir}/.factory-plugin/marketplace.json"
+  mkdir -p "{cache_dir}/alpha/skills/optimus-alpha"
+  echo "---\\nname: optimus-alpha\\n---\\n# alpha" > "{cache_dir}/alpha/skills/optimus-alpha/SKILL.md"
+  exit 0
+fi
+exit 0
+"""
+        _create_mock_bin(tmp_path, "git", git_script)
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(cache_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "Cloning repo cache" in result.stdout
+
+    def test_warns_on_clone_failure(self, tmp_path: Path) -> None:
+        """When clone fails, warn and skip Claude Code sync gracefully."""
+        _ensure_claude_dir(tmp_path)
+        cache_dir = tmp_path / "home" / ".optimus" / "repo"
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        # Mock git that always fails
+        _create_mock_bin(tmp_path, "git", 'exit 1')
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(cache_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        # Should not crash — graceful skip
+        assert "Could not clone repo" in result.stderr or "skipped" in result.stdout.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dual platform sync tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestDualPlatformSync:
+    def test_syncs_both_platforms_simultaneously(self, tmp_path: Path) -> None:
+        """When both droid and ~/.claude/ are available, sync both."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        _create_marketplace(tmp_path, ["alpha", "beta"])
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha", "beta"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        result = _run_sync(tmp_path, {
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        })
+        assert result.returncode == 0
+        # Both platform sections should appear
+        assert "── Droid (Factory) ──" in result.stdout
+        assert "── Claude Code ──" in result.stdout
+        # Both should report success
+        assert "Droid" in result.stdout
+        assert "Claude Code" in result.stdout
+        # Claude Code skills should be installed
+        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
+        assert (skills_dir / "optimus-beta" / "SKILL.md").exists()
+
+    def test_droid_only_when_no_claude_dir(self, tmp_path: Path) -> None:
+        """Without ~/.claude/, only Droid sync runs."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        _create_marketplace(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path)
+        assert result.returncode == 0
+        assert "── Droid (Factory) ──" in result.stdout
+        assert "── Claude Code ──" not in result.stdout
+
+    def test_claude_only_when_no_droid(self, tmp_path: Path) -> None:
+        """Without droid CLI, only Claude Code sync runs."""
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        }, exclude_droid=True)
+        assert result.returncode == 0
+        assert "── Droid (Factory) ──" not in result.stdout
+        assert "── Claude Code ──" in result.stdout
+
+    def test_droid_failure_doesnt_block_claude(self, tmp_path: Path) -> None:
+        """If Droid sync fails, Claude Code sync still runs."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log, install_exit=1))
+        _create_marketplace(tmp_path, ["alpha"])
+        _ensure_claude_dir(tmp_path)
+        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
+        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
+        result = _run_sync(tmp_path, env_extra={
+            "OPTIMUS_CACHE_DIR": str(repo_dir),
+            "CLAUDE_SKILLS_DIR": str(skills_dir),
+        })
+        # Overall should fail (droid failed) but Claude Code should succeed
+        assert result.returncode == 1
+        assert "── Droid (Factory) ──" in result.stdout
+        assert "── Claude Code ──" in result.stdout
+        # Claude Code skill should still be installed
+        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()

--- a/sync/scripts/sync-user-plugins.sh
+++ b/sync/scripts/sync-user-plugins.sh
@@ -25,9 +25,9 @@ readonly OPTIMUS_REPO_URL="${OPTIMUS_REPO_URL:-https://github.com/alexgarzao/opt
 
 # ─── Platform detection ───────────────────────────────────────────────────────
 HAS_DROID=false
-HAS_CLAUDE=false
+HAS_CLAUDE_CODE=false
 command -v droid >/dev/null 2>&1 && HAS_DROID=true
-[ -d "$HOME/.claude" ] && HAS_CLAUDE=true
+[ -d "$HOME/.claude/skills" ] && HAS_CLAUDE_CODE=true
 
 # ─── Validate inputs ─────────────────────────────────────────────────────────
 if [ "$HAS_DROID" = true ]; then
@@ -37,10 +37,10 @@ if [ "$HAS_DROID" = true ]; then
   fi
 fi
 
-if [ "$HAS_DROID" = false ] && [ "$HAS_CLAUDE" = false ]; then
+if [ "$HAS_DROID" = false ] && [ "$HAS_CLAUDE_CODE" = false ]; then
   _error "No supported platform found."
   echo "  Install Droid from: https://docs.factory.ai" >&2
-  echo "  Or create ~/.claude/ for Claude Code support." >&2
+  echo "  Or create ~/.claude/skills/ for Claude Code support." >&2
   exit 1
 fi
 
@@ -61,13 +61,25 @@ _droid() {
   fi
 }
 
-_count_lines() {
-  echo "$1" | grep -c . 2>/dev/null || echo 0
-}
-
 _read_result() {
   local file="$1"
   cat "$file" 2>/dev/null || echo "FAIL"
+}
+
+# _compute_diffs <expected> <installed>
+# Sets globals: NEW_PLUGINS, ORPHANED_PLUGINS, EXISTING_PLUGINS
+_compute_diffs() {
+  local expected="$1"
+  local installed="$2"
+  if [ -z "$installed" ]; then
+    NEW_PLUGINS="$expected"
+    ORPHANED_PLUGINS=""
+    EXISTING_PLUGINS=""
+  else
+    NEW_PLUGINS=$(comm -23 <(echo "$expected") <(echo "$installed"))
+    ORPHANED_PLUGINS=$(comm -13 <(echo "$expected") <(echo "$installed"))
+    EXISTING_PLUGINS=$(comm -12 <(echo "$expected") <(echo "$installed"))
+  fi
 }
 
 # ─── Get expected plugins from marketplace JSON ──────────────────────────────
@@ -93,8 +105,10 @@ _resolve_expected_plugins() {
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     local repo_root
     repo_root="$(cd "$script_dir/../.." && pwd)"
-    if [ -f "$repo_root/.factory-plugin/marketplace.json" ]; then
-      marketplace_file="$repo_root/.factory-plugin/marketplace.json"
+    if [ -f "$repo_root/AGENTS.md" ] && [ -f "$repo_root/sync/scripts/sync-user-plugins.sh" ]; then
+      if [ -f "$repo_root/.factory-plugin/marketplace.json" ]; then
+        marketplace_file="$repo_root/.factory-plugin/marketplace.json"
+      fi
     fi
   fi
 
@@ -112,6 +126,16 @@ _resolve_expected_plugins() {
     return 1
   fi
 
+  # Validate plugin names (path-traversal defense)
+  local p
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    if ! [[ "$p" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+      _error "Invalid plugin name in marketplace.json: '$p' (must match ^[a-z0-9][a-z0-9_-]*\$)"
+      return 1
+    fi
+  done <<< "$expected"
+
   echo "$expected"
 }
 
@@ -124,12 +148,6 @@ _sync_droid() {
   echo "── Droid (Factory) ──"
   echo ""
 
-  # Update marketplace
-  echo "Updating marketplace..."
-  if ! _droid plugin marketplace update "$MARKETPLACE_NAME" 2>/dev/null; then
-    _warn "Could not update marketplace. Proceeding with cached version."
-  fi
-
   # Get installed optimus plugins
   local installed
   installed=$(_droid plugin list 2>/dev/null \
@@ -139,20 +157,16 @@ _sync_droid() {
     | sort) || true
 
   # Calculate diffs
-  local new_plugins orphaned_plugins existing_plugins
-  if [ -z "$installed" ]; then
-    new_plugins="$expected"
-    orphaned_plugins=""
-    existing_plugins=""
-  else
-    new_plugins=$(comm -23 <(echo "$expected") <(echo "$installed"))
-    orphaned_plugins=$(comm -13 <(echo "$expected") <(echo "$installed"))
-    existing_plugins=$(comm -12 <(echo "$expected") <(echo "$installed"))
-  fi
+  _compute_diffs "$expected" "$installed"
+  local new_plugins="$NEW_PLUGINS"
+  local orphaned_plugins="$ORPHANED_PLUGINS"
+  local existing_plugins="$EXISTING_PLUGINS"
 
   # All operations run in parallel using temp dir for result collection
   local results_dir
   results_dir=$(mktemp -d)
+  local _saved_trap
+  _saved_trap=$(trap -p INT TERM)
   # shellcheck disable=SC2064
   trap "rm -rf '$results_dir'; echo ''; _warn 'Sync interrupted. Re-run /optimus-sync to complete.'; exit 130" INT TERM
   local retry_removals="" retry_installs="" retry_updates=""
@@ -271,6 +285,7 @@ _sync_droid() {
 
   # Collect results
   local removed=0 added=0 updated=0 failed=0
+  local result
 
   if [ -n "$orphaned_plugins" ]; then
     while IFS= read -r plugin; do
@@ -313,40 +328,53 @@ _sync_droid() {
   fi
 
   rm -rf "$results_dir"
+  eval "${_saved_trap:-trap - INT TERM}"
 
   echo ""
   echo "  Droid — Added: $added | Updated: $updated | Removed: $removed | Failed: $failed"
 
-  [ "$failed" -gt 0 ] && return 1
-  return 0
+  local rc=0
+  [ "$failed" -gt 0 ] && rc=1
+  return $rc
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Repo Cache Management (used by Claude Code sync and as marketplace fallback)
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Track whether repo cache is usable (set by _ensure_repo_cache)
-_REPO_CACHE_OK=false
+# Track whether repo cache is usable (set by _ensure_repo_cache).
+# Possible values: "true" (fresh), "stale" (cached but fetch failed), "false" (unusable).
+_REPO_CACHE_OK="false"
 
 _ensure_repo_cache() {
   local repo_dir="$OPTIMUS_CACHE_DIR"
 
   if [ -d "$repo_dir/.git" ]; then
+    # Verify the cache origin matches OPTIMUS_REPO_URL before using it.
+    local actual_url
+    actual_url=$(git -C "$repo_dir" config --get remote.origin.url 2>/dev/null || echo "")
+    if [ "$actual_url" != "$OPTIMUS_REPO_URL" ]; then
+      _error "Repo cache at $repo_dir has unexpected origin: '$actual_url' (expected '$OPTIMUS_REPO_URL'). Refusing to use it. Delete it manually if intentional."
+      _REPO_CACHE_OK="false"
+      return 0  # Soft failure — script can continue if Source 1 or 3 work
+    fi
+
     echo "Updating repo cache..."
     if ! git -C "$repo_dir" fetch --depth 1 origin main 2>/dev/null; then
-      _warn "Could not fetch latest. Using cached version."
+      _warn "Could not fetch latest. Using cached (possibly stale) version."
+      _REPO_CACHE_OK="stale"
     else
       git -C "$repo_dir" reset --hard origin/main 2>/dev/null || true
+      _REPO_CACHE_OK="true"
     fi
-    _REPO_CACHE_OK=true
   else
     echo "Cloning repo cache..."
     if git clone --depth 1 "$OPTIMUS_REPO_URL" "$repo_dir" 2>/dev/null; then
-      _REPO_CACHE_OK=true
+      _REPO_CACHE_OK="true"
     else
       _warn "Could not clone repo. Claude Code sync requires a repo cache."
       echo "  Run: git clone --depth 1 ${OPTIMUS_REPO_URL} ${repo_dir}" >&2
-      _REPO_CACHE_OK=false
+      _REPO_CACHE_OK="false"
     fi
   fi
 }
@@ -362,7 +390,7 @@ _sync_claude_code() {
 
   local repo_dir="$OPTIMUS_CACHE_DIR"
 
-  if [ "$_REPO_CACHE_OK" = false ]; then
+  if [ "$_REPO_CACHE_OK" = "false" ]; then
     echo "  Claude Code — Added: 0 | Updated: 0 | Removed: 0 | Failed: 0 (skipped)"
     return 0
   fi
@@ -370,27 +398,21 @@ _sync_claude_code() {
   local skills_dir="$CLAUDE_SKILLS_DIR"
   mkdir -p "$skills_dir"
 
-  # Step 3: Get currently installed optimus skills
+  # Get currently installed optimus skills
   local installed=""
   if [ -d "$skills_dir" ]; then
     installed=$(find "$skills_dir" -maxdepth 1 -type d -name 'optimus-*' -exec basename {} \; 2>/dev/null | sed 's/^optimus-//' | sort) || true
   fi
 
-  # Step 4: Calculate diffs
-  local new_plugins orphaned_plugins existing_plugins
-  if [ -z "$installed" ]; then
-    new_plugins="$expected"
-    orphaned_plugins=""
-    existing_plugins=""
-  else
-    new_plugins=$(comm -23 <(echo "$expected") <(echo "$installed"))
-    orphaned_plugins=$(comm -13 <(echo "$expected") <(echo "$installed"))
-    existing_plugins=$(comm -12 <(echo "$expected") <(echo "$installed"))
-  fi
+  # Calculate diffs
+  _compute_diffs "$expected" "$installed"
+  local new_plugins="$NEW_PLUGINS"
+  local orphaned_plugins="$ORPHANED_PLUGINS"
+  local existing_plugins="$EXISTING_PLUGINS"
 
   local added=0 updated=0 removed=0 failed=0 unchanged=0
 
-  # Step 5: Install new plugins
+  # Install new plugins
   if [ -n "$new_plugins" ]; then
     while IFS= read -r plugin; do
       [ -z "$plugin" ] && continue
@@ -398,7 +420,9 @@ _sync_claude_code() {
       local dest_dir="$skills_dir/optimus-${plugin}"
       if [ -f "$src" ]; then
         mkdir -p "$dest_dir"
+        rm -f "$dest_dir/SKILL.md"
         cp "$src" "$dest_dir/SKILL.md"
+        touch "$dest_dir/.optimus-managed"
         echo "  + $plugin ... OK"
         added=$((added + 1))
       else
@@ -408,12 +432,13 @@ _sync_claude_code() {
     done <<< "$new_plugins"
   fi
 
-  # Step 6: Update existing plugins (skip if unchanged)
+  # Update existing plugins (skip if unchanged)
   if [ -n "$existing_plugins" ]; then
     while IFS= read -r plugin; do
       [ -z "$plugin" ] && continue
       local src="$repo_dir/${plugin}/skills/optimus-${plugin}/SKILL.md"
-      local dest="$skills_dir/optimus-${plugin}/SKILL.md"
+      local dest_dir="$skills_dir/optimus-${plugin}"
+      local dest="$dest_dir/SKILL.md"
       if [ ! -f "$src" ]; then
         echo "  * $plugin ... FAIL (source not found)"
         failed=$((failed + 1))
@@ -422,23 +447,39 @@ _sync_claude_code() {
       if [ -f "$dest" ] && diff -q "$src" "$dest" >/dev/null 2>&1; then
         echo "  * $plugin ... unchanged"
         unchanged=$((unchanged + 1))
+        # Idempotently ensure the marker exists for pre-existing installs.
+        touch "$dest_dir/.optimus-managed"
       else
-        mkdir -p "$skills_dir/optimus-${plugin}"
+        mkdir -p "$dest_dir"
+        rm -f "$dest"
         cp "$src" "$dest"
+        touch "$dest_dir/.optimus-managed"
         echo "  * $plugin ... OK"
         updated=$((updated + 1))
       fi
     done <<< "$existing_plugins"
   fi
 
-  # Step 7: Remove orphaned plugins (ONLY optimus- prefixed)
+  # Remove orphaned plugins (ONLY optimus- prefixed, ONLY with .optimus-managed marker)
   if [ -n "$orphaned_plugins" ]; then
     while IFS= read -r plugin; do
       [ -z "$plugin" ] && continue
       local target_dir="$skills_dir/optimus-${plugin}"
       if [ -d "$target_dir" ]; then
-        rm -rf "$target_dir"
-        echo "  - $plugin ... OK"
+        if [ -f "$target_dir/.optimus-managed" ]; then
+          if rm -rf "$target_dir" 2>/dev/null; then
+            echo "  - $plugin"
+            removed=$((removed + 1))
+          else
+            echo "  - $plugin (FAIL)"
+            failed=$((failed + 1))
+          fi
+        else
+          echo "  - $plugin (skipped — no .optimus-managed marker; user-created?)"
+          # Not counted as removed or failed
+        fi
+      else
+        echo "  - $plugin (already gone)"
         removed=$((removed + 1))
       fi
     done <<< "$orphaned_plugins"
@@ -448,6 +489,9 @@ _sync_claude_code() {
   local summary="Claude Code — Added: $added | Updated: $updated | Removed: $removed | Failed: $failed"
   if [ "$unchanged" -gt 0 ]; then
     summary="$summary | Unchanged: $unchanged"
+  fi
+  if [ "$_REPO_CACHE_OK" = "stale" ]; then
+    summary="$summary (cache: stale)"
   fi
   echo "  $summary"
 
@@ -465,15 +509,26 @@ echo ""
 # Detect platforms
 platforms=""
 if [ "$HAS_DROID" = true ]; then platforms="${platforms}Droid "; fi
-if [ "$HAS_CLAUDE" = true ]; then platforms="${platforms}Claude Code "; fi
+if [ "$HAS_CLAUDE_CODE" = true ]; then platforms="${platforms}Claude Code "; fi
 echo "Platforms: $platforms"
 echo ""
 
-# Ensure repo cache is populated (needed for Claude Code sync and marketplace fallback)
-if [ "$HAS_CLAUDE" = true ]; then
-  _ensure_repo_cache
+# Surface a custom OPTIMUS_REPO_URL so users notice it on each run.
+_default_url="https://github.com/alexgarzao/optimus"
+if [ "$OPTIMUS_REPO_URL" != "$_default_url" ]; then
+  echo "Note: using custom OPTIMUS_REPO_URL=$OPTIMUS_REPO_URL"
   echo ""
 fi
+
+# Refresh both marketplace sources before resolving EXPECTED
+if [ "$HAS_DROID" = true ]; then
+  echo "Updating Droid marketplace..."
+  _droid plugin marketplace update "$MARKETPLACE_NAME" >/dev/null 2>&1 || _warn "Could not update Droid marketplace. Using cached version."
+fi
+if [ "$HAS_CLAUDE_CODE" = true ]; then
+  _ensure_repo_cache
+fi
+echo ""
 
 # Resolve expected plugins (shared across platforms)
 EXPECTED=$(_resolve_expected_plugins) || exit 1
@@ -487,7 +542,7 @@ if [ "$HAS_DROID" = true ]; then
   echo ""
 fi
 
-if [ "$HAS_CLAUDE" = true ]; then
+if [ "$HAS_CLAUDE_CODE" = true ]; then
   _sync_claude_code "$EXPECTED" || claude_rc=$?
   echo ""
 fi

--- a/sync/scripts/sync-user-plugins.sh
+++ b/sync/scripts/sync-user-plugins.sh
@@ -2,21 +2,54 @@
 set -euo pipefail
 
 # Syncs installed Optimus plugins with the marketplace.
+# Supports two platforms:
+#   - Droid (Factory): uses `droid plugin install/update/uninstall`
+#   - Claude Code: copies SKILL.md files to ~/.claude/skills/default/optimus-<name>/
+#
+# Detects which platforms are available and syncs both in a single run.
 # - Installs new plugins that were added to the marketplace
 # - Removes orphaned plugins that were removed from the marketplace
-# - Updates all existing plugins (with uninstall+reinstall fallback for scope conflicts)
+# - Updates all existing plugins (with uninstall+reinstall fallback for Droid scope conflicts)
 
 _error() { echo "ERROR: $*" >&2; }
 _warn() { echo "WARNING: $*" >&2; }
 
 trap 'echo ""; _warn "Sync interrupted. Re-run /optimus-sync to complete."; exit 130' INT TERM
 
+# ─── Configurable constants ───────────────────────────────────────────────────
 readonly MARKETPLACE_NAME="${OPTIMUS_MARKETPLACE_NAME:-optimus}"
 readonly DROID_TIMEOUT="${OPTIMUS_DROID_TIMEOUT:-60}"
-if ! [[ "$DROID_TIMEOUT" =~ ^[1-9][0-9]*$ ]]; then
-  _error "OPTIMUS_DROID_TIMEOUT must be a positive integer (got: '$DROID_TIMEOUT')"
+readonly OPTIMUS_CACHE_DIR="${OPTIMUS_CACHE_DIR:-$HOME/.optimus/repo}"
+readonly CLAUDE_SKILLS_DIR="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills/default}"
+readonly OPTIMUS_REPO_URL="${OPTIMUS_REPO_URL:-https://github.com/alexgarzao/optimus}"
+
+# ─── Platform detection ───────────────────────────────────────────────────────
+HAS_DROID=false
+HAS_CLAUDE=false
+command -v droid >/dev/null 2>&1 && HAS_DROID=true
+[ -d "$HOME/.claude" ] && HAS_CLAUDE=true
+
+# ─── Validate inputs ─────────────────────────────────────────────────────────
+if [ "$HAS_DROID" = true ]; then
+  if ! [[ "$DROID_TIMEOUT" =~ ^[1-9][0-9]*$ ]]; then
+    _error "OPTIMUS_DROID_TIMEOUT must be a positive integer (got: '$DROID_TIMEOUT')"
+    exit 1
+  fi
+fi
+
+if [ "$HAS_DROID" = false ] && [ "$HAS_CLAUDE" = false ]; then
+  _error "No supported platform found."
+  echo "  Install Droid from: https://docs.factory.ai" >&2
+  echo "  Or create ~/.claude/ for Claude Code support." >&2
   exit 1
 fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  _error "jq is required but not installed."
+  exit 1
+fi
+
+# ─── Shared helpers ───────────────────────────────────────────────────────────
 
 _droid() {
   if command -v timeout >/dev/null 2>&1; then
@@ -37,234 +70,431 @@ _read_result() {
   cat "$file" 2>/dev/null || echo "FAIL"
 }
 
+# ─── Get expected plugins from marketplace JSON ──────────────────────────────
+# Resolves marketplace.json from: Droid cache, Optimus repo cache, or repo root.
+# Returns the list of expected plugin names (sorted, one per line) via stdout.
+
+_resolve_expected_plugins() {
+  local marketplace_file=""
+
+  # Source 1: Droid marketplace cache
+  if [ "$HAS_DROID" = true ]; then
+    marketplace_file=$(find ~/.factory -path "*/marketplaces/${MARKETPLACE_NAME}/.factory-plugin/marketplace.json" -type f 2>/dev/null | head -1)
+  fi
+
+  # Source 2: Optimus repo cache
+  if [ -z "$marketplace_file" ] && [ -f "$OPTIMUS_CACHE_DIR/.factory-plugin/marketplace.json" ]; then
+    marketplace_file="$OPTIMUS_CACHE_DIR/.factory-plugin/marketplace.json"
+  fi
+
+  # Source 3: Running from inside the optimus repo
+  if [ -z "$marketplace_file" ]; then
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local repo_root
+    repo_root="$(cd "$script_dir/../.." && pwd)"
+    if [ -f "$repo_root/.factory-plugin/marketplace.json" ]; then
+      marketplace_file="$repo_root/.factory-plugin/marketplace.json"
+    fi
+  fi
+
+  if [ -z "$marketplace_file" ]; then
+    _error "Marketplace '${MARKETPLACE_NAME}' not found. Register it first:"
+    echo "  droid plugin marketplace add ${OPTIMUS_REPO_URL}" >&2
+    echo "  Or run: git clone --depth 1 ${OPTIMUS_REPO_URL} ${OPTIMUS_CACHE_DIR}" >&2
+    return 1
+  fi
+
+  local expected
+  expected=$(jq -r '.plugins[].name' "$marketplace_file" | sort)
+  if [ -z "$expected" ]; then
+    _error "No plugins found in marketplace."
+    return 1
+  fi
+
+  echo "$expected"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Droid Sync
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_sync_droid() {
+  local expected="$1"
+  echo "── Droid (Factory) ──"
+  echo ""
+
+  # Update marketplace
+  echo "Updating marketplace..."
+  if ! _droid plugin marketplace update "$MARKETPLACE_NAME" 2>/dev/null; then
+    _warn "Could not update marketplace. Proceeding with cached version."
+  fi
+
+  # Get installed optimus plugins
+  local installed
+  installed=$(_droid plugin list 2>/dev/null \
+    | grep -F "@${MARKETPLACE_NAME}" \
+    | awk '{print $1}' \
+    | while IFS= read -r _line; do echo "${_line%@"${MARKETPLACE_NAME}"}"; done \
+    | sort) || true
+
+  # Calculate diffs
+  local new_plugins orphaned_plugins existing_plugins
+  if [ -z "$installed" ]; then
+    new_plugins="$expected"
+    orphaned_plugins=""
+    existing_plugins=""
+  else
+    new_plugins=$(comm -23 <(echo "$expected") <(echo "$installed"))
+    orphaned_plugins=$(comm -13 <(echo "$expected") <(echo "$installed"))
+    existing_plugins=$(comm -12 <(echo "$expected") <(echo "$installed"))
+  fi
+
+  # All operations run in parallel using temp dir for result collection
+  local results_dir
+  results_dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$results_dir'; echo ''; _warn 'Sync interrupted. Re-run /optimus-sync to complete.'; exit 130" INT TERM
+  local retry_removals="" retry_installs="" retry_updates=""
+
+  # Remove orphaned plugins (parallel)
+  if [ -n "$orphaned_plugins" ]; then
+    echo "Removing orphaned plugins..."
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      (
+        if _droid plugin uninstall "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
+          echo "OK" > "$results_dir/remove-${plugin}"
+        else
+          echo "RETRY" > "$results_dir/remove-${plugin}"
+        fi
+      ) &
+    done <<< "$orphaned_plugins"
+    wait
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      if [ "$(_read_result "$results_dir/remove-${plugin}")" = "RETRY" ]; then
+        retry_removals="${retry_removals}${plugin}
+"
+      fi
+    done <<< "$orphaned_plugins"
+  fi
+
+  # Install new plugins (parallel)
+  if [ -n "$new_plugins" ]; then
+    echo "Installing new plugins..."
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      (
+        if _droid plugin install "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
+          echo "OK" > "$results_dir/install-${plugin}"
+        else
+          echo "RETRY" > "$results_dir/install-${plugin}"
+        fi
+      ) &
+    done <<< "$new_plugins"
+    wait
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      if [ "$(_read_result "$results_dir/install-${plugin}")" = "RETRY" ]; then
+        retry_installs="${retry_installs}${plugin}
+"
+      fi
+    done <<< "$new_plugins"
+  fi
+
+  # Update existing plugins (parallel)
+  if [ -n "$existing_plugins" ]; then
+    echo "Updating existing plugins..."
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      (
+        if _droid plugin update "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
+          echo "OK" > "$results_dir/update-${plugin}"
+        else
+          echo "RETRY" > "$results_dir/update-${plugin}"
+        fi
+      ) &
+    done <<< "$existing_plugins"
+    wait
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      if [ "$(_read_result "$results_dir/update-${plugin}")" = "RETRY" ]; then
+        retry_updates="${retry_updates}${plugin}
+"
+      fi
+    done <<< "$existing_plugins"
+  fi
+
+  # Retry transient failures serially
+  if [ -n "$retry_removals$retry_installs$retry_updates" ]; then
+    echo "Retrying failed plugin operations serially..."
+  fi
+
+  if [ -n "$retry_removals" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      if _droid plugin uninstall "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
+        echo "OK" > "$results_dir/remove-${plugin}"
+      else
+        echo "FAIL" > "$results_dir/remove-${plugin}"
+      fi
+    done <<< "$retry_removals"
+  fi
+
+  if [ -n "$retry_installs" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      if _droid plugin install "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
+        echo "OK" > "$results_dir/install-${plugin}"
+      else
+        echo "FAIL" > "$results_dir/install-${plugin}"
+      fi
+    done <<< "$retry_installs"
+  fi
+
+  if [ -n "$retry_updates" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      if _droid plugin update "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
+        echo "OK" > "$results_dir/update-${plugin}"
+        continue
+      fi
+      _droid plugin uninstall "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1 || true
+      if _droid plugin install "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
+        echo "REINSTALLED" > "$results_dir/update-${plugin}"
+      else
+        echo "FAIL" > "$results_dir/update-${plugin}"
+      fi
+    done <<< "$retry_updates"
+  fi
+
+  # Collect results
+  local removed=0 added=0 updated=0 failed=0
+
+  if [ -n "$orphaned_plugins" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      result=$(_read_result "$results_dir/remove-${plugin}")
+      if [ "$result" = "OK" ]; then
+        echo "  - $plugin ... OK"
+        removed=$((removed + 1))
+      else
+        echo "  - $plugin ... FAIL"
+        failed=$((failed + 1))
+      fi
+    done <<< "$orphaned_plugins"
+  fi
+
+  if [ -n "$new_plugins" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      result=$(_read_result "$results_dir/install-${plugin}")
+      if [ "$result" = "OK" ]; then
+        echo "  + $plugin ... OK"
+        added=$((added + 1))
+      else
+        echo "  + $plugin ... FAIL"
+        failed=$((failed + 1))
+      fi
+    done <<< "$new_plugins"
+  fi
+
+  if [ -n "$existing_plugins" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      result=$(_read_result "$results_dir/update-${plugin}")
+      case "$result" in
+        OK)          echo "  * $plugin ... OK";            updated=$((updated + 1)) ;;
+        REINSTALLED) echo "  * $plugin ... OK (reinstalled)"; updated=$((updated + 1)) ;;
+        *)           echo "  * $plugin ... FAIL";           failed=$((failed + 1)) ;;
+      esac
+    done <<< "$existing_plugins"
+  fi
+
+  rm -rf "$results_dir"
+
+  echo ""
+  echo "  Droid — Added: $added | Updated: $updated | Removed: $removed | Failed: $failed"
+
+  [ "$failed" -gt 0 ] && return 1
+  return 0
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Repo Cache Management (used by Claude Code sync and as marketplace fallback)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Track whether repo cache is usable (set by _ensure_repo_cache)
+_REPO_CACHE_OK=false
+
+_ensure_repo_cache() {
+  local repo_dir="$OPTIMUS_CACHE_DIR"
+
+  if [ -d "$repo_dir/.git" ]; then
+    echo "Updating repo cache..."
+    if ! git -C "$repo_dir" fetch --depth 1 origin main 2>/dev/null; then
+      _warn "Could not fetch latest. Using cached version."
+    else
+      git -C "$repo_dir" reset --hard origin/main 2>/dev/null || true
+    fi
+    _REPO_CACHE_OK=true
+  else
+    echo "Cloning repo cache..."
+    if git clone --depth 1 "$OPTIMUS_REPO_URL" "$repo_dir" 2>/dev/null; then
+      _REPO_CACHE_OK=true
+    else
+      _warn "Could not clone repo. Claude Code sync requires a repo cache."
+      echo "  Run: git clone --depth 1 ${OPTIMUS_REPO_URL} ${repo_dir}" >&2
+      _REPO_CACHE_OK=false
+    fi
+  fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Claude Code Sync
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_sync_claude_code() {
+  local expected="$1"
+  echo "── Claude Code ──"
+  echo ""
+
+  local repo_dir="$OPTIMUS_CACHE_DIR"
+
+  if [ "$_REPO_CACHE_OK" = false ]; then
+    echo "  Claude Code — Added: 0 | Updated: 0 | Removed: 0 | Failed: 0 (skipped)"
+    return 0
+  fi
+
+  local skills_dir="$CLAUDE_SKILLS_DIR"
+  mkdir -p "$skills_dir"
+
+  # Step 3: Get currently installed optimus skills
+  local installed=""
+  if [ -d "$skills_dir" ]; then
+    installed=$(find "$skills_dir" -maxdepth 1 -type d -name 'optimus-*' -exec basename {} \; 2>/dev/null | sed 's/^optimus-//' | sort) || true
+  fi
+
+  # Step 4: Calculate diffs
+  local new_plugins orphaned_plugins existing_plugins
+  if [ -z "$installed" ]; then
+    new_plugins="$expected"
+    orphaned_plugins=""
+    existing_plugins=""
+  else
+    new_plugins=$(comm -23 <(echo "$expected") <(echo "$installed"))
+    orphaned_plugins=$(comm -13 <(echo "$expected") <(echo "$installed"))
+    existing_plugins=$(comm -12 <(echo "$expected") <(echo "$installed"))
+  fi
+
+  local added=0 updated=0 removed=0 failed=0 unchanged=0
+
+  # Step 5: Install new plugins
+  if [ -n "$new_plugins" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      local src="$repo_dir/${plugin}/skills/optimus-${plugin}/SKILL.md"
+      local dest_dir="$skills_dir/optimus-${plugin}"
+      if [ -f "$src" ]; then
+        mkdir -p "$dest_dir"
+        cp "$src" "$dest_dir/SKILL.md"
+        echo "  + $plugin ... OK"
+        added=$((added + 1))
+      else
+        echo "  + $plugin ... FAIL (source not found)"
+        failed=$((failed + 1))
+      fi
+    done <<< "$new_plugins"
+  fi
+
+  # Step 6: Update existing plugins (skip if unchanged)
+  if [ -n "$existing_plugins" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      local src="$repo_dir/${plugin}/skills/optimus-${plugin}/SKILL.md"
+      local dest="$skills_dir/optimus-${plugin}/SKILL.md"
+      if [ ! -f "$src" ]; then
+        echo "  * $plugin ... FAIL (source not found)"
+        failed=$((failed + 1))
+        continue
+      fi
+      if [ -f "$dest" ] && diff -q "$src" "$dest" >/dev/null 2>&1; then
+        echo "  * $plugin ... unchanged"
+        unchanged=$((unchanged + 1))
+      else
+        mkdir -p "$skills_dir/optimus-${plugin}"
+        cp "$src" "$dest"
+        echo "  * $plugin ... OK"
+        updated=$((updated + 1))
+      fi
+    done <<< "$existing_plugins"
+  fi
+
+  # Step 7: Remove orphaned plugins (ONLY optimus- prefixed)
+  if [ -n "$orphaned_plugins" ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      local target_dir="$skills_dir/optimus-${plugin}"
+      if [ -d "$target_dir" ]; then
+        rm -rf "$target_dir"
+        echo "  - $plugin ... OK"
+        removed=$((removed + 1))
+      fi
+    done <<< "$orphaned_plugins"
+  fi
+
+  echo ""
+  local summary="Claude Code — Added: $added | Updated: $updated | Removed: $removed | Failed: $failed"
+  if [ "$unchanged" -gt 0 ]; then
+    summary="$summary | Unchanged: $unchanged"
+  fi
+  echo "  $summary"
+
+  [ "$failed" -gt 0 ] && return 1
+  return 0
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════════════
+
 echo "=== Optimus Plugin Sync ==="
 echo ""
 
-# Check dependencies
-if ! command -v droid >/dev/null 2>&1; then
-  _error "droid CLI is required but not installed."
-  echo "  Install from: https://docs.factory.ai" >&2
-  exit 1
-fi
-
-if ! command -v jq >/dev/null 2>&1; then
-  _error "jq is required but not installed."
-  exit 1
-fi
-
-# Step 1: Update marketplace
-echo "Updating marketplace..."
-if ! _droid plugin marketplace update "$MARKETPLACE_NAME" 2>/dev/null; then
-  _warn "Could not update marketplace. Proceeding with cached version."
-fi
-
-# Step 2: Get expected plugins from marketplace
-MARKETPLACE_FILE=$(find ~/.factory -path "*/marketplaces/${MARKETPLACE_NAME}/.factory-plugin/marketplace.json" -type f 2>/dev/null | head -1)
-if [ -z "$MARKETPLACE_FILE" ]; then
-  _error "Marketplace '${MARKETPLACE_NAME}' not found. Register it first:"
-  echo "  droid plugin marketplace add https://github.com/alexgarzao/optimus" >&2
-  exit 1
-fi
-
-EXPECTED=$(jq -r '.plugins[].name' "$MARKETPLACE_FILE" | sort)
-if [ -z "$EXPECTED" ]; then
-  _error "No plugins found in marketplace."
-  exit 1
-fi
-
-# Step 3: Get installed optimus plugins
-INSTALLED=$(_droid plugin list 2>/dev/null \
-  | grep -F "@${MARKETPLACE_NAME}" \
-  | awk '{print $1}' \
-  | while IFS= read -r _line; do echo "${_line%@"${MARKETPLACE_NAME}"}"; done \
-  | sort) || true
-
-# Step 4: Calculate diffs
-if [ -z "$INSTALLED" ]; then
-  # First-time install — all plugins are new, nothing to remove or update
-  NEW_PLUGINS="$EXPECTED"
-  ORPHANED_PLUGINS=""
-  EXISTING_PLUGINS=""
-else
-  # comm -23: lines only in EXPECTED (new plugins to install)
-  NEW_PLUGINS=$(comm -23 <(echo "$EXPECTED") <(echo "$INSTALLED"))
-  # comm -13: lines only in INSTALLED (orphaned plugins to remove)
-  ORPHANED_PLUGINS=$(comm -13 <(echo "$EXPECTED") <(echo "$INSTALLED"))
-  # comm -12: lines in both (existing plugins to update)
-  EXISTING_PLUGINS=$(comm -12 <(echo "$EXPECTED") <(echo "$INSTALLED"))
-fi
-
-# All operations run in parallel using temp dir for result collection
-RESULTS_DIR=$(mktemp -d)
-_cleanup() { rm -rf "$RESULTS_DIR"; }
-trap '_cleanup; echo ""; _warn "Sync interrupted. Re-run /optimus-sync to complete."; exit 130' INT TERM
-trap '_cleanup' EXIT
-RETRY_REMOVALS=""
-RETRY_INSTALLS=""
-RETRY_UPDATES=""
-
-# Step 5: Remove orphaned plugins (parallel)
-if [ -n "$ORPHANED_PLUGINS" ]; then
-  echo ""
-  echo "Removing orphaned plugins..."
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    (
-      if _droid plugin uninstall "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-        echo "OK" > "$RESULTS_DIR/remove-${plugin}"
-      else
-        echo "RETRY" > "$RESULTS_DIR/remove-${plugin}"
-      fi
-    ) &
-  done <<< "$ORPHANED_PLUGINS"
-  wait
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    if [ "$(_read_result "$RESULTS_DIR/remove-${plugin}")" = "RETRY" ]; then
-      RETRY_REMOVALS="${RETRY_REMOVALS}${plugin}
-"
-    fi
-  done <<< "$ORPHANED_PLUGINS"
-fi
-
-# Step 6: Install new plugins (parallel)
-if [ -n "$NEW_PLUGINS" ]; then
-  echo "Installing new plugins..."
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    (
-      if _droid plugin install "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-        echo "OK" > "$RESULTS_DIR/install-${plugin}"
-      else
-        echo "RETRY" > "$RESULTS_DIR/install-${plugin}"
-      fi
-    ) &
-  done <<< "$NEW_PLUGINS"
-  wait
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    if [ "$(_read_result "$RESULTS_DIR/install-${plugin}")" = "RETRY" ]; then
-      RETRY_INSTALLS="${RETRY_INSTALLS}${plugin}
-"
-    fi
-  done <<< "$NEW_PLUGINS"
-fi
-
-# Step 7: Update existing plugins (parallel)
-if [ -n "$EXISTING_PLUGINS" ]; then
-  echo "Updating existing plugins..."
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    (
-      if _droid plugin update "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-        echo "OK" > "$RESULTS_DIR/update-${plugin}"
-      else
-        echo "RETRY" > "$RESULTS_DIR/update-${plugin}"
-      fi
-    ) &
-  done <<< "$EXISTING_PLUGINS"
-  wait
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    if [ "$(_read_result "$RESULTS_DIR/update-${plugin}")" = "RETRY" ]; then
-      RETRY_UPDATES="${RETRY_UPDATES}${plugin}
-"
-    fi
-  done <<< "$EXISTING_PLUGINS"
-fi
-
-# Step 7.5: Retry transient failures serially
-if [ -n "$RETRY_REMOVALS$RETRY_INSTALLS$RETRY_UPDATES" ]; then
-  echo "Retrying failed plugin operations serially..."
-fi
-
-if [ -n "$RETRY_REMOVALS" ]; then
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    if _droid plugin uninstall "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-      echo "OK" > "$RESULTS_DIR/remove-${plugin}"
-    else
-      echo "FAIL" > "$RESULTS_DIR/remove-${plugin}"
-    fi
-  done <<< "$RETRY_REMOVALS"
-fi
-
-if [ -n "$RETRY_INSTALLS" ]; then
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    if _droid plugin install "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-      echo "OK" > "$RESULTS_DIR/install-${plugin}"
-    else
-      echo "FAIL" > "$RESULTS_DIR/install-${plugin}"
-    fi
-  done <<< "$RETRY_INSTALLS"
-fi
-
-if [ -n "$RETRY_UPDATES" ]; then
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    if _droid plugin update "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-      echo "OK" > "$RESULTS_DIR/update-${plugin}"
-      continue
-    fi
-    _droid plugin uninstall "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1 || true
-    if _droid plugin install "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-      echo "REINSTALLED" > "$RESULTS_DIR/update-${plugin}"
-    else
-      echo "FAIL" > "$RESULTS_DIR/update-${plugin}"
-    fi
-  done <<< "$RETRY_UPDATES"
-fi
-
-# Step 8: Collect results and print summary
-REMOVED=0; ADDED=0; UPDATED=0; FAILED=0
-
-if [ -n "$ORPHANED_PLUGINS" ]; then
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    result=$(_read_result "$RESULTS_DIR/remove-${plugin}")
-    if [ "$result" = "OK" ]; then
-      echo "  - $plugin ... OK"
-      REMOVED=$((REMOVED + 1))
-    else
-      echo "  - $plugin ... FAIL"
-      FAILED=$((FAILED + 1))
-    fi
-  done <<< "$ORPHANED_PLUGINS"
-fi
-
-if [ -n "$NEW_PLUGINS" ]; then
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    result=$(_read_result "$RESULTS_DIR/install-${plugin}")
-    if [ "$result" = "OK" ]; then
-      echo "  + $plugin ... OK"
-      ADDED=$((ADDED + 1))
-    else
-      echo "  + $plugin ... FAIL"
-      FAILED=$((FAILED + 1))
-    fi
-  done <<< "$NEW_PLUGINS"
-fi
-
-if [ -n "$EXISTING_PLUGINS" ]; then
-  while IFS= read -r plugin; do
-    [ -z "$plugin" ] && continue
-    result=$(_read_result "$RESULTS_DIR/update-${plugin}")
-    case "$result" in
-      OK)          echo "  * $plugin ... OK";            UPDATED=$((UPDATED + 1)) ;;
-      REINSTALLED) echo "  * $plugin ... OK (reinstalled)"; UPDATED=$((UPDATED + 1)) ;;
-      *)           echo "  * $plugin ... FAIL";           FAILED=$((FAILED + 1)) ;;
-    esac
-  done <<< "$EXISTING_PLUGINS"
-fi
-
+# Detect platforms
+platforms=""
+if [ "$HAS_DROID" = true ]; then platforms="${platforms}Droid "; fi
+if [ "$HAS_CLAUDE" = true ]; then platforms="${platforms}Claude Code "; fi
+echo "Platforms: $platforms"
 echo ""
+
+# Ensure repo cache is populated (needed for Claude Code sync and marketplace fallback)
+if [ "$HAS_CLAUDE" = true ]; then
+  _ensure_repo_cache
+  echo ""
+fi
+
+# Resolve expected plugins (shared across platforms)
+EXPECTED=$(_resolve_expected_plugins) || exit 1
+
+# Run sync per platform
+droid_rc=0
+claude_rc=0
+
+if [ "$HAS_DROID" = true ]; then
+  _sync_droid "$EXPECTED" || droid_rc=$?
+  echo ""
+fi
+
+if [ "$HAS_CLAUDE" = true ]; then
+  _sync_claude_code "$EXPECTED" || claude_rc=$?
+  echo ""
+fi
+
 echo "=== Sync Complete ==="
-echo "  Added:   $ADDED"
-echo "  Updated: $UPDATED"
-echo "  Removed: $REMOVED"
-if [ "$FAILED" -gt 0 ]; then
-  echo "  Failed:  $FAILED"
+
+# Exit with failure if any platform had failures
+if [ "$droid_rc" -gt 0 ] || [ "$claude_rc" -gt 0 ]; then
   exit 1
 fi

--- a/sync/skills/optimus-sync/SKILL.md
+++ b/sync/skills/optimus-sync/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimus-sync
-description: "Sync all Optimus plugins — install new, update existing, remove orphaned. Recommended after new releases."
+description: "Sync all Optimus plugins — install new, update existing, remove orphaned. Supports Droid (Factory) and Claude Code simultaneously."
 trigger: >
   - When user says "sync", "sync plugins", "update plugins", or "optimus sync"
   - When user wants to install/update all Optimus plugins at once
@@ -8,9 +8,10 @@ trigger: >
 skip_when: >
   - User wants to install a single specific plugin (use `droid plugin install` directly)
 prerequisite: >
-  - droid CLI installed and available
+  - At least one supported platform: droid CLI installed OR ~/.claude/ directory exists
   - jq installed and available
-  - Optimus marketplace registered (`droid plugin marketplace add https://github.com/alexgarzao/optimus`)
+  - For Droid: Optimus marketplace registered (`droid plugin marketplace add https://github.com/alexgarzao/optimus`)
+  - For Claude Code: git installed (for repo cache clone/update)
 NOT_skip_when: >
   - "I'll update plugins manually" -- optimus-sync handles scope conflicts and orphan removal automatically.
   - "Only one plugin needs updating" -- sync is optimized for batch operations and ensures consistency.
@@ -18,11 +19,12 @@ examples:
   - name: Sync all plugins
     invocation: "/optimus-sync"
     expected_flow: >
-      1. Update marketplace
-      2. Calculate changes (new/orphaned/existing)
-      3. Show plan and ask for confirmation
-      4. Execute each operation with progress
-      5. Show summary
+      1. Detect available platforms (Droid, Claude Code, or both)
+      2. Update marketplace / repo cache
+      3. Calculate changes per platform (new/orphaned/existing)
+      4. Show plan and ask for confirmation
+      5. Execute each operation with progress
+      6. Show per-platform summary
 related:
   complementary:
     - optimus-help
@@ -31,11 +33,11 @@ related:
       - optimus-help
 verification:
   manual:
-    - Marketplace update completed
+    - At least one platform detected
     - New plugins installed successfully
     - Orphaned plugins removed
-    - Existing plugins updated
-    - Summary shows correct counts
+    - Existing plugins updated (or skipped if unchanged on Claude Code)
+    - Per-platform summary shows correct counts
 ---
 
 # Optimus Sync
@@ -43,19 +45,25 @@ verification:
 Syncs installed Optimus plugins with the marketplace. Installs new plugins, removes
 orphaned ones, and updates all existing plugins — with real-time progress.
 
+Supports **dual-platform sync**: Droid (Factory) and Claude Code. Detects which
+platforms are available and syncs both in a single run.
+
 ---
 
 ## Phase 1: Prerequisites
 
-Check that required tools are available.
+Check that at least one supported platform is available.
 
-### Step 1.1: Check droid CLI
+### Step 1.1: Detect platforms
 
 ```bash
-command -v droid >/dev/null 2>&1
+HAS_DROID=false; HAS_CLAUDE=false
+command -v droid >/dev/null 2>&1 && HAS_DROID=true
+[ -d "$HOME/.claude" ] && HAS_CLAUDE=true
+echo "Droid: $HAS_DROID | Claude Code: $HAS_CLAUDE"
 ```
 
-If `droid` is not found, **STOP**: "droid CLI is required but not installed. Install from: https://docs.factory.ai"
+If both are `false`, **STOP**: "No supported platform found. Install Droid from https://docs.factory.ai or create ~/.claude/ for Claude Code support."
 
 ### Step 1.2: Check jq
 
@@ -67,13 +75,21 @@ If `jq` is not found, **STOP**: "jq is required but not installed."
 
 ---
 
-## Phase 2: Update Marketplace
+## Phase 2: Update Sources
 
-Run:
+### Step 2.1: Droid marketplace (if available)
 
 ```bash
 droid plugin marketplace update optimus 2>&1 || echo "WARNING: Could not update marketplace. Proceeding with cached version."
 ```
+
+### Step 2.2: Claude Code repo cache (if available)
+
+The repo cache lives at `~/.optimus/repo/` (configurable via `OPTIMUS_CACHE_DIR`).
+
+- If cache exists: `git -C ~/.optimus/repo fetch --depth 1 origin main && git -C ~/.optimus/repo reset --hard origin/main`
+- If no cache: `git clone --depth 1 https://github.com/alexgarzao/optimus ~/.optimus/repo`
+- If clone/fetch fails: warn and skip Claude Code sync
 
 Show the result to the user before proceeding.
 
@@ -83,20 +99,10 @@ Show the result to the user before proceeding.
 
 ### Step 3.1: Find marketplace file
 
-```bash
-MARKETPLACE_FILE=$(find ~/.factory -path "*/marketplaces/optimus/.factory-plugin/marketplace.json" -type f 2>/dev/null | head -1)
-echo "$MARKETPLACE_FILE"
-```
-
-If empty, **STOP**: "Marketplace 'optimus' not found. Register it first: `droid plugin marketplace add https://github.com/alexgarzao/optimus`"
-
-Validate the marketplace JSON is parseable:
-
-```bash
-jq empty "$MARKETPLACE_FILE" 2>/dev/null
-```
-
-If this fails, **STOP**: "Marketplace JSON is malformed. Re-run `droid plugin marketplace update optimus` to fix."
+The script resolves the marketplace JSON from multiple sources (in priority order):
+1. Droid marketplace cache (`~/.factory/marketplaces/optimus/`)
+2. Optimus repo cache (`~/.optimus/repo/.factory-plugin/marketplace.json`)
+3. Running from inside the optimus repo (relative path)
 
 ### Step 3.2: Get expected plugins
 
@@ -104,21 +110,25 @@ If this fails, **STOP**: "Marketplace JSON is malformed. Re-run `droid plugin ma
 jq -r '.plugins[].name' "$MARKETPLACE_FILE" | sort
 ```
 
-Store the output as `EXPECTED` (one plugin name per line).
+Store the output as `EXPECTED` (one plugin name per line, shared across platforms).
 
-If `EXPECTED` is empty, **STOP**: "No plugins found in marketplace. The marketplace may be empty or corrupted."
+If `EXPECTED` is empty, **STOP**: "No plugins found in marketplace."
 
-### Step 3.3: Get installed plugins
+### Step 3.3: Get installed state per platform
 
+**Droid:**
 ```bash
 droid plugin list 2>/dev/null | grep -F "@optimus" | awk '{print $1}' | sed 's/@optimus$//' | sort
 ```
 
-Store the output as `INSTALLED` (one plugin name per line). May be empty (first-time install).
+**Claude Code:**
+```bash
+find ~/.claude/skills/default -maxdepth 1 -type d -name 'optimus-*' -exec basename {} \; | sed 's/^optimus-//' | sort
+```
 
-### Step 3.4: Calculate diffs
+### Step 3.4: Calculate diffs per platform
 
-Compare `EXPECTED` vs `INSTALLED` to determine three lists:
+Compare `EXPECTED` vs each platform's `INSTALLED` to determine three lists per platform:
 
 - **NEW_PLUGINS**: in EXPECTED but not in INSTALLED (to install)
 - **ORPHANED_PLUGINS**: in INSTALLED but not in EXPECTED (to remove)
@@ -128,19 +138,23 @@ Compare `EXPECTED` vs `INSTALLED` to determine three lists:
 
 ## Phase 4: Show Plan
 
-Present the plan to the user before executing. Show:
+Present the plan to the user before executing. Show **per-platform** counts:
 
-1. Total counts: `Expected: N | Installed: N | New: N | Orphaned: N | Update: N`
-2. If there are new plugins, list them with `+` prefix
-3. If there are orphaned plugins, list them with `-` prefix
-4. If there are existing plugins, list them with `*` prefix
+```
+Platforms: Droid, Claude Code
+
+Droid:       Expected: N | Installed: N | New: N | Orphaned: N | Update: N
+Claude Code: Expected: N | Installed: N | New: N | Orphaned: N | Update: N
+```
+
+If there are new/orphaned/existing plugins, list them with `+`/`-`/`*` prefixes.
 
 Use `<json-render>` with a Table component for clear display.
 
 Then ask the user via `AskUser`:
 
 ```
-Ready to sync N plugins (X new, Y remove, Z update). Proceed?
+Ready to sync N plugins across M platform(s). Proceed?
 ```
 
 Options:
@@ -154,63 +168,60 @@ If **Cancel**, **STOP**.
 ## Phase 5: Execute
 
 Run all operations in a **single Execute call** using the sync shell script. The script
-runs all plugin operations in parallel (remove, install, update simultaneously) and
-prints a summary with per-plugin results.
+detects platforms, syncs both, and prints a per-platform summary.
 
 ```bash
 bash sync/scripts/sync-user-plugins.sh 2>&1
 ```
 
-If not running inside the Optimus repo (script not available), construct an equivalent
-single command that runs all `droid plugin update` calls in parallel:
+If not running inside the Optimus repo (script not available), construct equivalent
+commands:
 
+**For Droid:** parallel `droid plugin update` calls (same as before).
+
+**For Claude Code:** copy SKILL.md files from repo cache:
 ```bash
-RESULTS_DIR=$(mktemp -d)
-for plugin in <space-separated list of all plugins>; do
-  (
-    if droid plugin update "${plugin}@optimus" >/dev/null 2>&1; then
-      echo "OK" > "$RESULTS_DIR/$plugin"
-    else
-      droid plugin uninstall "${plugin}@optimus" >/dev/null 2>&1 || true
-      if droid plugin install "${plugin}@optimus" >/dev/null 2>&1; then
-        echo "REINSTALLED" > "$RESULTS_DIR/$plugin"
-      else
-        echo "FAIL" > "$RESULTS_DIR/$plugin"
-      fi
-    fi
-  ) &
-done
-wait
+CACHE=~/.optimus/repo
+DEST=~/.claude/skills/default
 for plugin in <space-separated list>; do
-  result=$(cat "$RESULTS_DIR/$plugin" 2>/dev/null || echo "FAIL")
-  echo "  * $plugin ... $result"
+  src="$CACHE/${plugin}/skills/optimus-${plugin}/SKILL.md"
+  dest_dir="$DEST/optimus-${plugin}"
+  mkdir -p "$dest_dir"
+  cp "$src" "$dest_dir/SKILL.md"
 done
-rm -rf "$RESULTS_DIR"
 ```
 
-Use a 90-second timeout for the entire Execute call (all plugins run in parallel,
-so total time is ~6-8 seconds for 16 plugins).
+Use a 90-second timeout for the entire Execute call.
 
 ---
 
 ## Phase 6: Summary
 
-Present the final summary using `<json-render>` with metrics:
+Present the final summary using `<json-render>` with **per-platform** metrics:
 
-- Added: N
-- Updated: N
-- Removed: N
-- Failed: N (only show if > 0)
+```
+=== Sync Complete ===
+
+Droid — Added: N | Updated: N | Removed: N | Failed: N
+Claude Code — Added: N | Updated: N | Removed: N | Failed: N | Unchanged: N
+```
+
+Only show platforms that were detected and synced.
 
 ---
 
 ## Rules
 
-- All plugin operations run in **parallel** via a single Execute call — no separate
+- All Droid plugin operations run in **parallel** via a single Execute call — no separate
   calls per plugin. This makes sync complete in ~6-8 seconds instead of ~2 minutes.
+- Claude Code operations are sequential (filesystem copies are fast enough).
 - If a plugin operation fails, the script logs it and continues. Do NOT stop
   the entire sync on a single failure.
 - If the user cancels mid-sync or the session is interrupted, inform them:
   "Sync interrupted. Some plugins may be partially updated. Re-run `/optimus-sync` to complete."
 - The `make sync-plugins` target in the project Makefile runs `sync/scripts/sync-user-plugins.sh`
   directly. Both the agent skill and CLI use the same parallel script.
+- Claude Code sync **only** touches `optimus-*` directories under `~/.claude/skills/default/`.
+  It never modifies other skill directories (e.g., `ring:*`, user-created skills).
+- Command aliases (`/sp`, `/bd`, etc.) are **not supported** on Claude Code — only
+  `/optimus-<name>` invocations work. This is a platform limitation.

--- a/sync/skills/optimus-sync/SKILL.md
+++ b/sync/skills/optimus-sync/SKILL.md
@@ -8,7 +8,7 @@ trigger: >
 skip_when: >
   - User wants to install a single specific plugin (use `droid plugin install` directly)
 prerequisite: >
-  - At least one supported platform: droid CLI installed OR ~/.claude/ directory exists
+  - At least one supported platform: droid CLI installed OR ~/.claude/skills/ directory exists
   - jq installed and available
   - For Droid: Optimus marketplace registered (`droid plugin marketplace add https://github.com/alexgarzao/optimus`)
   - For Claude Code: git installed (for repo cache clone/update)
@@ -22,9 +22,8 @@ examples:
       1. Detect available platforms (Droid, Claude Code, or both)
       2. Update marketplace / repo cache
       3. Calculate changes per platform (new/orphaned/existing)
-      4. Show plan and ask for confirmation
-      5. Execute each operation with progress
-      6. Show per-platform summary
+      4. Execute each operation with progress
+      5. Show per-platform summary
 related:
   complementary:
     - optimus-help
@@ -57,13 +56,13 @@ Check that at least one supported platform is available.
 ### Step 1.1: Detect platforms
 
 ```bash
-HAS_DROID=false; HAS_CLAUDE=false
+HAS_DROID=false; HAS_CLAUDE_CODE=false
 command -v droid >/dev/null 2>&1 && HAS_DROID=true
-[ -d "$HOME/.claude" ] && HAS_CLAUDE=true
-echo "Droid: $HAS_DROID | Claude Code: $HAS_CLAUDE"
+[ -d "$HOME/.claude/skills" ] && HAS_CLAUDE_CODE=true
+echo "Droid: $HAS_DROID | Claude Code: $HAS_CLAUDE_CODE"
 ```
 
-If both are `false`, **STOP**: "No supported platform found. Install Droid from https://docs.factory.ai or create ~/.claude/ for Claude Code support."
+If both are `false`, **STOP**: "No supported platform found. Install Droid from https://docs.factory.ai or create ~/.claude/skills/ for Claude Code support."
 
 ### Step 1.2: Check jq
 
@@ -136,66 +135,24 @@ Compare `EXPECTED` vs each platform's `INSTALLED` to determine three lists per p
 
 ---
 
-## Phase 4: Show Plan
+## Phase 4: Execute
 
-Present the plan to the user before executing. Show **per-platform** counts:
+Run the sync shell script. The script detects platforms, syncs both, and prints
+a per-platform summary.
 
-```
-Platforms: Droid, Claude Code
-
-Droid:       Expected: N | Installed: N | New: N | Orphaned: N | Update: N
-Claude Code: Expected: N | Installed: N | New: N | Orphaned: N | Update: N
-```
-
-If there are new/orphaned/existing plugins, list them with `+`/`-`/`*` prefixes.
-
-Use `<json-render>` with a Table component for clear display.
-
-Then ask the user via `AskUser`:
-
-```
-Ready to sync N plugins across M platform(s). Proceed?
-```
-
-Options:
-- **Proceed** — execute all operations
-- **Cancel** — abort sync
-
-If **Cancel**, **STOP**.
-
----
-
-## Phase 5: Execute
-
-Run all operations in a **single Execute call** using the sync shell script. The script
-detects platforms, syncs both, and prints a per-platform summary.
+Resolve script path (prefer local repo, fall back to cache):
 
 ```bash
-bash sync/scripts/sync-user-plugins.sh 2>&1
-```
-
-If not running inside the Optimus repo (script not available), construct equivalent
-commands:
-
-**For Droid:** parallel `droid plugin update` calls (same as before).
-
-**For Claude Code:** copy SKILL.md files from repo cache:
-```bash
-CACHE=~/.optimus/repo
-DEST=~/.claude/skills/default
-for plugin in <space-separated list>; do
-  src="$CACHE/${plugin}/skills/optimus-${plugin}/SKILL.md"
-  dest_dir="$DEST/optimus-${plugin}"
-  mkdir -p "$dest_dir"
-  cp "$src" "$dest_dir/SKILL.md"
-done
+SCRIPT="${OPTIMUS_CACHE_DIR:-$HOME/.optimus/repo}/sync/scripts/sync-user-plugins.sh"
+[ -f sync/scripts/sync-user-plugins.sh ] && SCRIPT="sync/scripts/sync-user-plugins.sh"
+bash "$SCRIPT" 2>&1
 ```
 
 Use a 90-second timeout for the entire Execute call.
 
 ---
 
-## Phase 6: Summary
+## Phase 5: Summary
 
 Present the final summary using `<json-render>` with **per-platform** metrics:
 


### PR DESCRIPTION
## Summary

- Refactors `sync-user-plugins.sh` to detect and sync both **Droid (Factory)** and **Claude Code** in a single run
- Claude Code skills are installed by copying SKILL.md files to `~/.claude/skills/default/optimus-<name>/`
- Adds 12 new tests for Claude Code sync, repo cache management, and dual-platform scenarios
- Updates SKILL.md, README.md, and AGENTS.md with multi-platform documentation

## Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Repo cache location | `~/.optimus/repo/` | Neutral, doesn't pollute `~/.claude/` with git repos |
| Skill destination | `~/.claude/skills/default/optimus-<name>/SKILL.md` | Consistent with existing skill naming conventions |
| Bootstrap | One-liner in README | Resolves chicken-and-egg (need sync to install sync) |
| Script approach | Extend existing `sync-user-plugins.sh` | Single source of truth for both platforms |

## Changes

### `sync/scripts/sync-user-plugins.sh`
- Platform detection: `command -v droid` and `[ -d ~/.claude ]`
- Extracted Droid logic into `_sync_droid()` function
- New `_sync_claude_code()` function with diff-based skip
- New `_ensure_repo_cache()` for shared git clone/fetch
- Shared `_resolve_expected_plugins()` with 3-tier fallback
- Per-platform summary output

### `scripts/test_sync_user_plugins.py`
- `TestClaudeCodeDetection` — platform detection tests
- `TestClaudeCodeSync` — install, update, skip unchanged, orphan removal, safety
- `TestClaudeCodeRepoCache` — clone, fetch, graceful failure
- `TestDualPlatformSync` — both platforms, droid-only, claude-only, failure isolation

### `sync/skills/optimus-sync/SKILL.md`
- Updated all phases for dual-platform awareness
- Prerequisites now require "at least one platform"

### `README.md`
- Added Claude Code bootstrap one-liner
- Noted alias limitation on Claude Code

### `AGENTS.md`
- New "Multi-Platform Support" section with comparison table
- Updated Plugin Lifecycle for both platforms

## Test plan

- [x] `make test` — all 194 tests pass (existing + 12 new)
- [x] `make lint` — shellcheck + ruff + py_compile clean
- [ ] Manual: run `bash sync/scripts/sync-user-plugins.sh` and verify skills appear in `~/.claude/skills/default/optimus-*/`
- [ ] Manual: re-run and verify unchanged skills show "unchanged"
- [ ] Manual: verify non-optimus skills (e.g., `ring:*`) are never touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)