### PR TITLE
fix(claude-code): use native plugin system instead of file copy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,165 @@
+{
+  "name": "optimus",
+  "metadata": {
+    "description": "Skills marketplace for Droid (Factory) and Claude Code"
+  },
+  "owner": {
+    "name": "Alex Garzão",
+    "email": "alexgarzao@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "optimus-import",
+      "source": "./import",
+      "version": "1.0.0",
+      "description": "Import Ring pre-dev artifacts into optimus format. Creates tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-report",
+      "source": "./report",
+      "version": "1.0.0",
+      "description": "Task status dashboard. Shows progress, active/blocked/ready tasks, dependency graph, and parallelization opportunities. Read-only.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-tasks",
+      "source": "./tasks",
+      "version": "1.0.0",
+      "description": "Administrative: Create, edit, remove, reorder, cancel, and reopen tasks. Manage versions and move tasks between versions. Runs on any branch.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-plan",
+      "source": "./plan",
+      "version": "1.0.0",
+      "description": "Stage 1: Validates task specifications against project docs before implementation. Catches gaps, contradictions, and test coverage holes. Creates workspace (branch/worktree).",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-build",
+      "source": "./build",
+      "version": "1.0.0",
+      "description": "Stage 2: End-to-end task implementation with verification gates, code review, and commit approval.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-review",
+      "source": "./review",
+      "version": "1.0.0",
+      "description": "Stage 3: Validates completed task implementation against spec, coding standards, and best practices using parallel specialist agents.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-pr-check",
+      "source": "./pr-check",
+      "version": "1.0.0",
+      "description": "Standalone PR review orchestrator. Collects PR metadata and existing comments (Codacy, DeepSource, CodeRabbit, human), dispatches agents, applies fixes, resolves threads. Does not change task status.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-done",
+      "source": "./done",
+      "version": "1.0.0",
+      "description": "Stage 4: Requires PR in final state (merged or closed) before marking task done. Cleans up worktree and branch interactively.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-batch",
+      "source": "./batch",
+      "version": "1.0.0",
+      "description": "Pipeline orchestrator: chains stages 1-4 for one or more tasks with user checkpoints between stages.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-resolve",
+      "source": "./resolve",
+      "version": "1.0.0",
+      "description": "Administrative: Resolves merge conflicts in tasks.md caused by parallel task execution across feature branches.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-deep-doc-review",
+      "source": "./deep-doc-review",
+      "version": "1.0.0",
+      "description": "Deep review of project documentation. Finds errors, inconsistencies, gaps, and improvements with interactive one-by-one resolution.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-deep-review",
+      "source": "./deep-review",
+      "version": "1.0.0",
+      "description": "Parallel code review with consolidation, deduplication, and interactive finding-by-finding resolution. Auto-discovers installed Ring review droids. Flexible scope: entire project, git diff, or specific directory.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-coderabbit-review",
+      "source": "./coderabbit-review",
+      "version": "1.0.0",
+      "description": "CodeRabbit-driven code review with TDD fix cycle, secondary validation via review agents, and interactive finding resolution. Requires CodeRabbit CLI.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-help",
+      "source": "./help",
+      "version": "1.0.0",
+      "description": "Lists all available Optimus skills with descriptions, usage commands, and when to use each one.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-sync",
+      "source": "./sync",
+      "version": "1.0.0",
+      "description": "Sync all Optimus plugins — install new, update existing, remove orphaned. Recommended after new releases.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-quick-report",
+      "source": "./quick-report",
+      "version": "1.0.0",
+      "description": "Compact daily status dashboard. Shows version progress, active tasks with current status, ready-to-start, and blocked tasks. Read-only.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    },
+    {
+      "name": "optimus-resume",
+      "source": "./resume",
+      "version": "1.0.0",
+      "description": "Administrative: Resume a task after closing the terminal. Locates/recreates the worktree for a given T-XXX, reports current status, and offers to invoke the next stage. Read-only on state.json except for a user-confirmed Reset-to-Pendente recovery.",
+      "homepage": "https://github.com/alexgarzao/optimus",
+      "repository": "https://github.com/alexgarzao/optimus",
+      "license": "MIT"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,93 +118,92 @@ rationalize these away.
 
 ## Multi-Platform Support
 
-Optimus skills can be installed on two platforms simultaneously:
+Optimus skills can be installed on two platforms simultaneously, each using its
+native plugin system:
 
 | Aspect | Droid (Factory) | Claude Code |
 |--------|-----------------|-------------|
-| **Install mechanism** | `droid plugin install/update/uninstall` | Copy SKILL.md to `~/.claude/skills/default/optimus-<name>/` |
-| **Marketplace** | `~/.factory/marketplaces/optimus/` | `~/.optimus/repo/` (git clone cache) |
-| **Skill discovery** | Plugin registry | Filesystem auto-discovery |
+| **Install mechanism** | `droid plugin install/update/uninstall` | `claude plugin install/update/uninstall` |
+| **Marketplace** | `.factory-plugin/marketplace.json` (added via `droid plugin marketplace add`) | `.claude-plugin/marketplace.json` (added via `claude plugin marketplace add`) |
+| **Skill discovery** | Plugin registry | Plugin registry |
+| **Plugin name format** | Bare (`plan`, `build`) | Prefixed (`optimus-plan`, `optimus-build`) |
 | **Command aliases** | Supported (`/sp`, `/bd`, etc.) | Not supported (platform limitation) |
 | **Invocation** | `/optimus-<name>` or alias | `/optimus-<name>` only |
 
-The sync script (`sync/scripts/sync-user-plugins.sh`) detects which platforms are available
-and syncs both in a single run. Platform detection:
+The sync script (`sync/scripts/sync-user-plugins.sh`) detects which platforms
+are available and syncs both in a single run via the platforms' native plugin APIs.
+
+Platform detection:
 - **Droid**: `command -v droid` succeeds
-- **Claude Code**: `~/.claude/` directory exists
+- **Claude Code**: `command -v claude` succeeds
 
-At least one platform must be available. The script uses a shared marketplace JSON
-as the source of truth for expected plugins, resolved through a 3-tier fallback:
+At least one platform must be available. The script uses the platform's
+marketplace cache as its source of truth for expected plugins.
 
-**Marketplace JSON resolution (3-tier fallback):**
-1. **Droid cache:** `~/.factory/marketplaces/optimus/.factory-plugin/marketplace.json` —
-   populated by `droid plugin marketplace add/update`.
-2. **Repo cache:** `~/.optimus/repo/.factory-plugin/marketplace.json` — populated by
-   the script when Claude Code is detected. Droid-only users do **not** get this
-   fallback automatically; they must run `droid plugin marketplace update optimus`
-   to populate Source 1.
-3. **Local repo:** when the script runs from inside a clone of the Optimus repo,
-   the `marketplace.json` next to the script is used.
+### Marketplace JSON resolution
+
+The script resolves the EXPECTED plugin list from one of three sources, in priority order:
+
+1. **Droid cache**: `~/.factory/marketplaces/optimus/.factory-plugin/marketplace.json`
+2. **Claude Code cache**: `~/.claude/plugins/marketplaces/optimus/.claude-plugin/marketplace.json`
+3. **In-repo**: when running from a clone of the Optimus repo, the local `.factory-plugin/marketplace.json` (preferred) or `.claude-plugin/marketplace.json`.
+
+Both schemas list the same set of plugins, but with different name conventions
+(see table above). The script normalizes to bare names internally.
 
 ### Claude Code specifics
-- Skills are installed at `~/.claude/skills/default/optimus-<name>/SKILL.md`
-- Only `optimus-*` prefixed directories are managed — other skills (e.g., `ring:*`) are never touched
-- Updates use `diff -q` to skip unchanged files (avoids unnecessary writes)
-- Repo cache lives at `~/.optimus/repo/` (configurable via `OPTIMUS_CACHE_DIR`)
 
-**`~/.optimus/repo/` is sync-managed.** The script runs `git fetch` +
-`git reset --hard origin/main` on every sync, discarding any local commits,
-branches, or uncommitted edits. Do not use this directory for hacking on plugins —
-work in your own clone of the repo and run the sync script from there.
+- Skills are installed via `claude plugin install <name>@optimus --scope user`
+- Plugin name format on Claude Code is `optimus-<plugin>` (e.g., `optimus-plan`)
+- Updates and uninstalls go through `claude plugin update/uninstall`
+- Claude Code manages its own plugin cache at `~/.claude/plugins/cache/optimus/`;
+  the script does not create or manage `~/.optimus/repo/` for Claude Code
 
-#### Environment variables
+### Environment variables
 
-The sync script honors the following environment variables (defaults sourced
-from the `readonly` declarations at the top of `sync/scripts/sync-user-plugins.sh`):
-
-| Env var | Default | Purpose |
-|---------|---------|---------|
-| `OPTIMUS_REPO_URL` | `https://github.com/alexgarzao/optimus` | Git URL cloned into the repo cache. Override at your own risk — the script trusts whatever this points to. |
-| `OPTIMUS_CACHE_DIR` | `~/.optimus/repo` | Path to the repo cache. |
-| `CLAUDE_SKILLS_DIR` | `~/.claude/skills/default` | Where Claude Code skills are installed. |
-| `OPTIMUS_MARKETPLACE_NAME` | `optimus` | Droid marketplace identifier. |
-| `OPTIMUS_DROID_TIMEOUT` | `60` | Per-call timeout for Droid plugin operations, in seconds. Must be a positive integer. |
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OPTIMUS_REPO_URL` | `https://github.com/alexgarzao/optimus` | Repo URL (used for non-default forks; both platforms honor) |
+| `OPTIMUS_MARKETPLACE_NAME` | `optimus` | Droid marketplace identifier |
+| `OPTIMUS_DROID_TIMEOUT` | `60` | Per-call timeout for Droid plugin operations (seconds) |
+| `CLAUDE_MARKETPLACE_FILE` | `~/.claude/plugins/marketplaces/optimus/.claude-plugin/marketplace.json` | Override Source 2 location (mostly for tests) |
 
 ## Plugin Lifecycle
 
 ### Adding a new plugin
-1. Create directory: `<name>/skills/optimus-<name>/SKILL.md`
-2. Create manifest: `<name>/.factory-plugin/plugin.json`
-3. Add entry to `.factory-plugin/marketplace.json`
-4. Update README.md table
+1. Add directory to repo (e.g., `myplugin/skills/optimus-myplugin/SKILL.md`)
+2. Add entry to `.factory-plugin/marketplace.json` (bare name: `myplugin`)
+3. Add entry to `.claude-plugin/marketplace.json` (prefixed name: `optimus-myplugin`, source `./myplugin`)
+4. Update README plugin list if applicable
 5. Commit, push
-6. **Droid**: `droid plugin install <name>@optimus`
-7. **Claude Code**: Run `/optimus-sync` (auto-installs from repo cache)
+6. **Droid**: `droid plugin install myplugin@optimus`
+7. **Claude Code**: `claude plugin install optimus-myplugin@optimus`
+8. Or just run `/optimus-sync` after the marketplace caches are refreshed (`droid plugin marketplace update optimus` and `claude plugin marketplace update optimus`)
 
 ### Updating a plugin
 1. Edit the SKILL.md
 2. Commit, push
-3. Run `/optimus-sync` (or `make sync-plugins`) to update all plugins at once on both platforms
+3. Run `/optimus-sync` (or `make sync-plugins`) — script handles both platforms
 
 ### Removing a plugin
-1. Remove from marketplace.json
-2. Remove directory
-3. Update README.md
+1. Remove directory
+2. Remove from BOTH `.factory-plugin/marketplace.json` AND `.claude-plugin/marketplace.json`
+3. Update README if applicable
 4. Commit, push
-5. Run `/optimus-sync` to remove orphaned plugins and update the rest (both platforms)
+5. Run `/optimus-sync` to remove the orphan from both platforms
 
-**Note:** End users on Claude Code do not get automatic updates. They must run
-`/optimus-sync` to receive removals (the orphan-removal step). Until they sync,
-the obsolete plugin's `SKILL.md` lingers under `~/.claude/skills/default/optimus-<name>/`.
-Consider announcing breaking removals in release notes.
+**Note for end users:** Claude Code plugins do NOT auto-update. Users must run
+`/optimus-sync` to receive removed plugins (orphan removal) and updates. The
+`installed_plugins.json` cache in `~/.claude/plugins/` tracks installed state
+between sessions.
 
 ### Syncing all plugins (for end users)
 Run `/optimus-sync` or `make sync-plugins`. This command:
 - Detects available platforms (Droid, Claude Code, or both)
-- Updates the Optimus marketplace (Droid) / repo cache (Claude Code)
-- Installs new plugins that were added
-- Removes orphaned plugins that were removed
-- Updates all existing plugins (with automatic scope conflict resolution on Droid, diff-based skip on Claude Code)
+- Refreshes the marketplace cache on each available platform
+- Installs new plugins that were added to the marketplace
+- Removes orphaned plugins that were removed from the marketplace
+- Updates all existing plugins (with automatic scope conflict resolution on Droid)
 - Shows a per-platform summary
 
 This is the recommended way for end users to stay up to date.

--- a/README.md
+++ b/README.md
@@ -60,16 +60,13 @@ Then run `/optimus-sync` to install all plugins at once.
 
 ### Claude Code
 
-One-liner bootstrap (resolves the chicken-and-egg problem):
-
 ```bash
-git clone --depth 1 https://github.com/alexgarzao/optimus ~/.optimus/repo \
-  && mkdir -p ~/.claude/skills/default/optimus-sync \
-  && cp ~/.optimus/repo/sync/skills/optimus-sync/SKILL.md \
-        ~/.claude/skills/default/optimus-sync/SKILL.md
+claude plugin marketplace add https://github.com/alexgarzao/optimus
+claude plugin install optimus-sync@optimus
 ```
 
-Then open Claude Code and run `/optimus-sync` — it will install all other plugins automatically.
+Reopen Claude Code (so the new plugin is discovered), then run `/optimus-sync` —
+it installs all other plugins automatically via Claude Code's native plugin system.
 
 **Note:** Command aliases (`/sp`, `/bd`, etc.) are not supported on Claude Code.
 Use the full skill name (e.g., `/optimus-plan`, `/optimus-build`).

--- a/scripts/test_sync_user_plugins.py
+++ b/scripts/test_sync_user_plugins.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python3
-"""Integration tests for sync-user-plugins.sh using mock commands."""
+"""Integration tests for sync-user-plugins.sh using mock commands.
 
+After the refactor to Claude Code's NATIVE plugin system, Claude Code support
+no longer copies SKILL.md files. It instead drives `claude plugin install/
+update/uninstall` against the user-scope plugin store. The tests here mock
+both the `droid` and `claude` binaries and assert the script's command
+choreography, summary lines, and failure isolation.
+"""
+
+import json
 import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -13,6 +22,10 @@ BASH = shutil.which("bash")
 if BASH is None:
     pytest.skip("bash not found", allow_module_level=True)
 
+DEFAULT_OPTIMUS_REPO_URL = "https://github.com/alexgarzao/optimus"
+
+
+# ─── Mock binary helpers ─────────────────────────────────────────────────────
 
 def _create_mock_bin(tmp_path: Path, name: str, script: str) -> None:
     """Create a mock executable in tmp_path/bin/."""
@@ -23,8 +36,96 @@ def _create_mock_bin(tmp_path: Path, name: str, script: str) -> None:
     mock.chmod(0o755)
 
 
+def _droid_script(log: Path, list_output: str = "",
+                  update_exit: int = 0, install_exit: int = 0,
+                  uninstall_exit: int = 0) -> str:
+    """Generate a droid mock script with configurable behavior."""
+    return f"""
+CMD="$1 $2"
+case "$CMD" in
+  "plugin marketplace") exit 0 ;;
+  "plugin list") {f'echo "{list_output}"' if list_output else 'echo ""'} ;;
+  "plugin update") echo "update $3" >> "{log}"; exit {update_exit} ;;
+  "plugin uninstall") echo "uninstall $3" >> "{log}"; exit {uninstall_exit} ;;
+  "plugin install") echo "install $3" >> "{log}"; exit {install_exit} ;;
+  *) echo "unknown: $@" >> "{log}" ;;
+esac
+"""
+
+
+def _claude_script(log: Path,
+                   installed_plugins: list[dict] | None = None,
+                   install_exit: int = 0,
+                   update_exit: int = 0,
+                   uninstall_exit: int = 0,
+                   marketplace_update_exit: int = 0) -> str:
+    """Return a bash mock for the `claude` binary.
+
+    The mock supports the four subcommands the sync script invokes:
+      - `claude plugin marketplace update <name>`
+      - `claude plugin list --json`
+      - `claude plugin install <id> --scope user`
+      - `claude plugin update <id>`
+      - `claude plugin uninstall <id>`
+
+    `installed_plugins` is a list of dicts that will be returned as the JSON
+    array from `claude plugin list --json`. Each dict should at minimum carry
+    the `id` key in the `<plugin>@<marketplace>` form (matches the real schema
+    observed in Claude Code 2.1.x).
+    """
+    json_out = json.dumps(installed_plugins or [])
+    log_q = shlex.quote(str(log))
+    return f"""
+echo "$@" >> {log_q}
+case "$1 $2" in
+  "plugin list")
+    if [ "$3" = "--json" ]; then
+      cat <<'JSONEOF'
+{json_out}
+JSONEOF
+      exit 0
+    fi
+    exit 0
+    ;;
+  "plugin install") exit {install_exit} ;;
+  "plugin update") exit {update_exit} ;;
+  "plugin uninstall") exit {uninstall_exit} ;;
+  "plugin marketplace")
+    if [ "$3" = "update" ]; then exit {marketplace_update_exit}; fi
+    exit 0
+    ;;
+esac
+exit 0
+"""
+
+
+def _install_claude_mock(tmp_path: Path, log: Path | None = None,
+                         installed_plugins: list[dict] | None = None,
+                         install_exit: int = 0, update_exit: int = 0,
+                         uninstall_exit: int = 0,
+                         marketplace_update_exit: int = 0) -> Path:
+    """Install a mock `claude` binary in tmp_path/bin/.
+
+    Returns the log path so tests can introspect the issued commands. If `log`
+    is not provided, defaults to tmp_path/'claude.log'.
+    """
+    log = log or (tmp_path / "claude.log")
+    script = _claude_script(
+        log=log,
+        installed_plugins=installed_plugins,
+        install_exit=install_exit,
+        update_exit=update_exit,
+        uninstall_exit=uninstall_exit,
+        marketplace_update_exit=marketplace_update_exit,
+    )
+    _create_mock_bin(tmp_path, "claude", script)
+    return log
+
+
+# ─── Marketplace / cache builders ───────────────────────────────────────────
+
 def _create_marketplace(tmp_path: Path, plugins: list[str], name: str = "optimus") -> None:
-    """Create a mock marketplace JSON file at the expected path."""
+    """Create a Source 1 (Droid) marketplace JSON file. Bare plugin names."""
     mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / name / ".factory-plugin"
     mp_dir.mkdir(parents=True)
     mp_file = mp_dir / "marketplace.json"
@@ -32,108 +133,76 @@ def _create_marketplace(tmp_path: Path, plugins: list[str], name: str = "optimus
     mp_file.write_text(f'{{"plugins": [{entries}]}}')
 
 
-DEFAULT_OPTIMUS_REPO_URL = "https://github.com/alexgarzao/optimus"
+def _create_claude_marketplace_cache(tmp_path: Path, plugins: list[str],
+                                     name: str = "optimus") -> Path:
+    """Create a Source 2 (Claude Code) marketplace cache.
 
-
-def _create_repo_cache(tmp_path: Path, plugins: list[str],
-                       cache_dir: str | None = None,
-                       origin_url: str = DEFAULT_OPTIMUS_REPO_URL,
-                       install_git_mock: bool = True) -> Path:
-    """Create a mock optimus repo cache with SKILL.md files.
-
-    Writes a minimal but functional .git/ dir (config + HEAD + objects/refs)
-    so real `git -C config --get remote.origin.url` returns the configured URL.
-    F26 (post bash refactor) verifies origin URL before using cache.
-
-    install_git_mock=True (default) installs a default mock `git` in tmp_path/bin
-    that handles config/fetch/reset as no-ops returning the right URL — preventing
-    real network calls. Set install_git_mock=False if a test wants to provide its
-    own git mock.
+    Plugin entries use the PREFIXED `optimus-<name>` form, matching the real
+    `.claude-plugin/marketplace.json` schema. The script strips the prefix.
+    Returns the path to marketplace.json so tests can pass it via
+    CLAUDE_MARKETPLACE_FILE.
     """
-    repo_dir = Path(cache_dir) if cache_dir else tmp_path / "home" / ".optimus" / "repo"
-    git_dir = repo_dir / ".git"
-    git_dir.mkdir(parents=True, exist_ok=True)
-    # Minimum files for git to recognize this as a valid repo.
-    (git_dir / "config").write_text(
-        '[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = false\n'
-        f'[remote "origin"]\n\turl = {origin_url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n'
-    )
-    (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
-    (git_dir / "objects").mkdir(exist_ok=True)
-    (git_dir / "refs" / "heads").mkdir(parents=True, exist_ok=True)
-    # Create marketplace.json
-    mp_dir = repo_dir / ".factory-plugin"
-    mp_dir.mkdir(parents=True, exist_ok=True)
-    entries = ", ".join(f'{{"name": "{p}"}}' for p in plugins)
-    (mp_dir / "marketplace.json").write_text(f'{{"plugins": [{entries}]}}')
-    # Create SKILL.md for each plugin
-    for plugin in plugins:
-        skill_dir = repo_dir / plugin / "skills" / f"optimus-{plugin}"
-        skill_dir.mkdir(parents=True, exist_ok=True)
-        (skill_dir / "SKILL.md").write_text(
-            f"---\nname: optimus-{plugin}\n---\n# {plugin}\nContent for {plugin}.\n"
-        )
-    # Install default git mock so the script's `git fetch` doesn't go to network,
-    # and `git config --get remote.origin.url` returns the configured origin.
-    # Skipped if the test already wrote one or explicitly opts out.
-    if install_git_mock:
-        bin_dir = tmp_path / "bin"
-        bin_dir.mkdir(exist_ok=True)
-        git_mock = bin_dir / "git"
-        if not git_mock.exists():
-            # The script invokes git with `-C <path>` prefix for repo ops
-            # (e.g. `git -C $repo_dir config --get remote.origin.url`).
-            # Strip leading "-C <path>" so we can dispatch on the real subcommand.
-            git_mock.write_text(
-                "#!/usr/bin/env bash\n"
-                'if [ "$1" = "-C" ]; then shift 2; fi\n'
-                'case "$1" in\n'
-                f'  config) echo "{origin_url}"; exit 0 ;;\n'
-                "  fetch|reset|clone) exit 0 ;;\n"
-                "esac\n"
-                "exit 0\n"
-            )
-            git_mock.chmod(0o755)
-    return repo_dir
+    mp_dir = tmp_path / "home" / ".claude" / "plugins" / "marketplaces" / name / ".claude-plugin"
+    mp_dir.mkdir(parents=True)
+    mp_file = mp_dir / "marketplace.json"
+    payload = {
+        "name": name,
+        "owner": {"name": "Test", "email": "test@example.com"},
+        "metadata": {"description": "test marketplace"},
+        "plugins": [
+            {"name": f"optimus-{p}", "source": f"./{p}", "version": "1.0.0",
+             "description": f"plugin {p}"}
+            for p in plugins
+        ],
+    }
+    mp_file.write_text(json.dumps(payload))
+    return mp_file
 
 
-def _ensure_claude_dir(tmp_path: Path) -> Path:
-    """Ensure ~/.claude/skills/ directory exists in mock home.
+# ─── PATH helpers ────────────────────────────────────────────────────────────
 
-    Per F49, Claude Code detection requires ~/.claude/skills/ (not just ~/.claude/).
-    """
-    claude_skills = tmp_path / "home" / ".claude" / "skills"
-    claude_skills.mkdir(parents=True, exist_ok=True)
-    return claude_skills.parent
-
-
-def _path_without_droid() -> str:
-    """Return system PATH with any directory containing a droid binary removed."""
+def _path_without(*binaries: str) -> str:
+    """Return system PATH with directories containing any named binary removed."""
     path_dirs = os.environ.get("PATH", "/usr/bin:/bin").split(":")
-    filtered = [d for d in path_dirs if d and not (Path(d) / "droid").exists()]
+    filtered = []
+    for d in path_dirs:
+        if not d:
+            continue
+        if any((Path(d) / b).exists() for b in binaries):
+            continue
+        filtered.append(d)
     return ":".join(filtered) if filtered else "/usr/bin:/bin"
 
+
+# ─── Test runner ─────────────────────────────────────────────────────────────
 
 def _run_sync(tmp_path: Path, env_extra: dict[str, str] | None = None,
               restrict_path: bool = False,
               exclude_droid: bool = False,
+              exclude_claude: bool = False,
               isolated: bool = False) -> subprocess.CompletedProcess:
     """Run the sync script with mocked PATH and HOME.
 
     Args:
-        restrict_path: Only use tmp_path/bin as PATH (excludes ALL system binaries).
-        exclude_droid: Remove droid from PATH but keep other system tools.
-        isolated: Copy script to tmp_path so BASH_SOURCE doesn't resolve to the repo.
+        restrict_path: Use only tmp_path/bin as PATH (no system binaries).
+        exclude_droid: Filter `droid` out of the system PATH.
+        exclude_claude: Filter `claude` out of the system PATH.
+        isolated: Copy script to tmp_path so BASH_SOURCE doesn't resolve to
+            the optimus repo (defeats Source 3 fallback).
     """
     env = os.environ.copy()
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir(exist_ok=True)
     if restrict_path:
         env["PATH"] = str(bin_dir)
-    elif exclude_droid:
-        env["PATH"] = f"{bin_dir}:{_path_without_droid()}"
     else:
-        env["PATH"] = f"{bin_dir}:{env.get('PATH', '/usr/bin')}"
+        excluded: list[str] = []
+        if exclude_droid:
+            excluded.append("droid")
+        if exclude_claude:
+            excluded.append("claude")
+        sys_path = _path_without(*excluded) if excluded else env.get("PATH", "/usr/bin")
+        env["PATH"] = f"{bin_dir}:{sys_path}"
     env["HOME"] = str(tmp_path / "home")
     if env_extra:
         env.update(env_extra)
@@ -154,30 +223,13 @@ def _run_sync(tmp_path: Path, env_extra: dict[str, str] | None = None,
     )
 
 
-def _droid_script(log: Path, list_output: str = "",
-                  update_exit: int = 0, install_exit: int = 0,
-                  uninstall_exit: int = 0) -> str:
-    """Generate a droid mock script with configurable behavior."""
-    return f"""
-CMD="$1 $2"
-case "$CMD" in
-  "plugin marketplace") exit 0 ;;
-  "plugin list") {f'echo "{list_output}"' if list_output else 'echo ""'} ;;
-  "plugin update") echo "update $3" >> "{log}"; exit {update_exit} ;;
-  "plugin uninstall") echo "uninstall $3" >> "{log}"; exit {uninstall_exit} ;;
-  "plugin install") echo "install $3" >> "{log}"; exit {install_exit} ;;
-  *) echo "unknown: $@" >> "{log}" ;;
-esac
-"""
-
-
 # ═══════════════════════════════════════════════════════════════════════════════
-# Existing Droid-only tests (adapted for dual-platform)
+# Dependency / detection
 # ═══════════════════════════════════════════════════════════════════════════════
 
 class TestDependencyChecks:
-    def test_fails_without_any_platform(self, tmp_path: Path):
-        """Neither droid nor ~/.claude/ → error."""
+    def test_fails_without_any_platform(self, tmp_path: Path) -> None:
+        """Neither droid nor claude on PATH → error."""
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir(exist_ok=True)
         jq_path = shutil.which("jq")
@@ -186,12 +238,11 @@ class TestDependencyChecks:
         else:
             (bin_dir / "jq").write_text("#!/bin/bash\necho jq\n")
             (bin_dir / "jq").chmod(0o755)
-        # No droid, no .claude dir
         result = _run_sync(tmp_path, restrict_path=True)
         assert result.returncode == 1
         assert "No supported platform found" in result.stderr
 
-    def test_fails_without_jq(self, tmp_path: Path):
+    def test_fails_without_jq(self, tmp_path: Path) -> None:
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir(exist_ok=True)
         droid_path = shutil.which("droid")
@@ -205,12 +256,44 @@ class TestDependencyChecks:
         assert "jq is required" in result.stderr
 
 
+class TestPlatformDetection:
+    def test_detects_claude_code_when_claude_binary_present(self, tmp_path: Path) -> None:
+        """When `claude` is on PATH and Droid is not, Claude Code is detected."""
+        _install_claude_mock(tmp_path)
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True, env_extra={
+            "CLAUDE_MARKETPLACE_FILE": str(
+                tmp_path / "home" / ".claude" / "plugins" / "marketplaces"
+                / "optimus" / ".claude-plugin" / "marketplace.json"),
+        })
+        assert result.returncode == 0
+        assert "Platforms:" in result.stdout
+        assert "Claude Code" in result.stdout
+        assert "── Claude Code ──" in result.stdout
+        assert "── Droid (Factory) ──" not in result.stdout
+
+    def test_skips_claude_code_when_claude_binary_missing(self, tmp_path: Path) -> None:
+        """When `claude` is absent and droid present, only Droid runs."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        _create_marketplace(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_claude=True)
+        assert result.returncode == 0
+        assert "── Droid (Factory) ──" in result.stdout
+        assert "── Claude Code ──" not in result.stdout
+        assert "install alpha@optimus" in log.read_text()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Droid sync — unchanged behavior (smoke + edge cases)
+# ═══════════════════════════════════════════════════════════════════════════════
+
 class TestFirstTimeInstall:
-    def test_installs_all_plugins_on_first_run(self, tmp_path: Path):
+    def test_installs_all_plugins_on_first_run(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         _create_marketplace(tmp_path, ["alpha", "beta"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert "Added: 2" in result.stdout
         assert "alpha ... OK" in result.stdout
@@ -221,23 +304,23 @@ class TestFirstTimeInstall:
 
 
 class TestUpdateWithExisting:
-    def test_updates_existing_plugins(self, tmp_path: Path):
+    def test_updates_existing_plugins(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(
             log, list_output="alpha@optimus  installed"))
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert "Updated: 1" in result.stdout
 
 
 class TestOrphanRemoval:
-    def test_removes_orphaned_plugins(self, tmp_path: Path):
+    def test_removes_orphaned_plugins(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(
             log, list_output="alpha@optimus  installed\norphan@optimus  installed"))
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert "Removed: 1" in result.stdout
         log_content = log.read_text()
@@ -245,12 +328,12 @@ class TestOrphanRemoval:
 
 
 class TestScopeConflict:
-    def test_reinstalls_on_scope_conflict(self, tmp_path: Path):
+    def test_reinstalls_on_scope_conflict(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(
             log, list_output="alpha@optimus  installed", update_exit=1))
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert "reinstalled" in result.stdout.lower()
         log_content = log.read_text()
@@ -259,43 +342,41 @@ class TestScopeConflict:
 
 
 class TestMarketplaceOverride:
-    def test_custom_marketplace_name(self, tmp_path: Path):
+    def test_custom_marketplace_name(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         _create_marketplace(tmp_path, ["test"], name="custom")
-        result = _run_sync(tmp_path, {"OPTIMUS_MARKETPLACE_NAME": "custom"})
+        result = _run_sync(tmp_path, env_extra={"OPTIMUS_MARKETPLACE_NAME": "custom"},
+                           exclude_claude=True)
         assert result.returncode == 0
         assert "Added: 1" in result.stdout
 
 
 class TestErrorPaths:
-    def test_fails_on_marketplace_not_found(self, tmp_path: Path):
+    def test_fails_on_marketplace_not_found(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         (tmp_path / "home" / ".factory").mkdir(parents=True)
-        # Use isolated=True so BASH_SOURCE doesn't resolve to the optimus repo,
-        # and set OPTIMUS_CACHE_DIR to a nonexistent path to prevent Source 2 fallback.
-        result = _run_sync(tmp_path, isolated=True, env_extra={
-            "OPTIMUS_CACHE_DIR": str(tmp_path / "nonexistent"),
-        })
+        # Use isolated=True so BASH_SOURCE doesn't resolve to the optimus repo.
+        result = _run_sync(tmp_path, isolated=True, exclude_claude=True)
         assert result.returncode == 1
         assert "not found" in result.stderr.lower()
 
-    def test_fails_on_empty_marketplace(self, tmp_path: Path):
+    def test_fails_on_empty_marketplace(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
         mp_dir.mkdir(parents=True)
         (mp_dir / "marketplace.json").write_text('{"plugins": []}')
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 1
         assert "No plugins found" in result.stderr
 
-    def test_exits_nonzero_on_persistent_failure(self, tmp_path: Path):
+    def test_exits_nonzero_on_persistent_failure(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log, install_exit=1))
         _create_marketplace(tmp_path, ["failing"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 1
         assert "Failed:" in result.stdout
 
@@ -305,7 +386,8 @@ class TestDroidTimeout:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path, {"OPTIMUS_DROID_TIMEOUT": "0"})
+        result = _run_sync(tmp_path, env_extra={"OPTIMUS_DROID_TIMEOUT": "0"},
+                           exclude_claude=True)
         assert result.returncode == 1
         assert "positive integer" in result.stderr
 
@@ -313,7 +395,8 @@ class TestDroidTimeout:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path, {"OPTIMUS_DROID_TIMEOUT": "abc"})
+        result = _run_sync(tmp_path, env_extra={"OPTIMUS_DROID_TIMEOUT": "abc"},
+                           exclude_claude=True)
         assert result.returncode == 1
         assert "positive integer" in result.stderr
 
@@ -321,7 +404,8 @@ class TestDroidTimeout:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path, {"OPTIMUS_DROID_TIMEOUT": "-5"})
+        result = _run_sync(tmp_path, env_extra={"OPTIMUS_DROID_TIMEOUT": "-5"},
+                           exclude_claude=True)
         assert result.returncode == 1
         assert "positive integer" in result.stderr
 
@@ -345,14 +429,14 @@ esac
 """
         _create_mock_bin(tmp_path, "droid", script)
         _create_marketplace(tmp_path, ["good", "fail-plugin", "also-good"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 1
         assert "Added: 2" in result.stdout
         assert "Failed:" in result.stdout
 
 
 class TestMarketplaceUpdateFailure:
-    def test_continues_after_marketplace_update_failure(self, tmp_path: Path) -> None:
+    def test_continues_after_droid_marketplace_update_failure(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         script = f"""
 CMD="$1 $2"
@@ -365,7 +449,7 @@ esac
 """
         _create_mock_bin(tmp_path, "droid", script)
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert "Could not update Droid marketplace" in result.stderr
         assert "Added: 1" in result.stdout
@@ -387,7 +471,7 @@ esac
         _create_marketplace(tmp_path, ["slow-plugin"])
         env = os.environ.copy()
         bin_dir = tmp_path / "bin"
-        env["PATH"] = f"{bin_dir}:{env.get('PATH', '/usr/bin')}"
+        env["PATH"] = f"{bin_dir}:{_path_without('claude')}"
         env["HOME"] = str(tmp_path / "home")
         import signal
         import time
@@ -401,7 +485,7 @@ esac
         )
         time.sleep(2)
         os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        stdout, stderr = proc.communicate(timeout=10)
+        proc.communicate(timeout=10)
         assert proc.returncode == 130
 
 
@@ -411,9 +495,12 @@ class TestTimeoutWrapper:
         timeout_log = tmp_path / "timeout.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         _create_marketplace(tmp_path, ["alpha"])
-        timeout_script = f'#!/usr/bin/env bash\necho "timeout called with: $@" >> "{timeout_log}"\nshift; exec "$@"\n'
+        timeout_script = (
+            f'echo "timeout called with: $@" >> "{timeout_log}"\n'
+            'shift; exec "$@"\n'
+        )
         _create_mock_bin(tmp_path, "timeout", timeout_script)
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert timeout_log.exists()
         assert "timeout called with" in timeout_log.read_text()
@@ -444,7 +531,7 @@ esac
 """
         _create_mock_bin(tmp_path, "droid", script)
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert "Retrying failed plugin operations serially" in result.stdout
         assert "Updated: 1" in result.stdout
@@ -476,7 +563,7 @@ esac
 """
         _create_mock_bin(tmp_path, "droid", script)
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert "Retrying failed plugin operations serially" in result.stdout
         assert "Added: 1" in result.stdout
@@ -492,485 +579,294 @@ class TestMalformedMarketplace:
         mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
         mp_dir.mkdir(parents=True)
         (mp_dir / "marketplace.json").write_text("{invalid json")
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode != 0
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Claude Code detection tests
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class TestClaudeCodeDetection:
-    def test_detects_claude_code_when_dir_exists(self, tmp_path: Path) -> None:
-        """When ~/.claude/ exists and no droid, runs Claude Code sync."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        assert result.returncode == 0
-        assert "── Claude Code ──" in result.stdout
-        assert "── Droid (Factory) ──" not in result.stdout
-
-    def test_skips_claude_code_when_no_dir(self, tmp_path: Path) -> None:
-        """When ~/.claude/skills/ doesn't exist but droid is available, only Droid runs."""
-        log = tmp_path / "droid.log"
-        _create_mock_bin(tmp_path, "droid", _droid_script(log))
-        _create_marketplace(tmp_path, ["alpha"])
-        # Don't create .claude/skills/ dir (F49 detection requires it).
-        result = _run_sync(tmp_path)
-        assert result.returncode == 0
-        # F32: assert exact section header AND that Droid actually installed something.
-        assert "── Droid (Factory) ──" in result.stdout
-        # Claude Code section should not appear
-        assert "── Claude Code ──" not in result.stdout
-        log_content = log.read_text()
-        assert "install alpha@optimus" in log_content
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Claude Code sync tests
+# Claude Code sync — native plugin install/update/uninstall
 # ═══════════════════════════════════════════════════════════════════════════════
 
 class TestClaudeCodeSync:
-    def test_installs_new_skills(self, tmp_path: Path) -> None:
-        """First-time install copies SKILL.md files to skills dir."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha", "beta"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        assert result.returncode == 0
-        assert "Added: 2" in result.stdout
-        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
-        assert (skills_dir / "optimus-beta" / "SKILL.md").exists()
+    def _claude_only_env(self, tmp_path: Path) -> dict[str, str]:
+        return {
+            "CLAUDE_MARKETPLACE_FILE": str(
+                tmp_path / "home" / ".claude" / "plugins" / "marketplaces"
+                / "optimus" / ".claude-plugin" / "marketplace.json"),
+        }
 
-    def test_updates_changed_skills(self, tmp_path: Path) -> None:
-        """When source SKILL.md differs, it gets updated."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Create existing skill with different content
-        skill_dir = skills_dir / "optimus-alpha"
-        skill_dir.mkdir(parents=True, exist_ok=True)
-        (skill_dir / "SKILL.md").write_text("old content")
-        # F11: existing installs need the .optimus-managed marker so update path runs.
-        (skill_dir / ".optimus-managed").touch()
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
+    def test_installs_new_plugins_via_claude_install(self, tmp_path: Path) -> None:
+        """`claude plugin install <name>@optimus --scope user` is called for every
+        plugin from the marketplace when none are installed yet."""
+        log = _install_claude_mock(tmp_path, installed_plugins=[])
+        _create_claude_marketplace_cache(tmp_path, ["alpha", "beta"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
+        assert result.returncode == 0
+        assert "── Claude Code ──" in result.stdout
+        assert "Added: 2" in result.stdout
+        log_content = log.read_text()
+        assert "plugin install optimus-alpha@optimus --scope user" in log_content
+        assert "plugin install optimus-beta@optimus --scope user" in log_content
+
+    def test_updates_existing_plugins_via_claude_update(self, tmp_path: Path) -> None:
+        """When a plugin is already installed, the script issues `plugin update`."""
+        installed = [
+            {"id": "optimus-alpha@optimus", "version": "1.0.0", "scope": "user",
+             "enabled": True},
+        ]
+        log = _install_claude_mock(tmp_path, installed_plugins=installed)
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
         assert result.returncode == 0
         assert "Updated: 1" in result.stdout
-        assert "alpha" in (skill_dir / "SKILL.md").read_text()
+        log_content = log.read_text()
+        assert "plugin update optimus-alpha@optimus" in log_content
+        assert "plugin install optimus-alpha@optimus" not in log_content
 
-    def test_skips_unchanged_skills(self, tmp_path: Path) -> None:
-        """When source SKILL.md is identical, skip with 'unchanged' and don't touch the file."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Copy the exact same content
-        src_content = (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").read_text()
-        skill_dir = skills_dir / "optimus-alpha"
-        skill_dir.mkdir(parents=True, exist_ok=True)
-        dest = skill_dir / "SKILL.md"
-        dest.write_text(src_content)
-        # F11: existing installs need the .optimus-managed marker.
-        (skill_dir / ".optimus-managed").touch()
-        # F14: capture mtime to verify the unchanged path doesn't rewrite the file.
-        mtime_before = dest.stat().st_mtime_ns
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        assert result.returncode == 0
-        assert "unchanged" in result.stdout.lower()
-        assert "Unchanged: 1" in result.stdout
-        assert dest.stat().st_mtime_ns == mtime_before
-
-    def test_removes_orphaned_skills(self, tmp_path: Path) -> None:
-        """Skills in dir but not in marketplace get removed (when marker present)."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Create orphaned skill with .optimus-managed marker (F11)
-        orphan_dir = skills_dir / "optimus-orphan"
-        orphan_dir.mkdir(parents=True, exist_ok=True)
-        (orphan_dir / "SKILL.md").write_text("orphan")
-        (orphan_dir / ".optimus-managed").touch()
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
+    def test_removes_orphans_via_claude_uninstall(self, tmp_path: Path) -> None:
+        """Plugins installed but not in the marketplace are uninstalled."""
+        installed = [
+            {"id": "optimus-alpha@optimus", "version": "1.0.0", "scope": "user",
+             "enabled": True},
+            {"id": "optimus-orphan@optimus", "version": "1.0.0", "scope": "user",
+             "enabled": True},
+        ]
+        log = _install_claude_mock(tmp_path, installed_plugins=installed)
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
         assert result.returncode == 0
         assert "Removed: 1" in result.stdout
-        assert not orphan_dir.exists()
+        log_content = log.read_text()
+        assert "plugin uninstall optimus-orphan@optimus" in log_content
 
-    def test_skips_orphan_without_marker(self, tmp_path: Path) -> None:
-        """F11: orphan dirs lacking .optimus-managed are skipped (user-created safety)."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Orphan WITHOUT marker — should be left alone.
-        orphan_dir = skills_dir / "optimus-orphan"
-        orphan_dir.mkdir(parents=True, exist_ok=True)
-        (orphan_dir / "SKILL.md").write_text("user-created")
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        assert result.returncode == 0
-        assert "Removed: 0" in result.stdout
-        assert "skipped" in result.stdout.lower()
-        assert ".optimus-managed marker" in result.stdout
-        assert orphan_dir.exists()
-        assert (orphan_dir / "SKILL.md").read_text() == "user-created"
-
-    def test_never_removes_non_optimus_skills(self, tmp_path: Path) -> None:
-        """Skills without optimus- prefix must NEVER be touched."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Create non-optimus skills that must survive
-        for name in ["ring:code-reviewer", "my-custom-skill", "other-tool"]:
-            safe_dir = skills_dir / name
-            safe_dir.mkdir(parents=True, exist_ok=True)
-            (safe_dir / "SKILL.md").write_text(f"safe: {name}")
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        assert result.returncode == 0
-        # All non-optimus skills must still exist
-        for name in ["ring:code-reviewer", "my-custom-skill", "other-tool"]:
-            assert (skills_dir / name / "SKILL.md").exists(), f"{name} was incorrectly removed!"
-
-    def test_source_not_found_reports_fail(self, tmp_path: Path) -> None:
-        """When SKILL.md doesn't exist in repo cache, report FAIL."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Remove the SKILL.md from cache to simulate missing source
-        (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").unlink()
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
+    def test_install_failure_increments_failed_count(self, tmp_path: Path) -> None:
+        """When `claude plugin install` exits non-zero, summary shows Failed > 0."""
+        log = _install_claude_mock(tmp_path, installed_plugins=[], install_exit=1)
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
         assert result.returncode == 1
-        assert "source not found" in result.stdout.lower()
+        assert "Claude Code — Added: 0" in result.stdout
+        assert "Failed: 1" in result.stdout
+        assert "+ alpha ... FAIL" in result.stdout
+        # Install was still attempted (logged) before failing.
+        assert "plugin install optimus-alpha@optimus" in log.read_text()
 
+    def test_update_failure_increments_failed_count(self, tmp_path: Path) -> None:
+        """A failing `claude plugin update` is reported as FAIL."""
+        installed = [
+            {"id": "optimus-alpha@optimus", "version": "1.0.0", "scope": "user",
+             "enabled": True},
+        ]
+        _install_claude_mock(tmp_path, installed_plugins=installed, update_exit=1)
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
+        assert result.returncode == 1
+        assert "Failed: 1" in result.stdout
+        assert "* alpha ... FAIL" in result.stdout
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Claude Code repo cache tests
-# ═══════════════════════════════════════════════════════════════════════════════
+    def test_uninstall_failure_increments_failed_count(self, tmp_path: Path) -> None:
+        """A failing `claude plugin uninstall` is reported as FAIL."""
+        installed = [
+            {"id": "optimus-orphan@optimus", "version": "1.0.0", "scope": "user",
+             "enabled": True},
+        ]
+        _install_claude_mock(tmp_path, installed_plugins=installed, uninstall_exit=1)
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
+        # alpha installs OK, orphan uninstall FAILs → exit 1.
+        assert result.returncode == 1
+        assert "Added: 1" in result.stdout
+        assert "Failed: 1" in result.stdout
+        assert "- orphan ... FAIL" in result.stdout
 
-class TestClaudeCodeRepoCache:
-    def test_uses_existing_cache(self, tmp_path: Path) -> None:
-        """When cache dir exists with .git, uses it without cloning, and EXPECTED comes from it."""
-        _ensure_claude_dir(tmp_path)
-        # Cache holds a single plugin "alpha-from-cache" — the expected list must come from here.
-        # Default git mock from _create_repo_cache handles config/fetch/reset as no-ops.
-        repo_dir = _create_repo_cache(tmp_path, ["alpha-from-cache"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
+    def test_marketplace_update_failure_warns_but_continues(self, tmp_path: Path) -> None:
+        """If `claude plugin marketplace update` fails, the script warns and continues
+        using the cached marketplace JSON."""
+        log = _install_claude_mock(tmp_path, installed_plugins=[],
+                                    marketplace_update_exit=1)
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
         assert result.returncode == 0
-        assert "Updating repo cache" in result.stdout
-        # F33: post-condition — EXPECTED was sourced from the cache.
-        assert (skills_dir / "optimus-alpha-from-cache" / "SKILL.md").exists()
-        assert "alpha-from-cache" in result.stdout
+        assert "Could not update Claude Code marketplace" in result.stderr
+        assert "Added: 1" in result.stdout
+        # Install was still attempted using the cached marketplace.
+        assert "plugin install optimus-alpha@optimus" in log.read_text()
 
-    def test_clones_when_no_cache(self, tmp_path: Path) -> None:
-        """When no cache exists, attempts to clone with exact expected arguments."""
-        _ensure_claude_dir(tmp_path)
-        cache_dir = tmp_path / "home" / ".optimus" / "repo"
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        git_log = tmp_path / "git.log"
-        # Mock git clone to create the repo cache.
-        # F57: use a heredoc so the SKILL.md actually contains literal newlines.
-        # F34: log every git invocation so we can assert exact clone args.
-        git_script = f"""
-echo "$@" >> "{git_log}"
-if [ "$1" = "clone" ]; then
-  # Args: clone --depth 1 <url> <dest>
-  dest="${{!#}}"
-  mkdir -p "$dest/.git"
-  mkdir -p "$dest/.factory-plugin"
-  echo '{{"plugins": [{{"name": "alpha"}}]}}' > "$dest/.factory-plugin/marketplace.json"
-  mkdir -p "$dest/alpha/skills/optimus-alpha"
-  cat > "$dest/alpha/skills/optimus-alpha/SKILL.md" <<'EOF'
----
-name: optimus-alpha
----
-# alpha
-EOF
-  exit 0
-fi
-exit 0
-"""
-        _create_mock_bin(tmp_path, "git", git_script)
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(cache_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
+    def test_summary_uses_added_updated_removed_failed_format(self, tmp_path: Path) -> None:
+        """Claude Code summary line matches Droid's format (no `Unchanged` field)."""
+        installed = [
+            {"id": "optimus-alpha@optimus", "version": "1.0.0", "scope": "user",
+             "enabled": True},
+            {"id": "optimus-orphan@optimus", "version": "1.0.0", "scope": "user",
+             "enabled": True},
+        ]
+        _install_claude_mock(tmp_path, installed_plugins=installed)
+        _create_claude_marketplace_cache(tmp_path, ["alpha", "beta"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
         assert result.returncode == 0
-        assert "Cloning repo cache" in result.stdout
-        # F34: verify exact clone arguments.
-        log_content = git_log.read_text()
-        expected_clone = f"clone --depth 1 {DEFAULT_OPTIMUS_REPO_URL} {cache_dir}"
-        assert expected_clone in log_content, (
-            f"Expected '{expected_clone}' in git log, got:\n{log_content}"
-        )
+        assert "Claude Code — Added: 1 | Updated: 1 | Removed: 1 | Failed: 0" in result.stdout
+        assert "Unchanged" not in result.stdout
 
-    def test_warns_on_clone_failure(self, tmp_path: Path) -> None:
-        """When clone fails, warn and skip Claude Code sync gracefully."""
-        _ensure_claude_dir(tmp_path)
-        cache_dir = tmp_path / "home" / ".optimus" / "repo"
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Mock git that always fails
-        _create_mock_bin(tmp_path, "git", 'exit 1')
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(cache_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        # F5: strict assertions — both the warning and the skip line must appear.
-        assert "Could not clone repo" in result.stderr
-        assert "(skipped)" in result.stdout
-        assert result.returncode in (0, 1)
+    def test_filters_non_optimus_marketplace_plugins(self, tmp_path: Path) -> None:
+        """Plugins from other marketplaces (not @optimus) are ignored."""
+        installed = [
+            {"id": "optimus-alpha@optimus", "version": "1.0.0", "scope": "user"},
+            {"id": "ring:reviewer@ring", "version": "2.0.0", "scope": "user"},
+            {"id": "vendor-tool@other", "version": "1.0.0", "scope": "user"},
+        ]
+        log = _install_claude_mock(tmp_path, installed_plugins=installed)
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_only_env(tmp_path))
+        assert result.returncode == 0
+        # alpha is updated (already installed under @optimus), no orphan removal,
+        # other-marketplace plugins are NOT touched.
+        assert "Updated: 1" in result.stdout
+        assert "Removed: 0" in result.stdout
+        log_content = log.read_text()
+        assert "plugin uninstall ring" not in log_content
+        assert "plugin uninstall vendor" not in log_content
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Dual platform sync tests
+# Dual-platform sync (both droid + claude installed)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 class TestDualPlatformSync:
+    def _claude_marketplace_env(self, tmp_path: Path) -> dict[str, str]:
+        return {
+            "CLAUDE_MARKETPLACE_FILE": str(
+                tmp_path / "home" / ".claude" / "plugins" / "marketplaces"
+                / "optimus" / ".claude-plugin" / "marketplace.json"),
+        }
+
     def test_syncs_both_platforms_simultaneously(self, tmp_path: Path) -> None:
-        """When both droid and ~/.claude/ are available, sync both."""
-        log = tmp_path / "droid.log"
-        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        droid_log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(droid_log))
         _create_marketplace(tmp_path, ["alpha", "beta"])
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha", "beta"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        result = _run_sync(tmp_path, {
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        })
+        claude_log = _install_claude_mock(tmp_path, installed_plugins=[])
+        result = _run_sync(tmp_path)
         assert result.returncode == 0
-        # Both platform sections should appear
         assert "── Droid (Factory) ──" in result.stdout
         assert "── Claude Code ──" in result.stdout
-        # Both should report success
-        assert "Droid" in result.stdout
-        assert "Claude Code" in result.stdout
-        # Claude Code skills should be installed
-        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
-        assert (skills_dir / "optimus-beta" / "SKILL.md").exists()
+        # Droid installed both via the Source 1 (droid) marketplace.
+        assert "install alpha@optimus" in droid_log.read_text()
+        assert "install beta@optimus" in droid_log.read_text()
+        # Claude installed both via the same EXPECTED list (bare names → prefixed).
+        claude_content = claude_log.read_text()
+        assert "plugin install optimus-alpha@optimus --scope user" in claude_content
+        assert "plugin install optimus-beta@optimus --scope user" in claude_content
 
-    def test_droid_only_when_no_claude_dir(self, tmp_path: Path) -> None:
-        """Without ~/.claude/, only Droid sync runs."""
+    def test_droid_only_when_no_claude_binary(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
         _create_marketplace(tmp_path, ["alpha"])
-        result = _run_sync(tmp_path)
+        result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
         assert "── Droid (Factory) ──" in result.stdout
         assert "── Claude Code ──" not in result.stdout
 
-    def test_claude_only_when_no_droid(self, tmp_path: Path) -> None:
-        """Without droid CLI, only Claude Code sync runs and installs skills."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
+    def test_claude_only_when_no_droid_binary(self, tmp_path: Path) -> None:
+        log = _install_claude_mock(tmp_path, installed_plugins=[])
+        _create_claude_marketplace_cache(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_droid=True,
+                           env_extra=self._claude_marketplace_env(tmp_path))
         assert result.returncode == 0
         assert "── Droid (Factory) ──" not in result.stdout
         assert "── Claude Code ──" in result.stdout
-        # F35: confirm files were actually installed.
-        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
+        assert "plugin install optimus-alpha@optimus --scope user" in log.read_text()
 
     def test_droid_failure_doesnt_block_claude(self, tmp_path: Path) -> None:
-        """If Droid sync fails, Claude Code sync still runs."""
-        log = tmp_path / "droid.log"
-        _create_mock_bin(tmp_path, "droid", _droid_script(log, install_exit=1))
+        """If Droid sync fails, Claude Code sync still runs to completion."""
+        droid_log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(droid_log, install_exit=1))
         _create_marketplace(tmp_path, ["alpha"])
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        })
-        # Overall should fail (droid failed) but Claude Code should succeed
+        claude_log = _install_claude_mock(tmp_path, installed_plugins=[])
+        result = _run_sync(tmp_path)
+        # Aggregated failure (droid failed) but both sections ran.
         assert result.returncode == 1
         assert "── Droid (Factory) ──" in result.stdout
         assert "── Claude Code ──" in result.stdout
-        # Claude Code skill should still be installed
-        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
+        # Claude install was attempted.
+        assert "plugin install optimus-alpha@optimus --scope user" in claude_log.read_text()
+        # Claude's added count must be 1 (not blocked by droid failure).
+        assert "Claude Code — Added: 1" in result.stdout
 
     def test_claude_failure_doesnt_block_droid(self, tmp_path: Path) -> None:
-        """F3: If Claude Code sync fails, Droid sync still completes installs.
-
-        Symmetric to test_droid_failure_doesnt_block_claude.
-        Claude Code is set up to fail at SKILL.md copy (source missing in cache),
-        so it reports FAIL — but Droid path must still run end-to-end.
-        """
-        log = tmp_path / "droid.log"
-        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        """If Claude Code sync fails, Droid sync still completes installs."""
+        droid_log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(droid_log))
         _create_marketplace(tmp_path, ["alpha"])
-        _ensure_claude_dir(tmp_path)
-        # Set up repo cache that has marketplace but is missing SKILL.md → Claude fails.
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").unlink()
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        })
-        # Aggregated failure expected (Claude failed)
+        # Claude install fails for every call.
+        _install_claude_mock(tmp_path, installed_plugins=[], install_exit=1)
+        result = _run_sync(tmp_path)
         assert result.returncode == 1
         assert "── Droid (Factory) ──" in result.stdout
         assert "── Claude Code ──" in result.stdout
-        # Droid must have completed its install.
-        log_content = log.read_text()
-        assert "install alpha@optimus" in log_content
-        # And Claude must have reported the source-not-found failure.
-        assert "source not found" in result.stdout.lower()
+        # Droid still completed its install.
+        assert "install alpha@optimus" in droid_log.read_text()
+        # And Claude reported a failure.
+        assert "Claude Code — Added: 0" in result.stdout
+        assert "Failed: 1" in result.stdout
 
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# README contract (F4)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class TestREADMEContract:
-    def test_bootstrap_oneliner_paths_exist(self) -> None:
-        """README bootstrap one-liner relies on these paths existing in the repo."""
-        repo_root = Path(__file__).resolve().parent.parent
-        skill_path = repo_root / "sync" / "skills" / "optimus-sync" / "SKILL.md"
-        assert skill_path.exists(), f"Missing: {skill_path}"
-        skill_md = skill_path.read_text()
-        assert "name: optimus-sync" in skill_md  # frontmatter sanity
-        # The bootstrap also relies on the sync script.
-        assert (repo_root / "sync" / "scripts" / "sync-user-plugins.sh").exists()
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Plugin name validation (F6)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class TestPluginNameValidation:
-    def test_rejects_plugin_name_with_path_traversal(self, tmp_path: Path) -> None:
-        """Marketplace.json with a name containing '..' must error and not write any files."""
-        log = tmp_path / "droid.log"
-        _create_mock_bin(tmp_path, "droid", _droid_script(log))
-        # Hand-craft a marketplace.json with a malicious name.
-        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
-        mp_dir.mkdir(parents=True)
-        (mp_dir / "marketplace.json").write_text(
-            '{"plugins": [{"name": "../../../etc"}]}'
-        )
-        # Ensure target path doesn't exist before sync.
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        result = _run_sync(tmp_path)
-        assert result.returncode == 1
-        assert "Invalid plugin name" in result.stderr
-        # No directory should have been created at the malicious location.
-        assert not (skills_dir / "optimus-../../../etc").exists()
-        assert not (tmp_path / "home" / ".claude" / "skills" / "etc").exists()
-
-    def test_rejects_plugin_name_with_uppercase(self, tmp_path: Path) -> None:
-        """Names like 'MyPlugin' should be rejected by the regex."""
-        log = tmp_path / "droid.log"
-        _create_mock_bin(tmp_path, "droid", _droid_script(log))
-        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
-        mp_dir.mkdir(parents=True)
-        (mp_dir / "marketplace.json").write_text(
-            '{"plugins": [{"name": "MyPlugin"}]}'
-        )
-        result = _run_sync(tmp_path)
-        assert result.returncode == 1
-        assert "Invalid plugin name" in result.stderr
-
-    def test_rejects_plugin_name_with_leading_dash(self, tmp_path: Path) -> None:
-        """Names starting with '-' should be rejected (must start with [a-z0-9])."""
-        log = tmp_path / "droid.log"
-        _create_mock_bin(tmp_path, "droid", _droid_script(log))
-        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
-        mp_dir.mkdir(parents=True)
-        (mp_dir / "marketplace.json").write_text(
-            '{"plugins": [{"name": "-evil"}]}'
-        )
-        result = _run_sync(tmp_path)
-        assert result.returncode == 1
-        assert "Invalid plugin name" in result.stderr
-
-    def test_accepts_valid_plugin_names(self, tmp_path: Path) -> None:
-        """Names matching ^[a-z0-9][a-z0-9_-]*$ are accepted."""
-        log = tmp_path / "droid.log"
-        _create_mock_bin(tmp_path, "droid", _droid_script(log))
-        # All valid: lowercase start, contain digits, underscores, hyphens.
-        valid_names = ["plan", "build-2", "optimus_helper", "abc", "x1"]
-        _create_marketplace(tmp_path, valid_names)
+    def test_both_marketplace_updates_attempted(self, tmp_path: Path) -> None:
+        """When both platforms are present, both marketplace-refresh calls happen."""
+        droid_log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(droid_log))
+        _create_marketplace(tmp_path, ["alpha"])
+        claude_log = _install_claude_mock(tmp_path, installed_plugins=[])
         result = _run_sync(tmp_path)
         assert result.returncode == 0
-        assert "Invalid plugin name" not in result.stderr
-        for name in valid_names:
-            assert f"+ {name} ... OK" in result.stdout
+        assert "Updating Droid marketplace..." in result.stdout
+        assert "Updating Claude Code marketplace..." in result.stdout
+        # Claude marketplace update is logged with `plugin marketplace update optimus`.
+        assert "plugin marketplace update optimus" in claude_log.read_text()
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Repo cache edge cases (F16)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class TestRepoCacheEdgeCases:
-    def test_repo_cache_corrupt_no_git(self, tmp_path: Path) -> None:
-        """F16: cache dir exists but lacks .git/ → script tries to clone, fails clearly.
-
-        `git clone` will not clone into a non-empty existing directory. Verify the
-        failure surfaces as a clear warning rather than a silent crash.
-        """
-        _ensure_claude_dir(tmp_path)
-        cache_dir = tmp_path / "home" / ".optimus" / "repo"
-        cache_dir.mkdir(parents=True)
-        # Populate without a .git/ directory — simulates a corrupted/manual cache.
-        (cache_dir / "stray.txt").write_text("not a git repo")
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Mock git clone to fail (mimics real `git clone` into non-empty dir).
-        _create_mock_bin(tmp_path, "git", 'if [ "$1" = "clone" ]; then exit 128; fi; exit 0')
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(cache_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        # Graceful: warns and skips Claude Code; exit code may be 0 (Claude skipped, no failures).
-        assert "Could not clone repo" in result.stderr
-        assert "Cloning repo cache" in result.stdout
-        assert "(skipped)" in result.stdout
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Source 3 marketplace resolution (F17 / F28)
+# Marketplace source resolution
 # ═══════════════════════════════════════════════════════════════════════════════
 
 class TestSourceResolution:
-    def test_resolve_expected_uses_source_3(self, tmp_path: Path) -> None:
-        """F17/F28: when Source 1 and Source 2 are absent, fall back to repo root.
-
-        Source 3 requires AGENTS.md AND sync/scripts/sync-user-plugins.sh at repo_root.
-        We simulate this by copying the script into a fake repo with stub AGENTS.md
-        and a marketplace.json at repo_root/.factory-plugin/marketplace.json.
-        """
+    def test_resolves_from_droid_cache_source_1(self, tmp_path: Path) -> None:
+        """Source 1 (~/.factory/marketplaces/.../marketplace.json) takes priority."""
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(log))
-        # Build a fake repo layout.
+        _create_marketplace(tmp_path, ["fromsrc1"])
+        result = _run_sync(tmp_path, exclude_claude=True)
+        assert result.returncode == 0
+        assert "install fromsrc1@optimus" in log.read_text()
+
+    def test_resolves_from_claude_marketplace_cache_source_2(self, tmp_path: Path) -> None:
+        """Source 2 (CLAUDE_MARKETPLACE_FILE) is used when Source 1 is absent.
+
+        Names from this source are PREFIXED (`optimus-foo`) — the script must
+        strip the prefix before exposing them as the EXPECTED bare list.
+        """
+        _install_claude_mock(tmp_path, installed_plugins=[])
+        # No droid binary, no Source 1.
+        mp_path = _create_claude_marketplace_cache(tmp_path, ["fromsrc2"])
+        # isolated=True so Source 3 cannot satisfy from the optimus repo root.
+        result = _run_sync(tmp_path, exclude_droid=True, isolated=True,
+                           env_extra={"CLAUDE_MARKETPLACE_FILE": str(mp_path)})
+        assert result.returncode == 0
+        # Bare name reaches Claude Code with the optimus- prefix re-attached.
+        assert "+ fromsrc2 ... OK" in result.stdout
+
+    def test_resolves_from_repo_factory_plugin_source_3(self, tmp_path: Path) -> None:
+        """Source 3 (in-repo .factory-plugin/marketplace.json) is the fallback when
+        Source 1 and Source 2 are both absent."""
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        # Build a fake repo layout that exposes Source 3.
         fake_repo = tmp_path / "fake_repo"
         (fake_repo / "sync" / "scripts").mkdir(parents=True)
         (fake_repo / ".factory-plugin").mkdir(parents=True)
@@ -981,13 +877,11 @@ class TestSourceResolution:
         )
         # Source 1: empty .factory cache (dir exists but no marketplace.json).
         (tmp_path / "home" / ".factory").mkdir(parents=True)
-        # Source 2: nonexistent OPTIMUS_CACHE_DIR.
         env = os.environ.copy()
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir(exist_ok=True)
-        env["PATH"] = f"{bin_dir}:{env.get('PATH', '/usr/bin')}"
+        env["PATH"] = f"{bin_dir}:{_path_without('claude')}"
         env["HOME"] = str(tmp_path / "home")
-        env["OPTIMUS_CACHE_DIR"] = str(tmp_path / "nonexistent")
         result = subprocess.run(
             [BASH, str(fake_repo / "sync" / "scripts" / "sync-user-plugins.sh")],
             capture_output=True,
@@ -997,125 +891,150 @@ class TestSourceResolution:
         )
         assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
         assert "Added: 1" in result.stdout
-        log_content = log.read_text()
-        assert "install fromsrc3@optimus" in log_content
+        assert "install fromsrc3@optimus" in log.read_text()
 
+    def test_resolves_from_repo_claude_plugin_fallback(self, tmp_path: Path) -> None:
+        """Source 3 fallback: in-repo `.claude-plugin/marketplace.json` is consulted
+        when `.factory-plugin/marketplace.json` is absent. Names use the prefixed
+        form and must be stripped to bare."""
+        _install_claude_mock(tmp_path, installed_plugins=[])
+        fake_repo = tmp_path / "fake_repo"
+        (fake_repo / "sync" / "scripts").mkdir(parents=True)
+        (fake_repo / ".claude-plugin").mkdir(parents=True)
+        shutil.copy2(SCRIPT, fake_repo / "sync" / "scripts" / "sync-user-plugins.sh")
+        (fake_repo / "AGENTS.md").write_text("# AGENTS")
+        (fake_repo / ".claude-plugin" / "marketplace.json").write_text(json.dumps({
+            "name": "optimus",
+            "owner": {"name": "T", "email": "t@e"},
+            "metadata": {"description": "x"},
+            "plugins": [{"name": "optimus-fallback", "source": "./fallback",
+                         "version": "1.0.0", "description": "x"}],
+        }))
+        # No Source 1 (no droid). No Source 2 (no CLAUDE_MARKETPLACE_FILE).
+        env = os.environ.copy()
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        env["PATH"] = f"{bin_dir}:{_path_without('droid', 'claude')}"
+        env["HOME"] = str(tmp_path / "home")
+        result = subprocess.run(
+            [BASH, str(fake_repo / "sync" / "scripts" / "sync-user-plugins.sh")],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+        # Stripped to bare 'fallback' on the EXPECTED list, then re-prefixed for
+        # the Claude Code install command.
+        assert "+ fallback ... OK" in result.stdout
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Symlink safety on orphan removal (F18)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class TestSymlinkSafety:
-    def test_symlinked_orphan_removal_safe(self, tmp_path: Path) -> None:
-        """F18: a symlink in the skills dir must NEVER cause the script to delete the target.
-
-        The current bash `find -type d` does NOT follow symlinks, so symlinked entries
-        are not detected as "installed" and are not candidates for orphan removal.
-        That's the safety guarantee: the symlink target stays untouched regardless.
-        F7 (rm -f before cp) is the install-side defense; this asserts the orphan-side
-        property: even if a symlink with .optimus-managed is present, the target survives.
-        """
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        skills_dir.mkdir(parents=True, exist_ok=True)
-        # Create a sensitive directory elsewhere with content + the .optimus-managed
-        # marker (so even if the script were to follow the symlink, it would still
-        # see the marker and could choose to delete — we want to verify it doesn't).
-        sensitive = tmp_path / "sensitive_data"
-        sensitive.mkdir()
-        (sensitive / "secret.txt").write_text("must-survive")
-        (sensitive / ".optimus-managed").touch()
-        orphan_link = skills_dir / "optimus-foo"
-        orphan_link.symlink_to(sensitive)
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        assert result.returncode == 0
-        # The target directory and its contents must be intact (primary safety property).
-        assert sensitive.exists()
-        assert (sensitive / "secret.txt").exists()
-        assert (sensitive / "secret.txt").read_text() == "must-survive"
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Update-path failure when source not found (F36)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class TestUpdatePathFailures:
-    def test_source_not_found_reports_fail_in_update(self, tmp_path: Path) -> None:
-        """F36: plugin already installed, but missing from cache → FAIL in update path."""
-        _ensure_claude_dir(tmp_path)
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Pre-install alpha locally with marker (simulates prior sync).
-        skill_dir = skills_dir / "optimus-alpha"
-        skill_dir.mkdir(parents=True, exist_ok=True)
-        (skill_dir / "SKILL.md").write_text("previously installed")
-        (skill_dir / ".optimus-managed").touch()
-        # Now remove SKILL.md from cache → update path must report FAIL.
-        (repo_dir / "alpha" / "skills" / "optimus-alpha" / "SKILL.md").unlink()
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        assert result.returncode == 1
-        # The * marker indicates update path (not + which is install).
-        assert "* alpha ... FAIL (source not found)" in result.stdout
-        assert "Failed: 1" in result.stdout
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Stale cache via fetch failure (F37)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class TestStaleCache:
-    def test_warns_on_fetch_failure_existing_cache(self, tmp_path: Path) -> None:
-        """F37: existing valid cache + git fetch fails → cache marked stale, sync proceeds."""
-        _ensure_claude_dir(tmp_path)
-        # install_git_mock=False so we can install our own that fails on fetch.
-        repo_dir = _create_repo_cache(tmp_path, ["alpha"], install_git_mock=False)
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # Mock git: handle `-C path` prefix, emit origin URL on config, fail on fetch.
-        git_script = f"""
-if [ "$1" = "-C" ]; then shift 2; fi
-case "$1" in
-  config) echo "{DEFAULT_OPTIMUS_REPO_URL}"; exit 0 ;;
-  fetch) exit 1 ;;
-  reset) exit 0 ;;
-esac
-exit 0
-"""
-        _create_mock_bin(tmp_path, "git", git_script)
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True)
-        # Sync still proceeds using cached marketplace.
-        assert result.returncode == 0
-        assert "Could not fetch latest" in result.stderr
-        assert "(cache: stale)" in result.stdout
-        # Confirms cached EXPECTED was used.
-        assert (skills_dir / "optimus-alpha" / "SKILL.md").exists()
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Empty marketplace via Source 2 (F38)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-class TestEmptyMarketplaceSource2:
-    def test_fails_on_empty_marketplace_via_source_2(self, tmp_path: Path) -> None:
-        """F38: Source 1 missing, Source 2 (repo cache) empty → exit 1 with 'No plugins found'."""
-        _ensure_claude_dir(tmp_path)
-        # Source 2: repo cache with empty marketplace. Default git mock handles
-        # config/fetch/reset as no-ops returning the right URL.
-        repo_dir = _create_repo_cache(tmp_path, [])
-        skills_dir = tmp_path / "home" / ".claude" / "skills" / "default"
-        # isolated=True so Source 3 (running from inside repo) can't accidentally satisfy.
-        result = _run_sync(tmp_path, env_extra={
-            "OPTIMUS_CACHE_DIR": str(repo_dir),
-            "CLAUDE_SKILLS_DIR": str(skills_dir),
-        }, exclude_droid=True, isolated=True)
+    def test_empty_marketplace_via_source_2_fails(self, tmp_path: Path) -> None:
+        """F38 analog: Source 1 missing, Source 2 is the only available source but
+        the marketplace plugin list is empty → exit 1 with 'No plugins found'."""
+        _install_claude_mock(tmp_path, installed_plugins=[])
+        mp_path = _create_claude_marketplace_cache(tmp_path, [])
+        # isolated=True so Source 3 inside the optimus repo doesn't accidentally satisfy.
+        result = _run_sync(tmp_path, exclude_droid=True, isolated=True,
+                           env_extra={"CLAUDE_MARKETPLACE_FILE": str(mp_path)})
         assert result.returncode == 1
         assert "No plugins found" in result.stderr
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Plugin name validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestPluginNameValidation:
+    def test_rejects_plugin_name_with_path_traversal(self, tmp_path: Path) -> None:
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
+        mp_dir.mkdir(parents=True)
+        (mp_dir / "marketplace.json").write_text(
+            '{"plugins": [{"name": "../../../etc"}]}'
+        )
+        result = _run_sync(tmp_path, exclude_claude=True)
+        assert result.returncode == 1
+        assert "Invalid plugin name" in result.stderr
+
+    def test_rejects_plugin_name_with_uppercase(self, tmp_path: Path) -> None:
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
+        mp_dir.mkdir(parents=True)
+        (mp_dir / "marketplace.json").write_text(
+            '{"plugins": [{"name": "MyPlugin"}]}'
+        )
+        result = _run_sync(tmp_path, exclude_claude=True)
+        assert result.returncode == 1
+        assert "Invalid plugin name" in result.stderr
+
+    def test_rejects_plugin_name_with_leading_dash(self, tmp_path: Path) -> None:
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        mp_dir = tmp_path / "home" / ".factory" / "marketplaces" / "optimus" / ".factory-plugin"
+        mp_dir.mkdir(parents=True)
+        (mp_dir / "marketplace.json").write_text(
+            '{"plugins": [{"name": "-evil"}]}'
+        )
+        result = _run_sync(tmp_path, exclude_claude=True)
+        assert result.returncode == 1
+        assert "Invalid plugin name" in result.stderr
+
+    def test_accepts_valid_plugin_names(self, tmp_path: Path) -> None:
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        valid_names = ["plan", "build-2", "optimus_helper", "abc", "x1"]
+        _create_marketplace(tmp_path, valid_names)
+        result = _run_sync(tmp_path, exclude_claude=True)
+        assert result.returncode == 0
+        assert "Invalid plugin name" not in result.stderr
+        for name in valid_names:
+            assert f"+ {name} ... OK" in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Custom OPTIMUS_REPO_URL surfacing
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCustomRepoURL:
+    def test_announces_custom_repo_url(self, tmp_path: Path) -> None:
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        _create_marketplace(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_claude=True, env_extra={
+            "OPTIMUS_REPO_URL": "https://example.com/fork/optimus",
+        })
+        assert result.returncode == 0
+        assert "Note: using custom OPTIMUS_REPO_URL=https://example.com/fork/optimus" in result.stdout
+
+    def test_does_not_announce_default_repo_url(self, tmp_path: Path) -> None:
+        log = tmp_path / "droid.log"
+        _create_mock_bin(tmp_path, "droid", _droid_script(log))
+        _create_marketplace(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_claude=True)
+        assert result.returncode == 0
+        assert "Note: using custom OPTIMUS_REPO_URL" not in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bootstrap path contract
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestBootstrapContract:
+    def test_bootstrap_paths_exist(self) -> None:
+        """The bootstrap one-liner relies on a specific set of repo files.
+
+        Post-refactor: the in-repo Claude Code marketplace
+        (`.claude-plugin/marketplace.json`) is now part of the contract — Source
+        3 falls back to it when Source 1 / 2 are missing.
+        """
+        repo_root = Path(__file__).resolve().parent.parent
+        skill_path = repo_root / "sync" / "skills" / "optimus-sync" / "SKILL.md"
+        assert skill_path.exists(), f"Missing: {skill_path}"
+        skill_md = skill_path.read_text()
+        assert "name: optimus-sync" in skill_md
+        assert (repo_root / "sync" / "scripts" / "sync-user-plugins.sh").exists()
+        # Both marketplace files must exist so dual-platform bootstrap works.
+        assert (repo_root / ".claude-plugin" / "marketplace.json").exists()
+        assert (repo_root / ".factory-plugin" / "marketplace.json").exists()

--- a/sync/scripts/sync-user-plugins.sh
+++ b/sync/scripts/sync-user-plugins.sh
@@ -4,12 +4,18 @@ set -euo pipefail
 # Syncs installed Optimus plugins with the marketplace.
 # Supports two platforms:
 #   - Droid (Factory): uses `droid plugin install/update/uninstall`
-#   - Claude Code: copies SKILL.md files to ~/.claude/skills/default/optimus-<name>/
+#   - Claude Code: uses `claude plugin install/update/uninstall` (native plugin system)
 #
 # Detects which platforms are available and syncs both in a single run.
 # - Installs new plugins that were added to the marketplace
 # - Removes orphaned plugins that were removed from the marketplace
 # - Updates all existing plugins (with uninstall+reinstall fallback for Droid scope conflicts)
+#
+# Plugin name conventions:
+#   - Droid:        bare names (e.g. `plan`, `build`, `sync`) — matches `.factory-plugin/marketplace.json`
+#   - Claude Code:  prefixed names (e.g. `optimus-plan`) — matches `.claude-plugin/marketplace.json`
+#   - The EXPECTED list returned by `_resolve_expected_plugins` is in BARE form (legacy contract).
+#     `_sync_claude_code` adds the `optimus-` prefix when building Claude Code commands.
 
 _error() { echo "ERROR: $*" >&2; }
 _warn() { echo "WARNING: $*" >&2; }
@@ -19,15 +25,14 @@ trap 'echo ""; _warn "Sync interrupted. Re-run /optimus-sync to complete."; exit
 # ─── Configurable constants ───────────────────────────────────────────────────
 readonly MARKETPLACE_NAME="${OPTIMUS_MARKETPLACE_NAME:-optimus}"
 readonly DROID_TIMEOUT="${OPTIMUS_DROID_TIMEOUT:-60}"
-readonly OPTIMUS_CACHE_DIR="${OPTIMUS_CACHE_DIR:-$HOME/.optimus/repo}"
-readonly CLAUDE_SKILLS_DIR="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills/default}"
 readonly OPTIMUS_REPO_URL="${OPTIMUS_REPO_URL:-https://github.com/alexgarzao/optimus}"
+readonly CLAUDE_MARKETPLACE_FILE="${CLAUDE_MARKETPLACE_FILE:-$HOME/.claude/plugins/marketplaces/${MARKETPLACE_NAME}/.claude-plugin/marketplace.json}"
 
 # ─── Platform detection ───────────────────────────────────────────────────────
 HAS_DROID=false
 HAS_CLAUDE_CODE=false
 command -v droid >/dev/null 2>&1 && HAS_DROID=true
-[ -d "$HOME/.claude/skills" ] && HAS_CLAUDE_CODE=true
+command -v claude >/dev/null 2>&1 && HAS_CLAUDE_CODE=true
 
 # ─── Validate inputs ─────────────────────────────────────────────────────────
 if [ "$HAS_DROID" = true ]; then
@@ -40,7 +45,7 @@ fi
 if [ "$HAS_DROID" = false ] && [ "$HAS_CLAUDE_CODE" = false ]; then
   _error "No supported platform found."
   echo "  Install Droid from: https://docs.factory.ai" >&2
-  echo "  Or create ~/.claude/skills/ for Claude Code support." >&2
+  echo "  Or install Claude Code: https://docs.anthropic.com/claude-code" >&2
   exit 1
 fi
 
@@ -83,20 +88,25 @@ _compute_diffs() {
 }
 
 # ─── Get expected plugins from marketplace JSON ──────────────────────────────
-# Resolves marketplace.json from: Droid cache, Optimus repo cache, or repo root.
-# Returns the list of expected plugin names (sorted, one per line) via stdout.
+# Resolves marketplace.json from one of three sources, preferring fresher caches.
+# Returns the list of expected plugin names in BARE form (one per line, sorted)
+# via stdout. Both Droid (`.factory-plugin/marketplace.json`) and Claude Code
+# (`.claude-plugin/marketplace.json`) sources are supported; for Claude Code the
+# `optimus-` prefix is stripped so the contract stays bare across platforms.
 
 _resolve_expected_plugins() {
   local marketplace_file=""
+  local strip_prefix=false
 
   # Source 1: Droid marketplace cache
   if [ "$HAS_DROID" = true ]; then
     marketplace_file=$(find ~/.factory -path "*/marketplaces/${MARKETPLACE_NAME}/.factory-plugin/marketplace.json" -type f 2>/dev/null | head -1)
   fi
 
-  # Source 2: Optimus repo cache
-  if [ -z "$marketplace_file" ] && [ -f "$OPTIMUS_CACHE_DIR/.factory-plugin/marketplace.json" ]; then
-    marketplace_file="$OPTIMUS_CACHE_DIR/.factory-plugin/marketplace.json"
+  # Source 2: Claude Code marketplace cache
+  if [ -z "$marketplace_file" ] && [ "$HAS_CLAUDE_CODE" = true ] && [ -f "$CLAUDE_MARKETPLACE_FILE" ]; then
+    marketplace_file="$CLAUDE_MARKETPLACE_FILE"
+    strip_prefix=true
   fi
 
   # Source 3: Running from inside the optimus repo
@@ -108,19 +118,31 @@ _resolve_expected_plugins() {
     if [ -f "$repo_root/AGENTS.md" ] && [ -f "$repo_root/sync/scripts/sync-user-plugins.sh" ]; then
       if [ -f "$repo_root/.factory-plugin/marketplace.json" ]; then
         marketplace_file="$repo_root/.factory-plugin/marketplace.json"
+      elif [ -f "$repo_root/.claude-plugin/marketplace.json" ]; then
+        marketplace_file="$repo_root/.claude-plugin/marketplace.json"
+        strip_prefix=true
       fi
     fi
   fi
 
   if [ -z "$marketplace_file" ]; then
     _error "Marketplace '${MARKETPLACE_NAME}' not found. Register it first:"
-    echo "  droid plugin marketplace add ${OPTIMUS_REPO_URL}" >&2
-    echo "  Or run: git clone --depth 1 ${OPTIMUS_REPO_URL} ${OPTIMUS_CACHE_DIR}" >&2
+    if [ "$HAS_DROID" = true ]; then
+      echo "  droid plugin marketplace add ${OPTIMUS_REPO_URL}" >&2
+    fi
+    if [ "$HAS_CLAUDE_CODE" = true ]; then
+      echo "  claude plugin marketplace add ${OPTIMUS_REPO_URL}" >&2
+    fi
     return 1
   fi
 
   local expected
-  expected=$(jq -r '.plugins[].name' "$marketplace_file" | sort)
+  if [ "$strip_prefix" = true ]; then
+    # Claude Code marketplace uses `optimus-<name>` — strip prefix to get bare names.
+    expected=$(jq -r '.plugins[].name' "$marketplace_file" | sed 's/^optimus-//' | sort)
+  else
+    expected=$(jq -r '.plugins[].name' "$marketplace_file" | sort)
+  fi
   if [ -z "$expected" ]; then
     _error "No plugins found in marketplace."
     return 1
@@ -339,70 +361,38 @@ _sync_droid() {
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Repo Cache Management (used by Claude Code sync and as marketplace fallback)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-# Track whether repo cache is usable (set by _ensure_repo_cache).
-# Possible values: "true" (fresh), "stale" (cached but fetch failed), "false" (unusable).
-_REPO_CACHE_OK="false"
-
-_ensure_repo_cache() {
-  local repo_dir="$OPTIMUS_CACHE_DIR"
-
-  if [ -d "$repo_dir/.git" ]; then
-    # Verify the cache origin matches OPTIMUS_REPO_URL before using it.
-    local actual_url
-    actual_url=$(git -C "$repo_dir" config --get remote.origin.url 2>/dev/null || echo "")
-    if [ "$actual_url" != "$OPTIMUS_REPO_URL" ]; then
-      _error "Repo cache at $repo_dir has unexpected origin: '$actual_url' (expected '$OPTIMUS_REPO_URL'). Refusing to use it. Delete it manually if intentional."
-      _REPO_CACHE_OK="false"
-      return 0  # Soft failure — script can continue if Source 1 or 3 work
-    fi
-
-    echo "Updating repo cache..."
-    if ! git -C "$repo_dir" fetch --depth 1 origin main 2>/dev/null; then
-      _warn "Could not fetch latest. Using cached (possibly stale) version."
-      _REPO_CACHE_OK="stale"
-    else
-      git -C "$repo_dir" reset --hard origin/main 2>/dev/null || true
-      _REPO_CACHE_OK="true"
-    fi
-  else
-    echo "Cloning repo cache..."
-    if git clone --depth 1 "$OPTIMUS_REPO_URL" "$repo_dir" 2>/dev/null; then
-      _REPO_CACHE_OK="true"
-    else
-      _warn "Could not clone repo. Claude Code sync requires a repo cache."
-      echo "  Run: git clone --depth 1 ${OPTIMUS_REPO_URL} ${repo_dir}" >&2
-      _REPO_CACHE_OK="false"
-    fi
-  fi
-}
-
-# ═══════════════════════════════════════════════════════════════════════════════
 # Claude Code Sync
 # ═══════════════════════════════════════════════════════════════════════════════
+#
+# Schema observed for `claude plugin list --json` (Claude Code 2.1.x):
+#   [
+#     {
+#       "id": "<plugin-name>@<marketplace-name>",
+#       "version": "1.0.0",
+#       "scope": "user",
+#       "enabled": true,
+#       "installPath": "/Users/.../.claude/plugins/cache/<marketplace>/<plugin>/<version>",
+#       "installedAt": "2026-...",
+#       "lastUpdated": "2026-...",
+#       "gitCommitSha": "..."   // optional
+#       "mcpServers": {...}     // optional
+#     },
+#     ...
+#   ]
+# We filter by marketplace via `select(.id | endswith("@<marketplace>"))`.
 
 _sync_claude_code() {
-  local expected="$1"
+  local expected="$1"  # bare plugin names, one per line, sorted
+  local marketplace="${2:-$MARKETPLACE_NAME}"
+
   echo "── Claude Code ──"
   echo ""
 
-  local repo_dir="$OPTIMUS_CACHE_DIR"
-
-  if [ "$_REPO_CACHE_OK" = "false" ]; then
-    echo "  Claude Code — Added: 0 | Updated: 0 | Removed: 0 | Failed: 0 (skipped)"
-    return 0
-  fi
-
-  local skills_dir="$CLAUDE_SKILLS_DIR"
-  mkdir -p "$skills_dir"
-
-  # Get currently installed optimus skills
+  # Get currently installed optimus plugins (bare names, sorted)
   local installed=""
-  if [ -d "$skills_dir" ]; then
-    installed=$(find "$skills_dir" -maxdepth 1 -type d -name 'optimus-*' -exec basename {} \; 2>/dev/null | sed 's/^optimus-//' | sort) || true
-  fi
+  installed=$(claude plugin list --json 2>/dev/null \
+    | jq -r --arg mp "@${marketplace}" '.[] | select(.id | endswith($mp)) | .id | sub("@.*$"; "") | sub("^optimus-"; "")' \
+    | sort) || true
 
   # Calculate diffs
   _compute_diffs "$expected" "$installed"
@@ -410,90 +400,52 @@ _sync_claude_code() {
   local orphaned_plugins="$ORPHANED_PLUGINS"
   local existing_plugins="$EXISTING_PLUGINS"
 
-  local added=0 updated=0 removed=0 failed=0 unchanged=0
+  local added=0 updated=0 removed=0 failed=0
 
   # Install new plugins
   if [ -n "$new_plugins" ]; then
     while IFS= read -r plugin; do
       [ -z "$plugin" ] && continue
-      local src="$repo_dir/${plugin}/skills/optimus-${plugin}/SKILL.md"
-      local dest_dir="$skills_dir/optimus-${plugin}"
-      if [ -f "$src" ]; then
-        mkdir -p "$dest_dir"
-        rm -f "$dest_dir/SKILL.md"
-        cp "$src" "$dest_dir/SKILL.md"
-        touch "$dest_dir/.optimus-managed"
+      if claude plugin install "optimus-${plugin}@${marketplace}" --scope user >/dev/null 2>&1; then
         echo "  + $plugin ... OK"
         added=$((added + 1))
       else
-        echo "  + $plugin ... FAIL (source not found)"
+        echo "  + $plugin ... FAIL"
         failed=$((failed + 1))
       fi
     done <<< "$new_plugins"
   fi
 
-  # Update existing plugins (skip if unchanged)
+  # Update existing plugins
   if [ -n "$existing_plugins" ]; then
     while IFS= read -r plugin; do
       [ -z "$plugin" ] && continue
-      local src="$repo_dir/${plugin}/skills/optimus-${plugin}/SKILL.md"
-      local dest_dir="$skills_dir/optimus-${plugin}"
-      local dest="$dest_dir/SKILL.md"
-      if [ ! -f "$src" ]; then
-        echo "  * $plugin ... FAIL (source not found)"
-        failed=$((failed + 1))
-        continue
-      fi
-      if [ -f "$dest" ] && diff -q "$src" "$dest" >/dev/null 2>&1; then
-        echo "  * $plugin ... unchanged"
-        unchanged=$((unchanged + 1))
-        # Idempotently ensure the marker exists for pre-existing installs.
-        touch "$dest_dir/.optimus-managed"
-      else
-        mkdir -p "$dest_dir"
-        rm -f "$dest"
-        cp "$src" "$dest"
-        touch "$dest_dir/.optimus-managed"
+      if claude plugin update "optimus-${plugin}@${marketplace}" >/dev/null 2>&1; then
         echo "  * $plugin ... OK"
         updated=$((updated + 1))
+      else
+        echo "  * $plugin ... FAIL"
+        failed=$((failed + 1))
       fi
     done <<< "$existing_plugins"
   fi
 
-  # Remove orphaned plugins (ONLY optimus- prefixed, ONLY with .optimus-managed marker)
+  # Remove orphaned plugins
   if [ -n "$orphaned_plugins" ]; then
     while IFS= read -r plugin; do
       [ -z "$plugin" ] && continue
-      local target_dir="$skills_dir/optimus-${plugin}"
-      if [ -d "$target_dir" ]; then
-        if [ -f "$target_dir/.optimus-managed" ]; then
-          if rm -rf "$target_dir" 2>/dev/null; then
-            echo "  - $plugin"
-            removed=$((removed + 1))
-          else
-            echo "  - $plugin (FAIL)"
-            failed=$((failed + 1))
-          fi
-        else
-          echo "  - $plugin (skipped — no .optimus-managed marker; user-created?)"
-          # Not counted as removed or failed
-        fi
-      else
-        echo "  - $plugin (already gone)"
+      if claude plugin uninstall "optimus-${plugin}@${marketplace}" >/dev/null 2>&1; then
+        echo "  - $plugin ... OK"
         removed=$((removed + 1))
+      else
+        echo "  - $plugin ... FAIL"
+        failed=$((failed + 1))
       fi
     done <<< "$orphaned_plugins"
   fi
 
   echo ""
-  local summary="Claude Code — Added: $added | Updated: $updated | Removed: $removed | Failed: $failed"
-  if [ "$unchanged" -gt 0 ]; then
-    summary="$summary | Unchanged: $unchanged"
-  fi
-  if [ "$_REPO_CACHE_OK" = "stale" ]; then
-    summary="$summary (cache: stale)"
-  fi
-  echo "  $summary"
+  echo "  Claude Code — Added: $added | Updated: $updated | Removed: $removed | Failed: $failed"
 
   [ "$failed" -gt 0 ] && return 1
   return 0
@@ -526,7 +478,8 @@ if [ "$HAS_DROID" = true ]; then
   _droid plugin marketplace update "$MARKETPLACE_NAME" >/dev/null 2>&1 || _warn "Could not update Droid marketplace. Using cached version."
 fi
 if [ "$HAS_CLAUDE_CODE" = true ]; then
-  _ensure_repo_cache
+  echo "Updating Claude Code marketplace..."
+  claude plugin marketplace update "$MARKETPLACE_NAME" >/dev/null 2>&1 || _warn "Could not update Claude Code marketplace. Using cached version."
 fi
 echo ""
 
@@ -543,7 +496,7 @@ if [ "$HAS_DROID" = true ]; then
 fi
 
 if [ "$HAS_CLAUDE_CODE" = true ]; then
-  _sync_claude_code "$EXPECTED" || claude_rc=$?
+  _sync_claude_code "$EXPECTED" "$MARKETPLACE_NAME" || claude_rc=$?
   echo ""
 fi
 

--- a/sync/skills/optimus-sync/SKILL.md
+++ b/sync/skills/optimus-sync/SKILL.md
@@ -8,10 +8,10 @@ trigger: >
 skip_when: >
   - User wants to install a single specific plugin (use `droid plugin install` directly)
 prerequisite: >
-  - At least one supported platform: droid CLI installed OR ~/.claude/skills/ directory exists
+  - At least one supported platform: droid CLI installed OR claude CLI installed
   - jq installed and available
   - For Droid: Optimus marketplace registered (`droid plugin marketplace add https://github.com/alexgarzao/optimus`)
-  - For Claude Code: git installed (for repo cache clone/update)
+  - For Claude Code: Optimus marketplace registered (`claude plugin marketplace add https://github.com/alexgarzao/optimus`) — one-time setup
 NOT_skip_when: >
   - "I'll update plugins manually" -- optimus-sync handles scope conflicts and orphan removal automatically.
   - "Only one plugin needs updating" -- sync is optimized for batch operations and ensures consistency.
@@ -20,7 +20,7 @@ examples:
     invocation: "/optimus-sync"
     expected_flow: >
       1. Detect available platforms (Droid, Claude Code, or both)
-      2. Update marketplace / repo cache
+      2. Update each platform's marketplace cache
       3. Calculate changes per platform (new/orphaned/existing)
       4. Execute each operation with progress
       5. Show per-platform summary
@@ -35,7 +35,7 @@ verification:
     - At least one platform detected
     - New plugins installed successfully
     - Orphaned plugins removed
-    - Existing plugins updated (or skipped if unchanged on Claude Code)
+    - Existing plugins updated
     - Per-platform summary shows correct counts
 ---
 
@@ -58,11 +58,11 @@ Check that at least one supported platform is available.
 ```bash
 HAS_DROID=false; HAS_CLAUDE_CODE=false
 command -v droid >/dev/null 2>&1 && HAS_DROID=true
-[ -d "$HOME/.claude/skills" ] && HAS_CLAUDE_CODE=true
+command -v claude >/dev/null 2>&1 && HAS_CLAUDE_CODE=true
 echo "Droid: $HAS_DROID | Claude Code: $HAS_CLAUDE_CODE"
 ```
 
-If both are `false`, **STOP**: "No supported platform found. Install Droid from https://docs.factory.ai or create ~/.claude/skills/ for Claude Code support."
+If both are `false`, **STOP**: "No supported platform found. Install Droid from https://docs.factory.ai or install Claude Code from https://docs.anthropic.com/claude-code."
 
 ### Step 1.2: Check jq
 
@@ -82,15 +82,14 @@ If `jq` is not found, **STOP**: "jq is required but not installed."
 droid plugin marketplace update optimus 2>&1 || echo "WARNING: Could not update marketplace. Proceeding with cached version."
 ```
 
-### Step 2.2: Claude Code repo cache (if available)
+### Step 2.2: Claude Code marketplace (if available)
 
-The repo cache lives at `~/.optimus/repo/` (configurable via `OPTIMUS_CACHE_DIR`).
+```bash
+claude plugin marketplace update optimus 2>&1 || echo "WARNING: Could not update Claude Code marketplace. Proceeding with cached version."
+```
 
-- If cache exists: `git -C ~/.optimus/repo fetch --depth 1 origin main && git -C ~/.optimus/repo reset --hard origin/main`
-- If no cache: `git clone --depth 1 https://github.com/alexgarzao/optimus ~/.optimus/repo`
-- If clone/fetch fails: warn and skip Claude Code sync
-
-Show the result to the user before proceeding.
+If the marketplace is not registered, the user must register it once with:
+`claude plugin marketplace add https://github.com/alexgarzao/optimus`
 
 ---
 
@@ -100,8 +99,12 @@ Show the result to the user before proceeding.
 
 The script resolves the marketplace JSON from multiple sources (in priority order):
 1. Droid marketplace cache (`~/.factory/marketplaces/optimus/`)
-2. Optimus repo cache (`~/.optimus/repo/.factory-plugin/marketplace.json`)
-3. Running from inside the optimus repo (relative path)
+2. Claude Code marketplace cache (`~/.claude/plugins/marketplaces/optimus/.claude-plugin/marketplace.json`)
+3. Running from inside the optimus repo (`.factory-plugin/marketplace.json` or `.claude-plugin/marketplace.json`)
+
+Plugin names returned by the resolver are always in BARE form (e.g. `plan`,
+`build`, `sync`). When the source is a Claude Code marketplace (which uses
+`optimus-<name>`), the resolver strips the `optimus-` prefix.
 
 ### Step 3.2: Get expected plugins
 
@@ -122,7 +125,9 @@ droid plugin list 2>/dev/null | grep -F "@optimus" | awk '{print $1}' | sed 's/@
 
 **Claude Code:**
 ```bash
-find ~/.claude/skills/default -maxdepth 1 -type d -name 'optimus-*' -exec basename {} \; | sed 's/^optimus-//' | sort
+claude plugin list --json 2>/dev/null \
+  | jq -r '.[] | select(.id | endswith("@optimus")) | .id | sub("@.*$"; "") | sub("^optimus-"; "")' \
+  | sort
 ```
 
 ### Step 3.4: Calculate diffs per platform
@@ -140,11 +145,51 @@ Compare `EXPECTED` vs each platform's `INSTALLED` to determine three lists per p
 Run the sync shell script. The script detects platforms, syncs both, and prints
 a per-platform summary.
 
-Resolve script path (prefer local repo, fall back to cache):
+Resolve script path with this fallback order:
+1. Inside the optimus repo (developer running locally)
+2. Legacy `~/.optimus/repo/` clone (PR #9 era — backwards compat for Droid users)
+3. Claude Code plugin install path — discovered dynamically via `claude plugin list --json`
+   so we never hardcode the version. Falls back to a versioned path if the dynamic
+   lookup fails (e.g. `claude` not on PATH).
 
 ```bash
-SCRIPT="${OPTIMUS_CACHE_DIR:-$HOME/.optimus/repo}/sync/scripts/sync-user-plugins.sh"
-[ -f sync/scripts/sync-user-plugins.sh ] && SCRIPT="sync/scripts/sync-user-plugins.sh"
+SCRIPT=""
+
+# 1. Local repo
+if [ -f sync/scripts/sync-user-plugins.sh ]; then
+  SCRIPT="sync/scripts/sync-user-plugins.sh"
+fi
+
+# 2. Legacy ~/.optimus/repo clone
+if [ -z "$SCRIPT" ]; then
+  CANDIDATE="${OPTIMUS_CACHE_DIR:-$HOME/.optimus/repo}/sync/scripts/sync-user-plugins.sh"
+  [ -f "$CANDIDATE" ] && SCRIPT="$CANDIDATE"
+fi
+
+# 3. Claude Code plugin install path (version-agnostic via JSON lookup)
+if [ -z "$SCRIPT" ] && command -v claude >/dev/null 2>&1; then
+  INSTALL_PATH=$(claude plugin list --json 2>/dev/null \
+    | jq -r '.[] | select(.id == "optimus-sync@optimus") | .installPath' \
+    | head -1)
+  if [ -n "$INSTALL_PATH" ] && [ -f "$INSTALL_PATH/sync/scripts/sync-user-plugins.sh" ]; then
+    SCRIPT="$INSTALL_PATH/sync/scripts/sync-user-plugins.sh"
+  fi
+fi
+
+# 3b. Versioned-path fallback if `claude plugin list --json` failed.
+# NOTE: 1.0.0 is the version pinned in .claude-plugin/marketplace.json. If that
+# version changes, update this fallback too — but the dynamic lookup above is
+# the preferred resolver and should normally make this unnecessary.
+if [ -z "$SCRIPT" ]; then
+  CANDIDATE="$HOME/.claude/plugins/cache/optimus/optimus-sync/1.0.0/sync/scripts/sync-user-plugins.sh"
+  [ -f "$CANDIDATE" ] && SCRIPT="$CANDIDATE"
+fi
+
+if [ -z "$SCRIPT" ]; then
+  echo "ERROR: Could not locate sync-user-plugins.sh" >&2
+  exit 1
+fi
+
 bash "$SCRIPT" 2>&1
 ```
 
@@ -160,7 +205,7 @@ Present the final summary using `<json-render>` with **per-platform** metrics:
 === Sync Complete ===
 
 Droid — Added: N | Updated: N | Removed: N | Failed: N
-Claude Code — Added: N | Updated: N | Removed: N | Failed: N | Unchanged: N
+Claude Code — Added: N | Updated: N | Removed: N | Failed: N
 ```
 
 Only show platforms that were detected and synced.
@@ -171,14 +216,16 @@ Only show platforms that were detected and synced.
 
 - All Droid plugin operations run in **parallel** via a single Execute call — no separate
   calls per plugin. This makes sync complete in ~6-8 seconds instead of ~2 minutes.
-- Claude Code operations are sequential (filesystem copies are fast enough).
+- Claude Code operations are sequential (one `claude plugin install/update/uninstall`
+  call per plugin). Claude Code's plugin daemon owns the cache, so parallelizing
+  is unnecessary and risks contention on shared state.
 - If a plugin operation fails, the script logs it and continues. Do NOT stop
   the entire sync on a single failure.
 - If the user cancels mid-sync or the session is interrupted, inform them:
   "Sync interrupted. Some plugins may be partially updated. Re-run `/optimus-sync` to complete."
 - The `make sync-plugins` target in the project Makefile runs `sync/scripts/sync-user-plugins.sh`
-  directly. Both the agent skill and CLI use the same parallel script.
-- Claude Code sync **only** touches `optimus-*` directories under `~/.claude/skills/default/`.
-  It never modifies other skill directories (e.g., `ring:*`, user-created skills).
+  directly. Both the agent skill and CLI use the same script.
+- Claude Code sync **only** touches `optimus-<name>@optimus` plugins via the native
+  plugin system. Other marketplaces and user-created skills are untouched.
 - Command aliases (`/sp`, `/bd`, etc.) are **not supported** on Claude Code — only
   `/optimus-<name>` invocations work. This is a platform limitation.


### PR DESCRIPTION
## Why

PR #9 added Claude Code support by copying SKILL.md files to
`~/.claude/skills/default/optimus-*/`. **It doesn't work.** Claude Code only
auto-discovers skills installed via its own plugin system
(`claude plugin install`), not arbitrary file placements. After PR #9 was
merged, dogfooding revealed that `/optimus-sync` never appeared as a slash
command despite the bootstrap "succeeding."

Root cause: the plugin discovery mechanism on Claude Code is entirely
plugin-system-based. Files placed manually under `~/.claude/skills/<team>/`
are silently ignored. The PR #9 design assumed parity with Droid (where
file placement IS the install), and none of the 6 reviewers caught it
because none had the Claude Code plugin system in their context.

## What

Ship Optimus as a proper Claude Code marketplace.

- `.claude-plugin/marketplace.json` — Claude Code marketplace manifest with
  17 plugins, mirroring `.factory-plugin/marketplace.json`. Validated with
  `claude plugin validate`.
- `_sync_claude_code` rewritten to use `claude plugin install/update/uninstall`
  and query installed state via `claude plugin list --json`.
- Detection switches from `[ -d ~/.claude/skills ]` to `command -v claude`.
- `_resolve_expected_plugins` Source 2 now reads
  `~/.claude/plugins/marketplaces/optimus/.claude-plugin/marketplace.json`.
- Plugin name format: BARE for Droid (`plan`, `build`), PREFIXED for
  Claude Code (`optimus-plan`, `optimus-build`). Script normalizes
  internally; `_sync_claude_code` adds prefix when issuing commands.
- Removed obsolete code from PR #9: `_ensure_repo_cache`, `_REPO_CACHE_OK`
  (and its tri-state stale handling), `CLAUDE_SKILLS_DIR`,
  `OPTIMUS_CACHE_DIR` (script-level — SKILL.md still uses it as
  backwards-compat hint), `.optimus-managed` marker logic, symlink-defense
  before cp, "(skipped — no marker)" output, "(already gone)" output,
  "Unchanged: N" summary count.
- 13 obsolete tests deleted, 22 new tests added, ~16 adapted (208 total
  pass; was 207).

## Bootstrap is now

\`\`\`bash
claude plugin marketplace add https://github.com/alexgarzao/optimus
claude plugin install optimus-sync@optimus
\`\`\`

Reopen Claude Code → run `/optimus-sync` → it installs the rest via
`claude plugin install`.

## Tested end-to-end

- `claude plugin validate` passes
- `claude plugin marketplace add /Users/.../optimus` succeeds
- `claude plugin install optimus-sync@optimus` succeeds — files land at
  `~/.claude/plugins/cache/optimus/optimus-sync/1.0.0/skills/optimus-sync/SKILL.md`
- `installed_plugins.json` registers `optimus-sync@optimus`
- `make test` → 208 passed
- `make lint` → PASS

## Test plan

- [ ] Open the PR and merge to main
- [ ] On a fresh Claude Code install: run the bootstrap, restart, verify `/optimus-sync` appears
- [ ] Run `/optimus-sync` → verify the other 16 plugins install via `claude plugin install`
- [ ] Run `/optimus-plan` (or any installed plugin) → verify it works
- [ ] Verify Droid users (separate machine) are not regressed