### PR TITLE
feat(tasks)!: rename tasks.md to optimus-tasks.md

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "optimus-import",
       "source": "./import",
       "version": "1.0.0",
-      "description": "Import Ring pre-dev artifacts into optimus format. Creates tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
+      "description": "Import Ring pre-dev artifacts into optimus format. Creates optimus-tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
       "license": "MIT"
@@ -93,7 +93,7 @@
       "name": "optimus-resolve",
       "source": "./resolve",
       "version": "1.0.0",
-      "description": "Administrative: Resolves merge conflicts in tasks.md caused by parallel task execution across feature branches.",
+      "description": "Administrative: Resolves merge conflicts in optimus-tasks.md caused by parallel task execution across feature branches.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
       "license": "MIT"

--- a/.factory-plugin/marketplace.json
+++ b/.factory-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "import",
-      "description": "Import Ring pre-dev artifacts into optimus format. Creates tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
+      "description": "Import Ring pre-dev artifacts into optimus format. Creates optimus-tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
       "source": "./import"
     },
     {
@@ -52,7 +52,7 @@
     },
     {
       "name": "resolve",
-      "description": "Administrative: Resolves merge conflicts in tasks.md caused by parallel task execution across feature branches.",
+      "description": "Administrative: Resolves merge conflicts in optimus-tasks.md caused by parallel task execution across feature branches.",
       "source": "./resolve"
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ optimus/
 ├── report/                    # Admin: Task status dashboard (read-only)
 ├── tasks/                      # Admin: Create, edit, remove, reorder tasks
 ├── batch/                     # Admin: Pipeline orchestrator (stages 1-4)
-├── resolve/          # Admin: Resolve tasks.md merge conflicts
+├── resolve/          # Admin: Resolve optimus-tasks.md merge conflicts
 ├── plan/              # Execution Stage 1: Spec validation + workspace creation
 ├── build/              # Execution Stage 2: Task implementation
 ├── review/      # Execution Stage 3: Implementation review
@@ -58,9 +58,9 @@ through Ring's pre-dev for specification, and Ring droids for execution. There i
 no standalone mode. Ring pre-dev artifacts are the source of truth for task content.
 The location of Ring artifacts is configurable via `tasksDir` in `.optimus/config.json`
 (default: `docs/pre-dev`). Optimus tracks structural data (dependencies, versions,
-priorities) in `<tasksDir>/tasks.md` — co-located with the Ring pre-dev artifacts —
+priorities) in `<tasksDir>/optimus-tasks.md` — co-located with the Ring pre-dev artifacts —
 and operational state (status, branch) in `.optimus/state.json` (gitignored). The
-`TaskSpec` column in tasks.md points to each task's Ring spec. `tasksDir` may live
+`TaskSpec` column in optimus-tasks.md points to each task's Ring spec. `tasksDir` may live
 in the same git repo as the project code (default) or in a **separate git repo** for
 teams that keep task tracking independent from production code.
 
@@ -208,9 +208,9 @@ Run `/optimus-sync` or `make sync-plugins`. This command:
 
 This is the recommended way for end users to stay up to date.
 
-## tasks.md Format
+## optimus-tasks.md Format
 
-Every project using the cycle pipeline MUST have a `tasks.md` file. This is the single
+Every project using the cycle pipeline MUST have an `optimus-tasks.md` file. This is the single
 source of truth for task tracking.
 
 ### File Location
@@ -232,7 +232,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -247,7 +247,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -260,7 +260,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -274,7 +274,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -296,10 +296,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -307,7 +307,7 @@ repo, it is committed there.
 
 ### Format Marker
 
-The **first line** of `tasks.md` MUST be the format marker:
+The **first line** of `optimus-tasks.md` MUST be the format marker:
 
 ```
 <!-- optimus:tasks-v1 -->
@@ -357,7 +357,7 @@ directory is `subtasks/T-001/` (relative to `tasksDir`).
 | Estimate | No | Task size estimate. Free text (e.g., `S`, `M`, `L`, `XL`, `2h`, `1d`). `-` if not estimated |
 | TaskSpec | Yes | Path to Ring pre-dev task spec, relative to `tasksDir`. `-` if not yet linked |
 
-**NOTE:** Status and Branch are NOT stored in tasks.md. They live in `.optimus/state.json`
+**NOTE:** Status and Branch are NOT stored in optimus-tasks.md. They live in `.optimus/state.json`
 (gitignored). See Protocol: State Management for read/write operations.
 
 ### Valid Tipo Values
@@ -412,7 +412,7 @@ feat(api)!: change authentication response format
 title MUST match the task's Tipo mapping (Feature→`feat`, Fix→`fix`, etc.). If the PR
 covers multiple tasks, use the type of the primary/largest change.
 
-**Administrative commits (tasks.md structural changes):** Structural changes to tasks.md
+**Administrative commits (optimus-tasks.md structural changes):** Structural changes to optimus-tasks.md
 (new task, dependency edit, version move) use `chore(tasks):` regardless of the task's
 Tipo. Status changes are NOT committed — they live in state.json (gitignored).
 
@@ -420,7 +420,7 @@ Tipo. Status changes are NOT committed — they live in state.json (gitignored).
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -465,12 +465,12 @@ The subtasks directory is derived automatically from the TaskSpec path:
 - The `T-NNN` identifier is extracted from the task spec filename convention
 
 Agents read objective and acceptance criteria directly from the Ring source files.
-The tasks.md table only tracks structural data (dependencies, versions, priorities)
+The optimus-tasks.md table only tracks structural data (dependencies, versions, priorities)
 — it does NOT duplicate content from Ring.
 
 ### Version Management
 
-The `## Versions` section in tasks.md is **mandatory** and defines the available versions
+The `## Versions` section in optimus-tasks.md is **mandatory** and defines the available versions
 (milestones) for the project. It is managed by `tasks` (version operations).
 
 #### Versions Table
@@ -512,7 +512,7 @@ The `## Versions` section in tasks.md is **mandatory** and defines the available
 
 ### Format Validation
 
-Every stage agent (1-4) MUST validate the tasks.md format before operating:
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
 3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
@@ -534,7 +534,7 @@ running `/optimus-import` to fix the format. Do NOT attempt to interpret malform
 15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
 format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
 format validation and before task identification. If zero data rows: **STOP** and inform the
-user: "No tasks found in tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
 **NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
@@ -551,8 +551,8 @@ The report agent computes and displays parallelization opportunities.
 ## Task Lifecycle
 
 Tasks flow through 4 stages. Status lives in `.optimus/state.json`
-(gitignored). Each stage is a separate skill. The tasks.md file contains only structural
-data — no stage agent commits to tasks.md for status changes.
+(gitignored). Each stage is a separate skill. The optimus-tasks.md file contains only structural
+data — no stage agent commits to optimus-tasks.md for status changes.
 
 ```
 Pendente → Validando Spec → Em Andamento → Validando Impl → DONE
@@ -583,7 +583,7 @@ It does NOT change task status and is NOT part of the pipeline stages.
    **Exception:** done does NOT support re-execution — once a task is
    `DONE`, it cannot be re-closed.
 6. **Dependency check** — every agent verifies that ALL dependencies (Depends column
-   from tasks.md) have status `DONE` (read from state.json) before proceeding. If
+   from optimus-tasks.md) have status `DONE` (read from state.json) before proceeding. If
    any dependency is not done, the agent fires the `task-blocked` hook (if configured)
    and then refuses with a clear message identifying which dependency is blocking.
    **If the blocking dependency has status `Cancelado`**, the message must differentiate:
@@ -615,20 +615,20 @@ It does NOT change task status and is NOT part of the pipeline stages.
 
    | Type | Agent | Allowed on main/default? | Reason |
    |------|-------|-------------------------|--------|
-   | Admin | import | Yes | Only creates/modifies tasks.md |
+   | Admin | import | Yes | Only creates/modifies optimus-tasks.md |
    | Admin | report | Yes | Read-only, no modifications |
    | Admin | quick-report | Yes | Read-only, no modifications |
-   | Admin | tasks | Yes | Only creates/edits/removes tasks in tasks.md and state.json |
+   | Admin | tasks | Yes | Only creates/edits/removes tasks in optimus-tasks.md and state.json |
    | Execution | plan | Yes (creates worktree) | Writes state.json and creates worktree |
    | Execution | build | Yes (auto-navigates) | Finds task worktree and navigates to it |
    | Execution | review | Yes (auto-navigates) | Finds task worktree and navigates to it |
    | Admin | pr-check | Yes | Standalone PR review tool, does not change task status |
    | Execution | done | Yes (auto-navigates) | Finds task worktree and navigates to it |
    | Admin | batch | Yes | Orchestrates stages, delegates to stage skills |
-   | Admin | resolve | Yes | Only resolves merge conflicts in tasks.md |
+   | Admin | resolve | Yes | Only resolves merge conflicts in optimus-tasks.md |
    | Admin | resume | Yes | Read-only on state.json EXCEPT for the user-confirmed Reset-to-Pendente recovery; creates a worktree only as recovery when branch exists but worktree is missing |
 
-   **Administrative skills** manage tasks.md metadata and state.json. They never modify
+   **Administrative skills** manage optimus-tasks.md metadata and state.json. They never modify
    project code and can run on any branch.
 
    **Execution skills** modify code or run verification. They require a feature branch
@@ -699,34 +699,34 @@ Each SKILL.md specifies its stage-specific parameters (stage name, expected stat
 and delegates the common logic to these protocols. This avoids duplicating the same steps
 in every SKILL.md.
 
-### Protocol: tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
-Every stage agent MUST validate tasks.md before operating. The full validation rules are
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
 defined in the "Format Validation" section above (items 1-15). This protocol is the
 executable version:
 
 1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
    resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
 3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
 
-**All subsequent references to `tasks.md` in the skill use the resolved `TASKS_FILE` path.
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
 All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on tasks.md use the `tasks_git` helper** (which handles both same-repo
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
 and separate-repo scopes).
 
-Skills reference this as: "Find and validate tasks.md (HARD BLOCK) — see AGENTS.md Protocol: tasks.md Validation."
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 ### Protocol: Resolve Tasks Git Scope
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -751,7 +751,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -778,7 +778,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -791,9 +791,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -918,7 +918,7 @@ logic (30-day age cap + 500-file count cap). Running both per session is a
 harmless cheap operation.
 
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
 **NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
@@ -1100,7 +1100,7 @@ Follow these rules to prevent injection and silent failures:
    branch names, and other user input may contain shell metacharacters
 4. **Use `grep -F` for fixed string matching** — never pass branch names or task IDs
    as regex patterns to `grep` without `-F`
-5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in tasks.md — plain `grep "T-NNN"`
+5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in optimus-tasks.md — plain `grep "T-NNN"`
    matches titles and dependency columns too
 6. **Validate tool availability** before use: `command -v jq >/dev/null 2>&1` before running `jq`
 7. **Validate JSON files** before parsing: `jq empty "$FILE" 2>/dev/null` before reading keys
@@ -1438,8 +1438,8 @@ Skills reference this as: "Resolve workspace (HARD BLOCK) — see AGENTS.md Prot
 
 **Referenced by:** all stage agents (1-4)
 
-Since status and branch data live in state.json (gitignored), tasks.md rarely changes
-on feature branches. This protocol detects the uncommon case where tasks.md WAS modified
+Since status and branch data live in state.json (gitignored), optimus-tasks.md rarely changes
+on feature branches. This protocol detects the uncommon case where optimus-tasks.md WAS modified
 (e.g., Active Version Guard moved a task). It uses `tasks_git` so it works in both
 same-repo and separate-repo scopes.
 
@@ -1478,7 +1478,7 @@ fi
 
 - If diff output is non-empty → warn via `AskUser`:
   ```
-  tasks.md has diverged between your branch and <default_branch>.
+  optimus-tasks.md has diverged between your branch and <default_branch>.
   This may cause merge conflicts when the PR is merged.
   ```
   Options:
@@ -1489,7 +1489,7 @@ fi
 - **NOTE:** In separate-repo scope, "diverged" means the tasks repo branches diverge —
   not the project code branches.
 
-Skills reference this as: "Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
+Skills reference this as: "Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
 
 ### Protocol: Notification Hooks
 
@@ -1694,7 +1694,7 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
-1. Read the task's `TaskSpec` column from `tasks.md`
+1. Read the task's `TaskSpec` column from `optimus-tasks.md`
 2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus-tasks` or `/optimus-import`."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
@@ -1801,7 +1801,7 @@ whether to suggest advancement or offer a re-run. This protocol replaces the sta
 
 4. **If "Re-run with clean context":**
    - Increment stage stats (new execution)
-   - **Skip:** GitHub CLI check, tasks.md validation, task identification, session state
+   - **Skip:** GitHub CLI check, optimus-tasks.md validation, task identification, session state
      check, status validation/change, workspace creation, divergence check
    - **Re-execute:** project structure discovery, document loading, static analysis,
      coverage profiling, agent dispatch (ALL agents), finding presentation, fix application,
@@ -1996,13 +1996,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do
@@ -2036,8 +2036,8 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 
 **Referenced by:** plan, build, review, pr-check, done (workspace auto-navigation)
 
-Branch names are derived deterministically from the task's structural data in tasks.md.
-They are NOT stored in tasks.md — they are stored in state.json for quick reference
+Branch names are derived deterministically from the task's structural data in optimus-tasks.md.
+They are NOT stored in optimus-tasks.md — they are stored in state.json for quick reference
 and can always be re-derived.
 
 **Derivation rule:**
@@ -2097,7 +2097,7 @@ Both `report` and `quick-report` support a version scope filter (`ativa`, `upcom
    fi
    ```
    **Validation:** `SCOPE` must be `ativa`, `upcoming`, `all`, or match a version name in
-   the `## Versions` table of `tasks.md`. If invalid (empty, unknown keyword, or a version
+   the `## Versions` table of `optimus-tasks.md`. If invalid (empty, unknown keyword, or a version
    name that no longer exists), warn the user and fall through to step 3.
    ```
    WARNING: .optimus/config.json has defaultScope="<value>" but it is not valid
@@ -2162,7 +2162,7 @@ Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Def
 After the task ID is confirmed and dependencies are validated, check if the task belongs
 to the `Ativa` version. If not, present options before proceeding.
 
-1. Read the task's **Version** column from `tasks.md`
+1. Read the task's **Version** column from `optimus-tasks.md`
 2. Read the **Versions** table and find the version with Status `Ativa`
    - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
 3. **If the task's version matches the `Ativa` version** → proceed silently
@@ -2177,7 +2177,7 @@ to the `Ativa` version. If not, present options before proceeding.
    - **Cancel** — stops execution
 
 5. **If "Move to active version and continue":**
-   - Update the task's Version column in `tasks.md` to the `Ativa` version name
+   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
    - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
      separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
      ```bash
@@ -2196,25 +2196,23 @@ Skills reference this as: "Check active version guard — see AGENTS.md Protocol
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -2251,7 +2249,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -2262,22 +2260,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -2293,7 +2291,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -2321,7 +2319,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -2339,7 +2337,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -2364,7 +2362,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -2374,18 +2372,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -2401,7 +2399,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -2421,7 +2419,189 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 ## Verification Command Convention
 
@@ -2867,11 +3047,11 @@ Skills reference this as: "Include per-droid quality checklists — see AGENTS.m
 
 ### Parallel Task Execution
 Since status and branch data live in `.optimus/state.json` (gitignored), parallel task
-execution via worktrees does NOT cause merge conflicts in tasks.md. The tasks.md file
+execution via worktrees does NOT cause merge conflicts in optimus-tasks.md. The optimus-tasks.md file
 is only modified by administrative operations (new tasks, dependency changes, version
 moves), which are infrequent and happen on the default branch.
 
-If tasks.md IS modified on a feature branch (e.g., Active Version Guard moves a task),
+If optimus-tasks.md IS modified on a feature branch (e.g., Active Version Guard moves a task),
 standard git merge conflict resolution applies — keep both changes.
 
 ### Concurrent state.json Writes

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Skills are classified as **Administrative** (run anywhere) or **Execution** (req
 
 | Skill | Description | Command |
 |-------|-------------|---------|
-| `import` | Import Ring pre-dev artifacts into optimus format. Creates tasks.md with TaskSpec column. Re-runnable — only imports what's new | `/optimus-import` |
+| `import` | Import Ring pre-dev artifacts into optimus format. Creates optimus-tasks.md with TaskSpec column. Re-runnable — only imports what's new | `/optimus-import` |
 | `report` | Task status dashboard. Shows progress, active/blocked/ready tasks, dependency graph, and parallelization opportunities. Read-only | `/optimus-report` |
 | `tasks` | Administrative: Create, edit, remove, reorder, cancel, and reopen tasks. Manage versions and move tasks between versions. Runs on any branch | `/optimus-tasks` |
 | `batch` | Pipeline orchestrator: chains stages 1-4 for one or more tasks with user checkpoints between stages | `/optimus-batch` |
-| `resolve` | Administrative: Resolves merge conflicts in tasks.md caused by parallel task execution across feature branches | `/optimus-resolve` |
+| `resolve` | Administrative: Resolves merge conflicts in optimus-tasks.md caused by parallel task execution across feature branches | `/optimus-resolve` |
 | `resume` | Administrative: Resume a task after closing the terminal. Locates/recreates the worktree for a given T-XXX, reports current status, and offers to invoke the next stage. Read-only on state.json except for a user-confirmed Reset-to-Pendente recovery. | `/optimus-resume` |
 | `quick-report` | Compact daily status dashboard. Shows version progress, active tasks with current status, ready-to-start, and blocked tasks. Read-only | `/optimus-quick-report` |
 | `help` | Lists all available Optimus skills with descriptions, usage commands, and when to use each one | `/optimus-help` |
@@ -78,7 +78,7 @@ updates existing, removes orphaned. Works for both Droid and Claude Code simulta
 
 ## Quick Start
 
-1. **Import tasks:** `/optimus-import` — creates `tasks.md` from Ring pre-dev artifacts
+1. **Import tasks:** `/optimus-import` — creates `optimus-tasks.md` from Ring pre-dev artifacts
 2. **Check status:** `/optimus-report` — see the dashboard with dependencies and parallelization
 3. **Validate spec:** `/optimus-plan` — validates the first pending task and creates a workspace
 4. **Implement:** `/optimus-build` — implements the task with TDD and verification gates

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ the threat model, trust boundaries, and mitigations in place.
 | AGENTS.md protocols | Trusted | Shipped by Optimus; reviewed in PRs |
 | SKILL.md files | Trusted | Same as AGENTS.md |
 | `.optimus/config.json` | **Partially untrusted** | Gitignored per-user; could be tampered by local attacker, received via Slack/email, or cloned from a malicious fork |
-| `tasks.md` content | **Partially untrusted** | Versioned — any contributor can add rows. Malicious values in `TaskSpec` column could attempt path traversal |
-| Ring pre-dev specs (`<tasksDir>/tasks/*.md`) | **Partially untrusted** | Same as tasks.md |
+| `optimus-tasks.md` content | **Partially untrusted** | Versioned — any contributor can add rows. Malicious values in `TaskSpec` column could attempt path traversal |
+| Ring pre-dev specs (`<tasksDir>/tasks/*.md`) | **Partially untrusted** | Same as optimus-tasks.md |
 | Environment variables | Trusted | User controls them |
 
 ## Attack Scenarios and Mitigations
@@ -43,7 +43,9 @@ are rejected outright to prevent TOCTOU attacks.
 Migration's `cp` would overwrite the sensitive target.
 
 **Mitigation:** `Protocol: Migrate tasks.md to tasksDir` rejects with `exit 1` if
-either source or destination is a symlink.
+either source or destination is a symlink. The newer `Protocol: Rename tasks.md to
+optimus-tasks.md` similarly refuses to operate on symlinked source or destination
+files.
 
 ### S4: Branch name injection in divergence checks
 

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -7,9 +7,9 @@ trigger: >
   - When user says "batch execute", "run pipeline", "full cycle"
 skip_when: >
   - User wants to run a single specific stage (use that stage directly)
-  - No tasks.md exists
+  - No optimus-tasks.md exists
 prerequisite: >
-  - tasks.md exists in valid optimus format
+  - optimus-tasks.md exists in valid optimus format
   - At least one task is eligible (Pendente or in-progress)
 NOT_skip_when: >
   - "I can run stages one by one" -- Batch mode saves context-switching and ensures no stage is skipped.
@@ -60,13 +60,14 @@ Chains stages 1-4 for one or more tasks with user checkpoints between stages.
 
 **HARD BLOCK:** Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 
-### Step 1.1: Find and Validate tasks.md
+### Step 1.1: Resolve and Validate optimus-tasks.md
 
-1. **Find tasks.md:** Resolve the path using the AGENTS.md Protocol: tasks.md Validation.
-2. **Validate format:** First line must be `<!-- optimus:tasks-v1 -->`. Full format validation.
-3. **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-   If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/tasks.md` does not, the
+1. **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
+   If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
    protocol offers migration before proceeding.
+   Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+2. **Find optimus-tasks.md:** Resolve the path using the AGENTS.md Protocol: optimus-tasks.md Validation.
+3. **Validate format:** First line must be `<!-- optimus:tasks-v1 -->`. Full format validation.
 
 If validation fails, **STOP** and suggest `/optimus-import`.
 
@@ -85,7 +86,7 @@ dependencies `DONE`. Prioritize by version (`Ativa` first), then priority, then 
 For each task:
 1. **Read status from state.json** — see AGENTS.md Protocol: State Management. Check that the task's status allows the requested starting stage
    - **Exclude tasks with status `Cancelado`** — cancelled tasks cannot be processed through the pipeline
-2. Check that all dependencies are `DONE` (read Depends from tasks.md, status for each dependency from state.json)
+2. Check that all dependencies are `DONE` (read Depends from optimus-tasks.md, status for each dependency from state.json)
 3. If any task is blocked, report it and exclude from the batch
 
 **NOTE:** Eligibility is re-evaluated after each task completes (Step 2.4). Tasks that
@@ -215,7 +216,7 @@ Options:
 
 After completing a task (all stages done), re-evaluate the remaining task pool:
 
-1. Re-read `tasks.md` for structural data and `state.json` for current statuses
+1. Re-read `optimus-tasks.md` for structural data and `state.json` for current statuses
 2. Check if any previously ineligible tasks are now eligible (dependencies satisfied by the just-completed task)
 3. If new eligible tasks are found, present via `AskUser`:
    ```
@@ -311,7 +312,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -326,7 +327,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -339,7 +340,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -353,7 +354,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -375,10 +376,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -387,7 +388,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -410,7 +411,7 @@ These operations require explicit user confirmation.
 
 ### Format Validation
 
-Every stage agent (1-4) MUST validate the tasks.md format before operating:
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
 3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
@@ -432,7 +433,7 @@ running `/optimus-import` to fix the format. Do NOT attempt to interpret malform
 15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
 format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
 format validation and before task identification. If zero data rows: **STOP** and inform the
-user: "No tasks found in tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
 **NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
@@ -444,10 +445,10 @@ in the cycle so the user can fix it with `/optimus-tasks`.
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -472,7 +473,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -499,7 +500,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -512,9 +513,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -608,25 +609,23 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -663,7 +662,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -674,22 +673,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -705,7 +704,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -733,7 +732,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -751,7 +750,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -776,7 +775,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -786,18 +785,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -813,7 +812,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -833,7 +832,190 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: Shell Safety Guidelines
@@ -860,7 +1042,7 @@ Follow these rules to prevent injection and silent failures:
    branch names, and other user input may contain shell metacharacters
 4. **Use `grep -F` for fixed string matching** — never pass branch names or task IDs
    as regex patterns to `grep` without `-F`
-5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in tasks.md — plain `grep "T-NNN"`
+5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in optimus-tasks.md — plain `grep "T-NNN"`
    matches titles and dependency columns too
 6. **Validate tool availability** before use: `command -v jq >/dev/null 2>&1` before running `jq`
 7. **Validate JSON files** before parsing: `jq empty "$FILE" 2>/dev/null` before reading keys
@@ -972,13 +1154,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do
@@ -1104,25 +1286,25 @@ will not see a title update.
 Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
 
 
-### Protocol: tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
-Every stage agent MUST validate tasks.md before operating. The full validation rules are
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
 defined in the "Format Validation" section above (items 1-15). This protocol is the
 executable version:
 
 1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
    resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
 3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
 
-**All subsequent references to `tasks.md` in the skill use the resolved `TASKS_FILE` path.
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
 All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on tasks.md use the `tasks_git` helper** (which handles both same-repo
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
 and separate-repo scopes).
 
-Skills reference this as: "Find and validate tasks.md (HARD BLOCK) — see AGENTS.md Protocol: tasks.md Validation."
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -76,13 +76,14 @@ Executes a validated task specification end-to-end: identifies the task, loads c
 
 **HARD BLOCK:** Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 
-### Step 1.1: Find and Validate tasks.md
-
-**HARD BLOCK:** Find and validate tasks.md — see AGENTS.md Protocol: tasks.md Validation.
+### Step 1.1: Resolve and Validate optimus-tasks.md
 
 **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/tasks.md` does not, the
+If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
 protocol offers migration before proceeding.
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+
+**HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
 ### Step 1.2: Identify Task to Execute
 
@@ -93,7 +94,7 @@ protocol offers migration before proceeding.
 **If the user did NOT specify a task ID** (e.g., "execute the next task", or just invoked the skill):
 1. **Identify the next task ready for implementation:** Read state.json and scan for the first task that:
    - Has status `Validando Spec` (plan completed) or `Em Andamento` (re-execution)
-   - Has all dependencies (Depends column from tasks.md) with status `DONE` in state.json (or Depends is `-`)
+   - Has all dependencies (Depends column from optimus-tasks.md) with status `DONE` in state.json (or Depends is `-`)
    - **Version priority:** prefer tasks from the `Ativa` version first. If none found, try `Próxima`. If none found, pick from any version and warn the user: "No eligible tasks in the active version (<name>). Suggesting T-XXX from version '<other>'."
 2. **If multiple candidates exist in the same version priority**, pick the one with highest Priority (`Alta` > `Media` > `Baixa`), then lowest ID
 3. **Suggest to the user** using `AskUser`: "I identified the next task to execute: T-XXX — [task title]. Is this correct, or would you like to execute a different task?"
@@ -160,13 +161,13 @@ _optimus_set_title ""
 
 **HARD BLOCK:** This step is mandatory. Do NOT skip it.
 
-1. Read `tasks.md` and find the row for the confirmed task ID
+1. Read `optimus-tasks.md` and find the row for the confirmed task ID
 2. Read the task's status from state.json — see AGENTS.md Protocol: State Management.
    - If status is `Validando Spec` → proceed (plan has completed, workspace will be resolved in Step 1.4 via Workspace Auto-Navigation protocol which handles missing worktrees with branch recovery)
    - If status is `Em Andamento` → proceed (re-execution of this stage)
    - If status is `Pendente` → **STOP**: "Task T-XXX is in 'Pendente'. Run plan first."
    - If status is `Validando Impl`, `DONE`, or `Cancelado` → **STOP**: "Task T-XXX is in '<status>'. It has already moved past this stage or was cancelled."
-3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from tasks.md.
+3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
    - For each dependency ID listed, read its status from state.json:
      - If ALL dependencies have status `DONE` → proceed
@@ -192,9 +193,9 @@ _optimus_set_title ""
 5. Update status to `Em Andamento` in state.json (if not already) — see AGENTS.md Protocol: State Management.
 6. Invoke notification hooks (event=`status-change`) — see AGENTS.md Protocol: Notification Hooks.
 
-### Step 1.3.1: Check tasks.md Divergence (warning)
+### Step 1.3.1: Check optimus-tasks.md Divergence (warning)
 
-Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
+Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
 
 ### Step 1.4: Verify Workspace
 
@@ -557,7 +558,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -572,7 +573,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -585,7 +586,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -599,7 +600,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -621,10 +622,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -633,7 +634,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -665,13 +666,13 @@ The subtasks directory is derived automatically from the TaskSpec path:
 - The `T-NNN` identifier is extracted from the task spec filename convention
 
 Agents read objective and acceptance criteria directly from the Ring source files.
-The tasks.md table only tracks structural data (dependencies, versions, priorities)
+The optimus-tasks.md table only tracks structural data (dependencies, versions, priorities)
 — it does NOT duplicate content from Ring.
 
 
 ### Format Validation
 
-Every stage agent (1-4) MUST validate the tasks.md format before operating:
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
 3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
@@ -693,7 +694,7 @@ running `/optimus-import` to fix the format. Do NOT attempt to interpret malform
 15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
 format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
 format validation and before task identification. If zero data rows: **STOP** and inform the
-user: "No tasks found in tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
 **NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
@@ -705,10 +706,10 @@ in the cycle so the user can fix it with `/optimus-tasks`.
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -733,7 +734,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -760,7 +761,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -773,9 +774,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -913,7 +914,7 @@ All cycle review skills follow this pattern:
 After the task ID is confirmed and dependencies are validated, check if the task belongs
 to the `Ativa` version. If not, present options before proceeding.
 
-1. Read the task's **Version** column from `tasks.md`
+1. Read the task's **Version** column from `optimus-tasks.md`
 2. Read the **Versions** table and find the version with Status `Ativa`
    - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
 3. **If the task's version matches the `Ativa` version** → proceed silently
@@ -928,7 +929,7 @@ to the `Ativa` version. If not, present options before proceeding.
    - **Cancel** — stops execution
 
 5. **If "Move to active version and continue":**
-   - Update the task's Version column in `tasks.md` to the `Ativa` version name
+   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
    - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
      separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
      ```bash
@@ -1115,8 +1116,8 @@ Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage
 
 **Referenced by:** all stage agents (1-4)
 
-Since status and branch data live in state.json (gitignored), tasks.md rarely changes
-on feature branches. This protocol detects the uncommon case where tasks.md WAS modified
+Since status and branch data live in state.json (gitignored), optimus-tasks.md rarely changes
+on feature branches. This protocol detects the uncommon case where optimus-tasks.md WAS modified
 (e.g., Active Version Guard moved a task). It uses `tasks_git` so it works in both
 same-repo and separate-repo scopes.
 
@@ -1155,7 +1156,7 @@ fi
 
 - If diff output is non-empty → warn via `AskUser`:
   ```
-  tasks.md has diverged between your branch and <default_branch>.
+  optimus-tasks.md has diverged between your branch and <default_branch>.
   This may cause merge conflicts when the PR is merged.
   ```
   Options:
@@ -1166,7 +1167,7 @@ fi
 - **NOTE:** In separate-repo scope, "diverged" means the tasks repo branches diverge —
   not the project code branches.
 
-Skills reference this as: "Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
+Skills reference this as: "Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
 
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
@@ -1185,25 +1186,23 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -1240,7 +1239,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -1251,22 +1250,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -1282,7 +1281,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -1310,7 +1309,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -1328,7 +1327,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -1353,7 +1352,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -1363,18 +1362,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -1390,7 +1389,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -1410,7 +1409,7 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: Notification Hooks
@@ -1819,6 +1818,189 @@ prints only the metric (example in Protocol: Coverage Measurement).
 Skills reference this as: "Run quietly — see AGENTS.md Protocol: Quiet Command Execution."
 
 
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
+
+
 ### Protocol: Ring Droid Requirement Check
 
 **Referenced by:** review, pr-check, deep-doc-review, coderabbit-review, plan, build
@@ -2097,13 +2279,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do
@@ -2140,7 +2322,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
-1. Read the task's `TaskSpec` column from `tasks.md`
+1. Read the task's `TaskSpec` column from `optimus-tasks.md`
 2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus-tasks` or `/optimus-import`."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
@@ -2264,25 +2446,25 @@ fi
 Skills reference this as: "Resolve workspace (HARD BLOCK) — see AGENTS.md Protocol: Workspace Auto-Navigation."
 
 
-### Protocol: tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
-Every stage agent MUST validate tasks.md before operating. The full validation rules are
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
 defined in the "Format Validation" section above (items 1-15). This protocol is the
 executable version:
 
 1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
    resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
 3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
 
-**All subsequent references to `tasks.md` in the skill use the resolved `TASKS_FILE` path.
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
 All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on tasks.md use the `tasks_git` helper** (which handles both same-repo
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
 and separate-repo scopes).
 
-Skills reference this as: "Find and validate tasks.md (HARD BLOCK) — see AGENTS.md Protocol: tasks.md Validation."
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -845,7 +845,7 @@ logic (30-day age cap + 500-file count cap). Running both per session is a
 harmless cheap operation.
 
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
 **NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before

--- a/deep-doc-review/skills/optimus-deep-doc-review/SKILL.md
+++ b/deep-doc-review/skills/optimus-deep-doc-review/SKILL.md
@@ -189,7 +189,7 @@ Present the full findings table for a bird's-eye view:
 | # | Type | Severity | File(s) | Problem | Suggested Fix | Tradeoff | Recommendation |
 |---|------|----------|---------|---------|---------------|----------|----------------|
 | 1 | INCONSISTENCY | CRITICAL | api-design.md, data-model.md | Field X defined as VARCHAR(50) in data-model but string with no limit in API design | Align to VARCHAR(100) in both | Changing limit may affect validation | Fix both docs |
-| 2 | GAP | HIGH | tasks.md | Task T-008 does not define Testing Strategy | Add section with unit + integration tests | Additional writing effort | Add before implementation |
+| 2 | GAP | HIGH | optimus-tasks.md | Task T-008 does not define Testing Strategy | Add section with unit + integration tests | Additional writing effort | Add before implementation |
 | ... | ... | ... | ... | ... | ... | ... | ... |
 
 ### Summary by Severity

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -795,7 +795,7 @@ logic (30-day age cap + 500-file count cap). Running both per session is a
 harmless cheap operation.
 
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
 **NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before

--- a/docs/future-improvements.md
+++ b/docs/future-improvements.md
@@ -4,7 +4,7 @@ Tracked improvements that are not yet prioritized for implementation.
 
 ---
 
-## I6: Additional Test Coverage for tasks.md Relocation Feature
+## I6: Additional Test Coverage for optimus-tasks.md Relocation Feature
 
 **Status:** Open
 **Affects:** scripts/test_skill_consistency.py
@@ -12,7 +12,7 @@ Tracked improvements that are not yet prioritized for implementation.
 
 ### Context
 
-The tasks.md-to-tasksDir migration feature (commit ad0d8d7, hardened in subsequent
+The optimus-tasks.md-to-tasksDir migration feature (commit ad0d8d7, hardened in subsequent
 review) has integration tests in `TestMigrationAndScopeIntegration` covering:
 scope detection (same-repo/separate-repo), non-git tasksDir rejection, dash-prefix
 rejection, path traversal, migration detection. Additional scenarios are identified
@@ -23,7 +23,7 @@ as gaps:
    correct repos, gitignore updated).
 2. **Concurrent migration** — two shell processes running migration simultaneously
    on the same project (expected: one succeeds, the other aborts cleanly).
-3. **Scale test** — tasks.md with 500+ rows; measure parsing time for `grep`/`awk`.
+3. **Scale test** — optimus-tasks.md with 500+ rows; measure parsing time for `grep`/`awk`.
 4. **Special characters in task titles** — pipes, emojis, unicode — verify table
    parsing does not break.
 5. **Migration rollback on partial failure** — inject failures at steps 2-5; verify
@@ -106,7 +106,7 @@ Weight each task's contribution to version progress by its Estimate column
 (S=1, M=2, L=3, XL=5, or similar). Progress becomes:
 `Sum(weight of DONE tasks) / Sum(weight of all non-cancelled tasks)`.
 
-The Estimate column already exists in tasks.md and comes from Ring pre-dev, so
+The Estimate column already exists in optimus-tasks.md and comes from Ring pre-dev, so
 no extra data collection is needed.
 
 ### Analysis
@@ -166,7 +166,7 @@ Portuguese. This creates a barrier for non-Portuguese-speaking users and contrib
 ### Considerations
 
 - Requires a migration path for state.json (existing status values)
-- tasks.md format marker may need versioning (v1 → v2)
+- optimus-tasks.md format marker may need versioning (v1 → v2)
 - All protocol references to status names must be updated atomically
 - Consider keeping Portuguese as an alias during transition period
 

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -9,7 +9,7 @@ skip_when: >
   - Task is already done
   - PR is still open (hard block — merge or close the PR first)
 prerequisite: >
-  - Task exists in tasks.md with status "Validando Impl" in state.json
+  - Task exists in optimus-tasks.md with status "Validando Impl" in state.json
   - review has completed
   - PR must be in final state (MERGED or CLOSED) or not exist
 NOT_skip_when: >
@@ -56,13 +56,14 @@ Stage 4 of the task lifecycle. Verifies all prerequisites before marking a task 
 
 Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 
-### Step 1.0.1: Find and Validate tasks.md
-
-**HARD BLOCK:** Find and validate tasks.md — see AGENTS.md Protocol: tasks.md Validation.
+### Step 1.0.1: Resolve and Validate optimus-tasks.md
 
 **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/tasks.md` does not, the
+If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
 protocol offers migration before proceeding.
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+
+**HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
 ### Step 1.0.2: Resolve Current Workspace (HARD BLOCK)
 
@@ -165,7 +166,7 @@ _optimus_set_title ""
 
 **HARD BLOCK:** This step is mandatory. Do NOT skip it.
 
-1. Read `tasks.md` and find the row for the confirmed task ID
+1. Read `optimus-tasks.md` and find the row for the confirmed task ID
 2. Read the task's status from state.json — see AGENTS.md Protocol: State Management.
    - If status is `Validando Impl` → proceed (review has completed)
    - If status is `Pendente` → **STOP**: "Task T-XXX is in 'Pendente'. It must go through plan, build, and review first."
@@ -173,7 +174,7 @@ _optimus_set_title ""
    - If status is `Em Andamento` → **STOP**: "Task T-XXX is in 'Em Andamento'. Run review first."
    - If status is `DONE` → **STOP**: "Task T-XXX is already done. Re-execution of done is not supported."
    - If status is `Cancelado` → **STOP**: "Task T-XXX was cancelled. Cannot close a cancelled task."
-3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from tasks.md.
+3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
    - For each dependency ID listed, read its status from state.json:
      - If ALL dependencies have status `DONE` → proceed
@@ -199,9 +200,9 @@ _optimus_set_title ""
 
    **NOTE:** done does not support re-execution (status always changes to `DONE`), so the re-execution skip does not apply here.
 
-### Step 1.2: Check tasks.md Divergence (warning)
+### Step 1.2: Check optimus-tasks.md Divergence (warning)
 
-Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
+Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
 
 ---
 
@@ -410,7 +411,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -425,7 +426,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -438,7 +439,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -452,7 +453,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -474,10 +475,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -486,7 +487,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -509,7 +510,7 @@ These operations require explicit user confirmation.
 
 ### Format Validation
 
-Every stage agent (1-4) MUST validate the tasks.md format before operating:
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
 3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
@@ -531,7 +532,7 @@ running `/optimus-import` to fix the format. Do NOT attempt to interpret malform
 15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
 format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
 format validation and before task identification. If zero data rows: **STOP** and inform the
-user: "No tasks found in tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
 **NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
@@ -543,10 +544,10 @@ in the cycle so the user can fix it with `/optimus-tasks`.
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -571,7 +572,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -598,7 +599,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -611,9 +612,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -698,7 +699,7 @@ Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: R
 After the task ID is confirmed and dependencies are validated, check if the task belongs
 to the `Ativa` version. If not, present options before proceeding.
 
-1. Read the task's **Version** column from `tasks.md`
+1. Read the task's **Version** column from `optimus-tasks.md`
 2. Read the **Versions** table and find the version with Status `Ativa`
    - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
 3. **If the task's version matches the `Ativa` version** → proceed silently
@@ -713,7 +714,7 @@ to the `Ativa` version. If not, present options before proceeding.
    - **Cancel** — stops execution
 
 5. **If "Move to active version and continue":**
-   - Update the task's Version column in `tasks.md` to the `Ativa` version name
+   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
    - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
      separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
      ```bash
@@ -735,8 +736,8 @@ Skills reference this as: "Check active version guard — see AGENTS.md Protocol
 
 **Referenced by:** all stage agents (1-4)
 
-Since status and branch data live in state.json (gitignored), tasks.md rarely changes
-on feature branches. This protocol detects the uncommon case where tasks.md WAS modified
+Since status and branch data live in state.json (gitignored), optimus-tasks.md rarely changes
+on feature branches. This protocol detects the uncommon case where optimus-tasks.md WAS modified
 (e.g., Active Version Guard moved a task). It uses `tasks_git` so it works in both
 same-repo and separate-repo scopes.
 
@@ -775,7 +776,7 @@ fi
 
 - If diff output is non-empty → warn via `AskUser`:
   ```
-  tasks.md has diverged between your branch and <default_branch>.
+  optimus-tasks.md has diverged between your branch and <default_branch>.
   This may cause merge conflicts when the PR is merged.
   ```
   Options:
@@ -786,7 +787,7 @@ fi
 - **NOTE:** In separate-repo scope, "diverged" means the tasks repo branches diverge —
   not the project code branches.
 
-Skills reference this as: "Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
+Skills reference this as: "Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
 
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
@@ -805,25 +806,23 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -860,7 +859,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -871,22 +870,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -902,7 +901,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -930,7 +929,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -948,7 +947,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -973,7 +972,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -983,18 +982,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -1010,7 +1009,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -1030,7 +1029,7 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: Notification Hooks
@@ -1099,6 +1098,189 @@ Hooks run in background (`&`) and their failure does NOT block the pipeline.
 If `tasks-hooks.sh` does not exist, hooks are silently skipped.
 
 Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: State Management
@@ -1194,13 +1376,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do
@@ -1231,25 +1413,25 @@ appearing as `Pendente` when they actually have active worktrees.
 Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: State Management."
 
 
-### Protocol: tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
-Every stage agent MUST validate tasks.md before operating. The full validation rules are
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
 defined in the "Format Validation" section above (items 1-15). This protocol is the
 executable version:
 
 1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
    resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
 3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
 
-**All subsequent references to `tasks.md` in the skill use the resolved `TASKS_FILE` path.
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
 All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on tasks.md use the `tasks_git` helper** (which handles both same-repo
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
 and separate-repo scopes).
 
-Skills reference this as: "Find and validate tasks.md (HARD BLOCK) — see AGENTS.md Protocol: tasks.md Validation."
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/help/skills/optimus-help/SKILL.md
+++ b/help/skills/optimus-help/SKILL.md
@@ -44,10 +44,10 @@ terminal display when available, otherwise use markdown tables.
 
 | Skill | Command | When to Use |
 |-------|---------|-------------|
-| **import** | `/optimus-import` | Import Ring pre-dev artifacts into optimus format. Creates `<tasksDir>/tasks.md` (default: `docs/pre-dev/tasks.md`) with TaskSpec column. Re-runnable — only imports what's new. Supports tasksDir in same repo or a separate git repo. |
+| **import** | `/optimus-import` | Import Ring pre-dev artifacts into optimus format. Creates `<tasksDir>/optimus-tasks.md` (default: `docs/pre-dev/optimus-tasks.md`) with TaskSpec column. Re-runnable — only imports what's new. Supports tasksDir in same repo or a separate git repo. |
 | **report** | `/optimus-report` | Task status dashboard — shows progress, active/blocked/ready tasks, dependency graph, and parallelization opportunities. Read-only. |
 | **tasks** | `/optimus-tasks` | Creating, editing, removing, reordering, cancelling, or reopening tasks. Managing versions. Any administrative task management. |
-| **resolve** | `/optimus-resolve` | Resolving merge conflicts in `tasks.md` caused by parallel task execution across feature branches. |
+| **resolve** | `/optimus-resolve` | Resolving merge conflicts in `optimus-tasks.md` caused by parallel task execution across feature branches. |
 | **resume** | `/optimus-resume` | Resume a task after closing the terminal — locates/recreates the worktree for a given T-XXX, reports current status, and offers to invoke the next stage. Read-only on state.json except for a user-confirmed Reset-to-Pendente recovery. |
 | **quick-report** | `/optimus-quick-report` | Compact daily status dashboard — shows version progress, active tasks with current status, ready-to-start, and blocked tasks. Read-only. |
 | **batch** | `/optimus-batch` | Pipeline orchestrator — chains stages 1-4 for one or more tasks with user checkpoints between stages. |
@@ -121,7 +121,7 @@ on their situation:
 ### "I want a quick status check"
 - Use `/optimus-report` with "quick status" — shows only current task and next-up
 
-### "I have a merge conflict in tasks.md"
+### "I have a merge conflict in optimus-tasks.md"
 - Use `/optimus-resolve` to auto-resolve structural conflicts (each task row is independent)
 
 ### "I completed a task outside the pipeline"

--- a/import/.factory-plugin/plugin.json
+++ b/import/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "import",
-  "description": "Import Ring pre-dev artifacts into optimus format. Creates tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
+  "description": "Import Ring pre-dev artifacts into optimus format. Creates optimus-tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
   "version": "1.0.0",
   "author": {
     "name": "Alex Garzao"

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: optimus-import
-description: "Import Ring pre-dev artifacts into optimus format. Reads task specs and subtasks, creates tasks.md with TaskSpec column linking to Ring source. Re-runnable — only imports what's new. Never deletes original files."
+description: "Import Ring pre-dev artifacts into optimus format. Reads task specs and subtasks, creates optimus-tasks.md with TaskSpec column linking to Ring source. Re-runnable — only imports what's new. Never deletes original files."
 trigger: >
   - When user wants to adopt the optimus task pipeline on a project with Ring pre-dev output
   - When user says "import tasks", "import pre-dev", "migrate tasks", "setup task pipeline"
-  - When plan can't find a valid tasks.md
+  - When plan can't find a valid optimus-tasks.md
 skip_when: >
-  - Project already has a valid tasks.md AND no new Ring pre-dev artifacts to import
+  - Project already has a valid optimus-tasks.md AND no new Ring pre-dev artifacts to import
   - No Ring pre-dev output exists (run Ring pre-dev first)
 prerequisite: >
   - Ring pre-dev has been run (task specs exist in the configured tasksDir)
 NOT_skip_when: >
   - "The project is small" -- Even small projects benefit from standardized task tracking.
-  - "I'll just create tasks.md manually" -- Use /optimus-tasks for ad-hoc tasks; this skill is for Ring pre-dev import.
+  - "I'll just create optimus-tasks.md manually" -- Use /optimus-tasks for ad-hoc tasks; this skill is for Ring pre-dev import.
 examples:
   - name: Import Ring pre-dev artifacts
     invocation: "Import pre-dev"
@@ -21,15 +21,15 @@ examples:
       2. Discover task specs in <tasksDir>/tasks/
       3. Present inventory of Ring tasks found
       4. User confirms and chooses version assignment
-      5. Create tasks.md with TaskSpec column
+      5. Create optimus-tasks.md with TaskSpec column
       6. Commit after approval
   - name: Re-run to import new Ring tasks
     invocation: "Import tasks"
     expected_flow: >
-      1. Detect existing tasks.md in optimus format
+      1. Detect existing optimus-tasks.md in optimus format
       2. Discover new Ring pre-dev tasks not yet imported
       3. Present only new tasks
-      4. Add to existing tasks.md
+      4. Add to existing optimus-tasks.md
       5. Commit after approval
 related:
   complementary:
@@ -46,22 +46,22 @@ verification:
   manual:
     - All Ring pre-dev tasks discovered and presented
     - Proposal shown before any changes
-    - tasks.md generated with TaskSpec column linking to Ring source
+    - optimus-tasks.md generated with TaskSpec column linking to Ring source
     - Original Ring files NOT deleted
 ---
 
 # Ring Pre-Dev Importer
 
-Reads Ring pre-dev artifacts and creates the optimus tracking layer: a `tasks.md` file
+Reads Ring pre-dev artifacts and creates the optimus tracking layer: a `optimus-tasks.md` file
 with a `TaskSpec` column linking each task to its Ring source. Never copies content
 from Ring — only references it via the TaskSpec column.
 
-**CRITICAL:** This agent NEVER deletes original Ring files. It creates/updates tasks.md,
+**CRITICAL:** This agent NEVER deletes original Ring files. It creates/updates optimus-tasks.md,
 leaving Ring pre-dev artifacts untouched.
 
 **NOTE:** Configuration is stored in `.optimus/config.json` (gitignored, per-user):
 - `tasksDir`: path to Ring pre-dev artifacts root (default: `docs/pre-dev`)
-- Tasks file is always at `<tasksDir>/tasks.md` (derived from tasksDir)
+- Tasks file is always at `<tasksDir>/optimus-tasks.md` (derived from tasksDir)
 - `tasksDir` may point to a directory in the same repo as the project, OR to a
   path in a separate git repo (for teams that keep task tracking independent from code)
 
@@ -116,37 +116,38 @@ workflow first (`ring:pre-dev-full` or `ring:pre-dev-feature`) to generate task 
 4. Check if a subtasks directory exists at `<TASKS_DIR>/subtasks/T-NNN/`
 5. If subtasks exist, list all `.md` files and read their headings
 
-### Step 1.3: Check Existing tasks.md
+### Step 1.3: Check Existing optimus-tasks.md
 
-Check if `<TASKS_DIR>/tasks.md` exists (the new standard location).
+Check if `<TASKS_DIR>/optimus-tasks.md` exists (the new standard location).
 
 **Migration check (HARD BLOCK):** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/tasks.md` does not, the protocol
+If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the protocol
 offers migration before proceeding.
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
-**If tasks.md exists in optimus format** (first line is `<!-- optimus:tasks-v1 -->`):
+**If optimus-tasks.md exists in optimus format** (first line is `<!-- optimus:tasks-v1 -->`):
 - Read existing tasks from the table
 - Filter out Ring pre-dev tasks that are already imported (match by `TaskSpec` column
   value, not by title or ID)
 - If ALL Ring tasks are already imported → "No new Ring artifacts to import." and **STOP**
 - If some are new → continue with only the new tasks
 
-**If tasks.md does not exist at the configured/default path**, scan the entire project
-for any file named `tasks.md`:
+**If optimus-tasks.md does not exist at the configured/default path**, scan the entire project
+for any file named `optimus-tasks.md` or legacy `tasks.md`:
 
 ```bash
-find . -name tasks.md ! -path '*/node_modules/*' ! -path '*/.git/*' 2>/dev/null
+find . \( -name optimus-tasks.md -o -name tasks.md \) ! -path '*/node_modules/*' ! -path '*/.git/*' 2>/dev/null
 ```
 
 For each file found, check the first line for the optimus format marker
 (`<!-- optimus:tasks-v1 -->`). Present ALL results to the user:
 
 ```
-I found N tasks.md files in this project:
+I found N task files in this project:
 
 | # | Path | Optimus format? | Tasks |
 |---|------|-----------------|-------|
-| 1 | docs/pre-dev/tasks.md | Yes | 42 tasks (27 done, 15 pending) |
+| 1 | docs/pre-dev/optimus-tasks.md | Yes | 42 tasks (27 done, 15 pending) |
 | 2 | .optimus/tasks.md | Yes | Legacy location — will migrate |
 
 How should I proceed?
@@ -164,11 +165,11 @@ transparency but cannot be selected.
   `{task_spec_path → {ID, Status, Depends, Priority, Version, Branch, Estimate}}`
 - If the existing file does not have a TaskSpec column, match tasks by title similarity
   (>80% keyword overlap) as a fallback. Present potential matches to the user for confirmation
-- Parse the Versions table and carry it over to the new tasks.md
+- Parse the Versions table and carry it over to the new optimus-tasks.md
 - Store this as `EXISTING_DATA` for use in Step 1.4
 - Store the source file path as `EXISTING_FILE` for cleanup in Step 3.4
 
-**If no tasks.md files are found**, continue (will create from scratch).
+**If no optimus-tasks.md files are found**, continue (will create from scratch).
 
 ### Step 1.4: Build Task Inventory
 
@@ -185,15 +186,15 @@ For each Ring pre-dev task not yet imported:
 | **Estimate** | From `EXISTING_DATA` if available, else `-` | `-` |
 | **TaskSpec** | Path to Ring task spec, relative to `TASKS_DIR` | Required |
 
-**NOTE:** Status and Branch are NOT stored in tasks.md. They live in `.optimus/state.json`
+**NOTE:** Status and Branch are NOT stored in optimus-tasks.md. They live in `.optimus/state.json`
 (gitignored). See AGENTS.md Protocol: State Management.
 
 **When `EXISTING_DATA` is available** (from Step 1.3), match Ring pre-dev tasks to
 existing tasks by TaskSpec path. For matched tasks,
-carry over Depends, Priority, Version, and Estimate into tasks.md.
+carry over Depends, Priority, Version, and Estimate into optimus-tasks.md.
 
 **Migration of Status/Branch from legacy format:** If `EXISTING_DATA` has columns named
-"Status" or "Branch" (from an older tasks.md format), migrate them to state.json:
+"Status" or "Branch" (from an older optimus-tasks.md format), migrate them to state.json:
 ```bash
 # For each task with non-Pendente status or non-empty branch in EXISTING_DATA:
 STATE_FILE=".optimus/state.json"
@@ -239,7 +240,7 @@ Options via `AskUser`:
 - **User-provided name** (e.g., "MVP", "v1") — creates it as `Ativa`
 - **Backlog** — creates a "Backlog" version with Status `Backlog`
 
-If tasks.md already exists, use the `Ativa` version by default. Ask via `AskUser`
+If optimus-tasks.md already exists, use the `Ativa` version by default. Ask via `AskUser`
 if the user wants a different version.
 
 ### Step 1.6: Generate Specs for Tasks Without TaskSpec
@@ -306,11 +307,11 @@ Options:
 
 Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 
-### Step 3.2: Write tasks.md
+### Step 3.2: Write optimus-tasks.md
 
 **If creating from scratch:**
 
-Create `<TASKS_DIR>/tasks.md` (typically `docs/pre-dev/tasks.md`) with:
+Create `<TASKS_DIR>/optimus-tasks.md` (typically `docs/pre-dev/optimus-tasks.md`) with:
 1. Format marker: `<!-- optimus:tasks-v1 -->` (MUST be the first line)
 2. H1 heading: `# Tasks`
 3. `## Versions` section with the versions table (from Step 1.5)
@@ -406,13 +407,13 @@ fi
 specs (via `/optimus-tasks` or re-running import), the old file can be removed by
 re-running import.
 
-Commit tasks.md using `tasks_git` (may be a different repo than the project repo in
+Commit optimus-tasks.md using `tasks_git` (may be a different repo than the project repo in
 separate-repo scope):
 
 ```bash
 tasks_git add "$TASKS_GIT_REL"
 COMMIT_MSG_FILE=$(mktemp)
-printf 'chore(tasks): import Ring pre-dev tasks to optimus format\n\nImported N tasks from %s/tasks/.\nOriginal Ring files preserved.' "$TASKS_DIR" > "$COMMIT_MSG_FILE"
+printf 'chore(tasks): import Ring pre-dev tasks to optimus format\n\nImported N tasks into optimus-tasks.md from %s/tasks/.\nOriginal Ring files preserved.' "$TASKS_DIR" > "$COMMIT_MSG_FILE"
 tasks_git commit -F "$COMMIT_MSG_FILE"
 rm -f "$COMMIT_MSG_FILE"
 ```
@@ -427,7 +428,7 @@ do NOT commit it (it's gitignored).
 
 - **Tasks imported:** N
 - **Ring source:** <TASKS_DIR>/tasks/ (N task specs, M subtask files)
-- **Tracking created:** <TASKS_DIR>/tasks.md
+- **Tracking created:** <TASKS_DIR>/optimus-tasks.md
 - **tasksDir:** <TASKS_DIR> (<same-repo|separate-repo>)
 - **Ring files:** NOT modified
 
@@ -441,8 +442,10 @@ do NOT commit it (it's gitignored).
 
 ## Rules
 
-- **NEVER delete or modify Ring pre-dev files** — only create/update tasks.md
-- **NEVER copy content from Ring into tasks.md** — only reference via TaskSpec column
+- **NEVER delete or modify Ring pre-dev files** — only create/update optimus-tasks.md
+- **NEVER copy content from Ring into optimus-tasks.md** — only reference via TaskSpec column
+  (note: Ring's own `tasks.md` is a different file at the same path; renaming the optimus
+  tracking file to `optimus-tasks.md` resolves the collision)
 - **NEVER apply changes without user approval** — always present and confirm first
 - **NEVER invent task content** — only extract titles from Ring source
 - Ring pre-dev is the ONLY import source — generic formats (YAML, checklist, index) are not supported
@@ -474,7 +477,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -489,7 +492,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -502,7 +505,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -516,7 +519,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -538,10 +541,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -550,7 +553,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -606,7 +609,7 @@ logic (30-day age cap + 500-file count cap). Running both per session is a
 harmless cheap operation.
 
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
 **NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
@@ -619,25 +622,23 @@ Skills reference this as: "Initialize .optimus directory — see AGENTS.md Proto
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -674,7 +675,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -685,22 +686,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -716,7 +717,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -744,7 +745,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -762,7 +763,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -787,7 +788,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -797,18 +798,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -824,7 +825,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -844,7 +845,190 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: State Management
@@ -940,13 +1124,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -81,13 +81,14 @@ Catches gaps, contradictions, and ambiguities that would cause rework.
 subsequent stages (2-5) all require `gh`. Failing early prevents the user from completing
 spec validation only to discover `gh` is not set up when they try to run Stage-2.
 
-### Step 1.0.1: Find and Validate tasks.md
-
-**HARD BLOCK:** Find and validate tasks.md — see AGENTS.md Protocol: tasks.md Validation.
+### Step 1.0.1: Resolve and Validate optimus-tasks.md
 
 **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/tasks.md` does not, the
+If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
 protocol offers migration before proceeding.
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+
+**HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
 ### Step 1.0.2: Identify Task to Validate
 
@@ -98,7 +99,7 @@ protocol offers migration before proceeding.
 **If the user did NOT specify a task ID** (e.g., "validate the next task", or just invoked the skill):
 1. **Identify the next eligible task:** Read state.json and scan for the first task that:
    - Has status `Pendente` (no entry in state.json) or `Validando Spec` (re-execution)
-   - Has all dependencies (Depends column from tasks.md) with status `DONE` in state.json (or Depends is `-`)
+   - Has all dependencies (Depends column from optimus-tasks.md) with status `DONE` in state.json (or Depends is `-`)
    - **Version priority:** prefer tasks from the `Ativa` version first. If none found, try `Próxima`. If none found, pick from any version and warn the user: "No eligible tasks in the active version (<name>). Suggesting T-XXX from version '<other>'."
 2. **If multiple candidates exist in the same version priority**, pick the one with highest Priority (`Alta` > `Media` > `Baixa`), then lowest ID
 3. **Suggest to the user** using `AskUser`: "I identified the next task to validate: T-XXX — [task title]. Is this correct, or would you like to validate a different task?"
@@ -165,7 +166,7 @@ _optimus_set_title ""
 
 **HARD BLOCK:** This step is mandatory. Do NOT skip it.
 
-1. Read `tasks.md` and find the row for the confirmed task ID
+1. Read `optimus-tasks.md` and find the row for the confirmed task ID
 2. Read the task's status from state.json — see AGENTS.md Protocol: State Management.
    - If status is `Pendente` (or no entry) → proceed
    - If status is `Validando Spec` → proceed (re-execution of this stage)
@@ -174,7 +175,7 @@ _optimus_set_title ""
      Task T-XXX is in '<current_status>'. To run plan,
      it must be in 'Pendente' or 'Validando Spec'. This task has already moved past this stage.
      ```
-3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from tasks.md.
+3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
    - For each dependency ID listed, read its status from state.json:
      - If ALL dependencies have status `DONE` → proceed
@@ -281,9 +282,9 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
 
 **BLOCKING**: Do NOT proceed until the worktree is created.
 
-### Step 1.0.6: Check tasks.md Divergence (warning)
+### Step 1.0.6: Check optimus-tasks.md Divergence (warning)
 
-Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
+Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
 
 ### Step 1.0.7: Increment Stage Stats
 
@@ -669,7 +670,7 @@ Execute the opt-in convergence loop — see AGENTS.md "Common Patterns > Protoco
 **Stage-specific scope for convergence rounds 2+:**
 Dispatch the **same 4 droids** from Step 2.4 (business-logic-reviewer, security-reviewer,
 qa-analyst, code-reviewer). Each agent receives file paths to task spec, reference docs,
-tasks.md, and project rules (re-read fresh from disk). Do NOT include the findings ledger
+optimus-tasks.md, and project rules (re-read fresh from disk). Do NOT include the findings ledger
 in agent prompts — the orchestrator handles dedup using strict matching (same file + same
 line range ±5 + same category).
 
@@ -690,7 +691,7 @@ When the loop exits (any status), proceed to Phase 7 (Re-run Guard).
 Execute re-run guard — see AGENTS.md Protocol: Re-run Guard.
 
 - If the user chooses **Re-run with clean context**: go back to Step 1.1 (Discover Project
-  Structure). Skip all prior setup steps (GitHub CLI check, tasks.md validation, task
+  Structure). Skip all prior setup steps (GitHub CLI check, optimus-tasks.md validation, task
   identification, session state, status validation, workspace creation, divergence check).
   Increment stage stats before re-starting analysis.
 - If the user chooses **Advance** (or 0 findings): proceed to Phase 8 (Push).
@@ -835,7 +836,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -850,7 +851,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -863,7 +864,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -877,7 +878,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -899,10 +900,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -911,7 +912,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -943,13 +944,13 @@ The subtasks directory is derived automatically from the TaskSpec path:
 - The `T-NNN` identifier is extracted from the task spec filename convention
 
 Agents read objective and acceptance criteria directly from the Ring source files.
-The tasks.md table only tracks structural data (dependencies, versions, priorities)
+The optimus-tasks.md table only tracks structural data (dependencies, versions, priorities)
 — it does NOT duplicate content from Ring.
 
 
 ### Format Validation
 
-Every stage agent (1-4) MUST validate the tasks.md format before operating:
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
 3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
@@ -971,7 +972,7 @@ running `/optimus-import` to fix the format. Do NOT attempt to interpret malform
 15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
 format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
 format validation and before task identification. If zero data rows: **STOP** and inform the
-user: "No tasks found in tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
 **NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
@@ -983,10 +984,10 @@ in the cycle so the user can fix it with `/optimus-tasks`.
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -1011,7 +1012,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -1038,7 +1039,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -1051,9 +1052,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -1207,7 +1208,7 @@ Every finding must present 2-3 options with this structure:
 After the task ID is confirmed and dependencies are validated, check if the task belongs
 to the `Ativa` version. If not, present options before proceeding.
 
-1. Read the task's **Version** column from `tasks.md`
+1. Read the task's **Version** column from `optimus-tasks.md`
 2. Read the **Versions** table and find the version with Status `Ativa`
    - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
 3. **If the task's version matches the `Ativa` version** → proceed silently
@@ -1222,7 +1223,7 @@ to the `Ativa` version. If not, present options before proceeding.
    - **Cancel** — stops execution
 
 5. **If "Move to active version and continue":**
-   - Update the task's Version column in `tasks.md` to the `Ativa` version name
+   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
    - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
      separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
      ```bash
@@ -1244,8 +1245,8 @@ Skills reference this as: "Check active version guard — see AGENTS.md Protocol
 
 **Referenced by:** plan, build, review, pr-check, done (workspace auto-navigation)
 
-Branch names are derived deterministically from the task's structural data in tasks.md.
-They are NOT stored in tasks.md — they are stored in state.json for quick reference
+Branch names are derived deterministically from the task's structural data in optimus-tasks.md.
+They are NOT stored in optimus-tasks.md — they are stored in state.json for quick reference
 and can always be re-derived.
 
 **Derivation rule:**
@@ -1377,8 +1378,8 @@ Dispatching a single agent in rounds 2+ creates false convergence — the agent 
 
 **Referenced by:** all stage agents (1-4)
 
-Since status and branch data live in state.json (gitignored), tasks.md rarely changes
-on feature branches. This protocol detects the uncommon case where tasks.md WAS modified
+Since status and branch data live in state.json (gitignored), optimus-tasks.md rarely changes
+on feature branches. This protocol detects the uncommon case where optimus-tasks.md WAS modified
 (e.g., Active Version Guard moved a task). It uses `tasks_git` so it works in both
 same-repo and separate-repo scopes.
 
@@ -1417,7 +1418,7 @@ fi
 
 - If diff output is non-empty → warn via `AskUser`:
   ```
-  tasks.md has diverged between your branch and <default_branch>.
+  optimus-tasks.md has diverged between your branch and <default_branch>.
   This may cause merge conflicts when the PR is merged.
   ```
   Options:
@@ -1428,7 +1429,7 @@ fi
 - **NOTE:** In separate-repo scope, "diverged" means the tasks repo branches diverge —
   not the project code branches.
 
-Skills reference this as: "Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
+Skills reference this as: "Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
 
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
@@ -1479,25 +1480,23 @@ Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Inc
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -1534,7 +1533,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -1545,22 +1544,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -1576,7 +1575,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -1604,7 +1603,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -1622,7 +1621,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -1647,7 +1646,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -1657,18 +1656,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -1684,7 +1683,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -1704,7 +1703,7 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: Notification Hooks
@@ -2008,7 +2007,7 @@ whether to suggest advancement or offer a re-run. This protocol replaces the sta
 
 4. **If "Re-run with clean context":**
    - Increment stage stats (new execution)
-   - **Skip:** GitHub CLI check, tasks.md validation, task identification, session state
+   - **Skip:** GitHub CLI check, optimus-tasks.md validation, task identification, session state
      check, status validation/change, workspace creation, divergence check
    - **Re-execute:** project structure discovery, document loading, static analysis,
      coverage profiling, agent dispatch (ALL agents), finding presentation, fix application,
@@ -2030,6 +2029,189 @@ committed during the previous run. It does NOT revert commits. This validates th
 applied fixes are correct and checks for any issues introduced by the fixes.
 
 Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: Ring Droid Requirement Check
@@ -2241,7 +2423,7 @@ Follow these rules to prevent injection and silent failures:
    branch names, and other user input may contain shell metacharacters
 4. **Use `grep -F` for fixed string matching** — never pass branch names or task IDs
    as regex patterns to `grep` without `-F`
-5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in tasks.md — plain `grep "T-NNN"`
+5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in optimus-tasks.md — plain `grep "T-NNN"`
    matches titles and dependency columns too
 6. **Validate tool availability** before use: `command -v jq >/dev/null 2>&1` before running `jq`
 7. **Validate JSON files** before parsing: `jq empty "$FILE" 2>/dev/null` before reading keys
@@ -2353,13 +2535,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do
@@ -2396,7 +2578,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
-1. Read the task's `TaskSpec` column from `tasks.md`
+1. Read the task's `TaskSpec` column from `optimus-tasks.md`
 2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus-tasks` or `/optimus-import`."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
@@ -2441,25 +2623,25 @@ Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
-### Protocol: tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
-Every stage agent MUST validate tasks.md before operating. The full validation rules are
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
 defined in the "Format Validation" section above (items 1-15). This protocol is the
 executable version:
 
 1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
    resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
 3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
 
-**All subsequent references to `tasks.md` in the skill use the resolved `TASKS_FILE` path.
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
 All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on tasks.md use the `tasks_git` helper** (which handles both same-repo
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
 and separate-repo scopes).
 
-Skills reference this as: "Find and validate tasks.md (HARD BLOCK) — see AGENTS.md Protocol: tasks.md Validation."
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -113,6 +113,16 @@ No task identification, status validation, or state.json writes are performed.
 
 ## Phase 1: Fetch PR Context
 
+### Step 1.0: Resolve Paths and Git Scope
+
+Execute AGENTS.md Protocol: Resolve Tasks Git Scope. This obtains `TASKS_DIR`,
+`TASKS_FILE`, `TASKS_GIT_SCOPE`, `TASKS_GIT_REL`, and the `tasks_git` helper. The
+TaskSpec lookups later in this skill (e.g., Step 1.1 PR-creation, Phase 4 attribution)
+depend on `TASKS_DIR` being resolved.
+
+**Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+
 ### Step 1.1: Obtain PR URL
 
 If the user provided a PR URL, use it directly.
@@ -135,7 +145,7 @@ Options:
 
 If the user chooses **Create PR**:
 1. Generate PR title from task Tipo + ID + title (e.g., `feat(T-003): add user registration API`)
-2. Generate PR body from Ring source (read via `TaskSpec` column in tasks.md)
+2. Generate PR body from Ring source (read via `TaskSpec` column in optimus-tasks.md)
 3. Push the branch if not yet pushed: `git push -u origin "$(git branch --show-current)"`
 4. Create the PR:
    ```bash
@@ -1926,7 +1936,7 @@ logic (30-day age cap + 500-file count cap). Running both per session is a
 harmless cheap operation.
 
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
 **NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
@@ -1935,6 +1945,234 @@ tasksDir) will offer to run `git rm --cached .optimus/config.json` so the local 
 is preserved but untracked.
 
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
+
+
+### Protocol: Migrate tasks.md to tasksDir
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
+LEGACY_FILE=".optimus/tasks.md"
+if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  # Partial/failed migration OR manual copy. Use new location but WARN the user.
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
+  echo "         This indicates a partial prior migration or manual copy." >&2
+  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
+  NEEDS_MIGRATION=0
+elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  NEEDS_MIGRATION=1
+else
+  NEEDS_MIGRATION=0
+fi
+```
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
+
+```
+[DRY-RUN] Migration would be offered for this task:
+[DRY-RUN]   Legacy: $LEGACY_FILE
+[DRY-RUN]   New:    $TASKS_FILE
+[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
+```
+
+**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
+in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
+are preserved locally but no longer shared via git. Warn user BEFORE untracking:
+
+```bash
+if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
+  if [ -f .optimus/config.json ]; then
+    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
+    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
+    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
+    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
+  fi
+fi
+```
+
+**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
+
+```
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
+Migrate now? (Recommended — keeping the old location will break other skills.)
+```
+
+Options:
+- **Migrate now** — copy → add in target repo → remove from project repo
+- **Skip this time** — continue with the legacy file (emit warning; this will break)
+- **Abort** — stop the current command so you can migrate manually
+
+**Migration flow (when user chooses "Migrate now"):**
+
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
+Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted migrations:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
+```
+
+**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  mkdir -p "$TASKS_DIR"
+  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
+    rm -f .optimus/.migration-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore legacy from HEAD, remove new from working tree
+    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.migration-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
+  mkdir -p "$TASKS_DIR"
+  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
+    echo "ERROR: cp failed. Migration aborted." >&2
+    rm -f .optimus/.migration-in-progress
+    exit 1
+  fi
+  # Commit #1: in tasks repo
+  if ! tasks_git add "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git add failed. Rolling back..." >&2
+    rm -f "$TASKS_FILE"
+    rm -f .optimus/.migration-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
+    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.migration-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+  # Commit #2: in project repo
+  if ! git rm "$LEGACY_FILE"; then
+    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
+    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
+    rm -f .optimus/.migration-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
+    echo "Manual cleanup needed: git commit after resolving." >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.migration-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
+commit exit code; restore index on failure:
+
+```bash
+if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
+  git rm --cached .optimus/config.json
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    # Restore to index so user can retry
+    git reset HEAD .optimus/config.json 2>/dev/null
+    rm -f "$COMMIT_MSG_FILE"
+    echo "ERROR: Failed to untrack config.json. Index restored." >&2
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
+  else
+    rm -f "$COMMIT_MSG_FILE"
+  fi
+fi
+```
+
+**Ensure `.gitignore` includes the operational-files block:**
+Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
+
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
+Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
+file was manually edited and lacks a `## Versions` section), inform user and suggest
+running `/optimus-import` to rebuild:
+
+```bash
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Migration success: clear checkpoint marker and log each step.**
+```bash
+rm -f .optimus/.migration-in-progress
+echo "INFO: Migration completed successfully:" >&2
+echo "  - Legacy location: $LEGACY_FILE" >&2
+echo "  - New location:    $TASKS_FILE" >&2
+echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
+```
+
+**Report success:**
+```
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
+Remember to push both repos (project + tasks) when you're ready.
+```
+
+**Interrupted migration recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.migration-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.migration-in-progress 2>/dev/null)
+  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry migration / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
+for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: PR Title Validation
@@ -2193,6 +2431,341 @@ prints only the metric (example in Protocol: Coverage Measurement).
 - Commands under 20 lines of output where the savings are negligible.
 
 Skills reference this as: "Run quietly — see AGENTS.md Protocol: Quiet Command Execution."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
+
+
+### Protocol: Resolve Tasks Git Scope
+
+**Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
+
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
+detects whether `tasksDir` lives in the same git repo as the project code or in a
+**separate** git repo. Exposes a `tasks_git` helper function so skills can run git
+commands on optimus-tasks.md uniformly regardless of scope.
+
+```bash
+# Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
+CONFIG_FILE=".optimus/config.json"
+if [ -f "$CONFIG_FILE" ] && jq empty "$CONFIG_FILE" 2>/dev/null; then
+  TASKS_DIR=$(jq -r '.tasksDir // "docs/pre-dev"' "$CONFIG_FILE")
+else
+  TASKS_DIR="docs/pre-dev"
+fi
+# Reject "null" (jq -r prints literal "null" for JSON null) or empty string.
+case "$TASKS_DIR" in
+  ""|"null") TASKS_DIR="docs/pre-dev" ;;
+esac
+# Security: reject TASKS_DIR values starting with "-" (git option injection via
+# `git -C --exec-path=...` or similar). Trust boundary: config.json is now gitignored,
+# but a user could still receive a malicious config via Slack/email.
+case "$TASKS_DIR" in
+  -*)
+    echo "ERROR: tasksDir cannot start with '-' (security)." >&2
+    exit 1
+    ;;
+esac
+
+# Step 2: Derive TASKS_FILE.
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
+
+# Step 3: Detect git scope.
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$PROJECT_ROOT" ]; then
+  echo "ERROR: Not inside a git repository — optimus requires git." >&2
+  exit 1
+fi
+
+TASKS_REPO_ROOT=""
+if [ -d "$TASKS_DIR" ]; then
+  TASKS_REPO_ROOT=$(git -C "$TASKS_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")
+fi
+
+if [ -z "$TASKS_REPO_ROOT" ]; then
+  if [ -d "$TASKS_DIR" ]; then
+    # Directory exists but is NOT inside a git repository — this is a
+    # misconfiguration. Without this guard, operations would silently target
+    # the project repo and fail confusingly.
+    echo "ERROR: tasksDir '$TASKS_DIR' exists but is not inside a git repository." >&2
+    echo "Options:" >&2
+    echo "  1. Initialize git in tasksDir: git -C \"$TASKS_DIR\" init" >&2
+    echo "  2. Point tasksDir to an existing git repo." >&2
+    echo "  3. Remove tasksDir to let optimus create it inside the project repo." >&2
+    exit 1
+  fi
+  # Fresh project: tasksDir does not exist yet — assume same-repo.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
+  TASKS_GIT_SCOPE="same-repo"
+elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
+  TASKS_GIT_SCOPE="same-repo"
+else
+  TASKS_GIT_SCOPE="separate-repo"
+fi
+
+# Step 4: Compute the path to pass to git commands.
+# In same-repo, git runs from project root and we pass TASKS_FILE as is.
+# In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
+if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
+  # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
+  # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
+    echo "Install python3 or point tasksDir inside the project repo." >&2
+    exit 1
+  fi
+  TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute TASKS_GIT_REL for '$TASKS_FILE' relative to '$TASKS_REPO_ROOT'." >&2
+    exit 1
+  fi
+else
+  TASKS_GIT_REL="$TASKS_FILE"
+fi
+
+# Step 5: Resolve the tasks repo's default branch once (used by tasks_git
+# operations that reference origin/$DEFAULT). This is DIFFERENT from
+# $DEFAULT_BRANCH (the project repo's default).
+if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
+  TASKS_DEFAULT_BRANCH=$(git -C "$TASKS_DIR" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+  if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
+    # Fallback: check origin/main vs origin/master existence (deterministic,
+    # unlike `git branch --list main master` which can return either arbitrarily).
+    if git -C "$TASKS_DIR" show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
+      TASKS_DEFAULT_BRANCH="main"
+    elif git -C "$TASKS_DIR" show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
+      TASKS_DEFAULT_BRANCH="master"
+    fi
+  fi
+else
+  TASKS_DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+  if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
+    if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
+      TASKS_DEFAULT_BRANCH="main"
+    elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
+      TASKS_DEFAULT_BRANCH="master"
+    fi
+  fi
+fi
+
+# Security: reject malformed branch names (prevents injection via
+# `git diff origin/<weird>`).
+if [ -n "$TASKS_DEFAULT_BRANCH" ] && ! [[ "$TASKS_DEFAULT_BRANCH" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  echo "ERROR: Invalid TASKS_DEFAULT_BRANCH format: '$TASKS_DEFAULT_BRANCH'" >&2
+  exit 1
+fi
+
+# Step 6: Define the tasks_git helper.
+tasks_git() {
+  if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
+    git -C "$TASKS_DIR" "$@"
+  else
+    git "$@"
+  fi
+}
+```
+
+**Usage:**
+```bash
+tasks_git add "$TASKS_GIT_REL"
+tasks_git commit -F "$COMMIT_MSG_FILE"
+# IMPORTANT: use $TASKS_DEFAULT_BRANCH (tasks repo default) — NOT $DEFAULT_BRANCH
+# (project repo default). They are the same in same-repo mode but may differ in
+# separate-repo mode (e.g., tasks repo is `master`, project repo is `main`).
+tasks_git diff "origin/$TASKS_DEFAULT_BRANCH" -- "$TASKS_GIT_REL"
+tasks_git show "origin/$TASKS_DEFAULT_BRANCH:$TASKS_GIT_REL"
+```
+
+**Rule:** Skills MUST use `tasks_git` (never raw `git`) when operating on `$TASKS_FILE`.
+Raw `git` on `$TASKS_FILE` breaks in separate-repo mode.
+
+**Rule:** When committing in separate-repo mode, commits land in the tasks repo (not the
+project repo). `tasks_git push` pushes the tasks repo. The project repo is unaffected.
+
+Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
 ### Protocol: Ring Droid Requirement Check

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -5,10 +5,10 @@ trigger: >
   - When user asks for a quick project overview (e.g., "quick report", "quick status", "daily report", "resumo rapido")
   - When user wants a fast, compact status check without velocity or dependency graphs
 skip_when: >
-  - No tasks.md exists in the project
+  - No optimus-tasks.md exists in the project
   - User wants the full dashboard with dependency graph, velocity, and workspace health (use optimus-report instead)
 prerequisite: >
-  - <tasksDir>/tasks.md exists in the project (default tasksDir: docs/pre-dev)
+  - <tasksDir>/optimus-tasks.md exists in the project (default tasksDir: docs/pre-dev)
 NOT_skip_when: >
   - "I already know the status" -- A quick glance catches tasks you forgot about.
   - "There's only one task" -- Even one task benefits from status visibility.
@@ -16,13 +16,13 @@ examples:
   - name: Daily status
     invocation: "Quick report"
     expected_flow: >
-      1. Find and parse tasks.md
+      1. Find and parse optimus-tasks.md
       2. Compute version progress, classify tasks
       3. Present compact dashboard
   - name: Resumo rapido
     invocation: "Resumo rapido"
     expected_flow: >
-      1. Parse tasks.md
+      1. Parse optimus-tasks.md
       2. Present compact dashboard
 related:
   complementary:
@@ -42,7 +42,7 @@ verification:
 
 # Quick Report
 
-Compact daily status dashboard. Parses `tasks.md` and presents a focused overview:
+Compact daily status dashboard. Parses `optimus-tasks.md` and presents a focused overview:
 version progress, active tasks with current status, ready-to-start tasks,
 and blocked tasks.
 
@@ -50,7 +50,7 @@ and blocked tasks.
 
 ---
 
-## Phase 1: Parse tasks.md
+## Phase 1: Parse optimus-tasks.md
 
 ### Step 1.0: Resolve Paths and Git Scope
 
@@ -59,11 +59,17 @@ Execute AGENTS.md Protocol: Resolve Tasks Git Scope. This obtains `TASKS_DIR`,
 
 Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
 Informational only in read-only skills — emit a warning if a legacy
-`.optimus/tasks.md` exists.
+`.optimus/tasks.md` exists without a new location; do NOT auto-migrate from a
+read-only skill.
+
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Informational only in read-only skills — emit a warning if `<TASKS_DIR>/tasks.md`
+exists with the optimus format marker but `<TASKS_DIR>/optimus-tasks.md` does not;
+do NOT auto-rename from a read-only skill.
 
 ### Step 1.1: Locate and Validate
 
-Tasks file is always at `<tasksDir>/tasks.md` (derived from `tasksDir`, default `docs/pre-dev`). If not found, inform the user and suggest `/optimus-import`.
+Tasks file is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`, default `docs/pre-dev`). If not found, inform the user and suggest `/optimus-import`.
 
 Check the first line for `<!-- optimus:tasks-v1 -->`. If missing, warn but attempt best-effort parsing.
 
@@ -265,11 +271,11 @@ Examples: `[█░░] 1/3`, `[██░] 2/3`, `[███] 3/3`
 
 - **NEVER modify any files** — read-only, with ONE exception: the user may opt in to
   persist their chosen scope to `.optimus/config.json` (see Step 2.1, sub-step 4).
-  No other writes are allowed — no tasks.md, no state.json, no code.
+  No other writes are allowed — no optimus-tasks.md, no state.json, no code.
 - **NEVER run git commands** — this skill avoids git operations for speed
 - **NEVER invoke other skills** — only report
 - Present the dashboard even if there's only 1 task
-- If tasks.md has no table or invalid format, suggest `/optimus-import`
+- If optimus-tasks.md has no table or invalid format, suggest `/optimus-import`
 
 <!-- INLINE-PROTOCOLS:START -->
 ## Shared Protocols (from AGENTS.md)
@@ -296,7 +302,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -311,7 +317,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -324,7 +330,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -338,7 +344,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -360,10 +366,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -372,7 +378,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -417,7 +423,7 @@ Both `report` and `quick-report` support a version scope filter (`ativa`, `upcom
    fi
    ```
    **Validation:** `SCOPE` must be `ativa`, `upcoming`, `all`, or match a version name in
-   the `## Versions` table of `tasks.md`. If invalid (empty, unknown keyword, or a version
+   the `## Versions` table of `optimus-tasks.md`. If invalid (empty, unknown keyword, or a version
    name that no longer exists), warn the user and fall through to step 3.
    ```
    WARNING: .optimus/config.json has defaultScope="<value>" but it is not valid
@@ -478,25 +484,23 @@ Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Def
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -533,7 +537,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -544,22 +548,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -575,7 +579,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -603,7 +607,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -621,7 +625,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -646,7 +650,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -656,18 +660,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -683,7 +687,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -703,17 +707,200 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: Resolve Tasks Git Scope
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -738,7 +925,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -765,7 +952,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -778,9 +965,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -951,13 +1138,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimus-report
-description: "Task status dashboard. Reads tasks.md, computes dependency graph, and presents a comprehensive project status report. Shows progress, active tasks, blocked tasks, ready-to-start tasks, dependency graph, and parallelization opportunities. Read-only -- this agent NEVER modifies any files."
+description: "Task status dashboard. Reads optimus-tasks.md, computes dependency graph, and presents a comprehensive project status report. Shows progress, active tasks, blocked tasks, ready-to-start tasks, dependency graph, and parallelization opportunities. Read-only -- this agent NEVER modifies any files."
 trigger: >
   - When user asks for project status (e.g., "show tasks", "project status", "what's ready?")
   - When user wants to know what can be parallelized
@@ -8,10 +8,10 @@ trigger: >
   - Before starting a new task (to see the full picture)
   - When user asks "quick status", "what am I working on?", "current task"
 skip_when: >
-  - No tasks.md exists in the project
+  - No optimus-tasks.md exists in the project
   - User wants to run a specific stage agent (use that agent directly)
 prerequisite: >
-  - <tasksDir>/tasks.md exists in the project (default tasksDir: docs/pre-dev)
+  - <tasksDir>/optimus-tasks.md exists in the project (default tasksDir: docs/pre-dev)
 NOT_skip_when: >
   - "I already know the status" -- The dashboard shows dependencies and parallelization you might miss.
   - "There's only one task" -- Even single tasks benefit from status verification.
@@ -19,20 +19,20 @@ examples:
   - name: Full project status
     invocation: "Show project status"
     expected_flow: >
-      1. Find and parse tasks.md
+      1. Find and parse optimus-tasks.md
       2. Compute dependency graph
       3. Classify tasks (done, active, ready, blocked)
       4. Present dashboard with all sections
   - name: What to work on next
     invocation: "What can I work on next?"
     expected_flow: >
-      1. Parse tasks.md
+      1. Parse optimus-tasks.md
       2. Find tasks with status Pendente and all dependencies DONE
       3. Present ready-to-start tasks with priority ordering
   - name: Quick status check
     invocation: "Quick status" or "What am I working on?"
     expected_flow: >
-      1. Parse tasks.md
+      1. Parse optimus-tasks.md
       2. Show only: current active task, its progress status, and next-up
       3. Skip dependency graph, parallelization, velocity, and completed tasks
 related:
@@ -49,16 +49,16 @@ verification:
 
 # Task Status Dashboard
 
-Read-only agent that parses `tasks.md` and presents a comprehensive project status report.
+Read-only agent that parses `optimus-tasks.md` and presents a comprehensive project status report.
 
 **CRITICAL:** This agent is effectively read-only. It may write ONLY to
 `.optimus/config.json` (`defaultScope`) and to `.optimus/reports/` (exports), and only
-when the user explicitly opts in. It never modifies `tasks.md`, `state.json`, code, or
+when the user explicitly opts in. It never modifies `optimus-tasks.md`, `state.json`, code, or
 any other project file.
 
 ---
 
-## Phase 1: Find and Parse tasks.md
+## Phase 1: Find and Parse optimus-tasks.md
 
 ### Step 1.0: Resolve Paths and Git Scope
 
@@ -70,17 +70,22 @@ Informational only in read-only skills — emit a warning if a legacy
 `.optimus/tasks.md` exists without a new location; do NOT auto-migrate from a
 read-only skill.
 
-### Step 1.1: Locate tasks.md
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Informational only in read-only skills — emit a warning if `<TASKS_DIR>/tasks.md`
+exists with the optimus format marker but `<TASKS_DIR>/optimus-tasks.md` does not;
+do NOT auto-rename from a read-only skill.
 
-Tasks file is always at `<tasksDir>/tasks.md` (derived from `tasksDir`, default `docs/pre-dev`).
+### Step 1.1: Locate optimus-tasks.md
 
-If not found, inform the user and suggest: "No tasks.md found. Run `/optimus-import` to create one from existing task files, or create it manually following the optimus format."
+Tasks file is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`, default `docs/pre-dev`).
+
+If not found, inform the user and suggest: "No optimus-tasks.md found. Run `/optimus-import` to create one from existing task files, or create it manually following the optimus format."
 
 ### Step 1.1.1: Validate Format Marker
 
-Check that the **first line** of `tasks.md` is `<!-- optimus:tasks-v1 -->`.
+Check that the **first line** of `optimus-tasks.md` is `<!-- optimus:tasks-v1 -->`.
 
-If missing, warn the user: "tasks.md exists but is not in optimus format (missing `<!-- optimus:tasks-v1 -->` marker). Run `/optimus-import` to convert it."
+If missing, warn the user: "optimus-tasks.md exists but is not in optimus format (missing `<!-- optimus:tasks-v1 -->` marker). Run `/optimus-import` to convert it."
 
 The report agent still ATTEMPTS to parse and display data even without the marker (best effort), but shows the warning prominently.
 
@@ -105,7 +110,7 @@ Skip this step silently.
 
 ### Step 1.2: Parse the Tasks Table
 
-Read `tasks.md` and extract the markdown table. Expected columns:
+Read `optimus-tasks.md` and extract the markdown table. Expected columns:
 
 | Column | Description |
 |--------|-------------|
@@ -144,7 +149,7 @@ For each task with dependencies:
 If the user's invocation matches quick status triggers ("quick status", "what am I working on?",
 "current task", "status rápido"):
 
-1. Parse tasks.md (Phase 1 still runs fully)
+1. Parse optimus-tasks.md (Phase 1 still runs fully)
 2. Find tasks with status other than `Pendente`, `DONE`, and `Cancelado` (active tasks)
 3. For each active task, read its Ring source via the `TaskSpec` column for context
 4. Present ONLY:
@@ -602,7 +607,7 @@ Flag worktrees as potentially orphaned if:
 - The task is `DONE` — worktree should have been cleaned up by done
 - The task is `Cancelado` — worktree should have been cleaned up by tasks cancel
 - The task is `Pendente` — worktree exists but task was never started or was reset
-- No matching task found — worktree has no corresponding task in tasks.md
+- No matching task found — worktree has no corresponding task in optimus-tasks.md
 
 ```
 ┌─────────────────────────────────────────────────┐
@@ -675,8 +680,8 @@ an artifact in `.optimus/reports/` (gitignored), not a project file.
 - **NEVER change task status** — only report current state
 - **NEVER invoke other stage agents** — only recommend
 - Present the full dashboard even if there's only 1 task
-- If tasks.md has no table or invalid format, suggest running `/optimus-import` to convert it to the standard format
-- If tasks.md does not exist, suggest running `/optimus-import` to create one from existing task files
+- If optimus-tasks.md has no table or invalid format, suggest running `/optimus-import` to convert it to the standard format
+- If optimus-tasks.md does not exist, suggest running `/optimus-import` to create one from existing task files
 - Always show the dependency graph, even for small projects — it reveals parallelization opportunities
 
 <!-- INLINE-PROTOCOLS:START -->
@@ -704,7 +709,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -719,7 +724,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -732,7 +737,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -746,7 +751,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -768,10 +773,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -780,7 +785,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -825,7 +830,7 @@ Both `report` and `quick-report` support a version scope filter (`ativa`, `upcom
    fi
    ```
    **Validation:** `SCOPE` must be `ativa`, `upcoming`, `all`, or match a version name in
-   the `## Versions` table of `tasks.md`. If invalid (empty, unknown keyword, or a version
+   the `## Versions` table of `optimus-tasks.md`. If invalid (empty, unknown keyword, or a version
    name that no longer exists), warn the user and fall through to step 3.
    ```
    WARNING: .optimus/config.json has defaultScope="<value>" but it is not valid
@@ -919,7 +924,7 @@ logic (30-day age cap + 500-file count cap). Running both per session is a
 harmless cheap operation.
 
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
 **NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
@@ -932,25 +937,23 @@ Skills reference this as: "Initialize .optimus directory — see AGENTS.md Proto
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -987,7 +990,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -998,22 +1001,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -1029,7 +1032,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -1057,7 +1060,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -1075,7 +1078,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -1100,7 +1103,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -1110,18 +1113,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -1137,7 +1140,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -1157,17 +1160,200 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: Resolve Tasks Git Scope
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -1192,7 +1378,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -1219,7 +1405,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -1232,9 +1418,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -1405,13 +1591,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do

--- a/resolve/.factory-plugin/plugin.json
+++ b/resolve/.factory-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "resolve",
-  "description": "Administrative: Resolves merge conflicts in tasks.md caused by parallel task execution across feature branches.",
+  "description": "Administrative: Resolves merge conflicts in optimus-tasks.md caused by parallel task execution across feature branches.",
   "version": "1.0.0",
   "author": {
     "name": "Alex Garzao"

--- a/resolve/skills/optimus-resolve/SKILL.md
+++ b/resolve/skills/optimus-resolve/SKILL.md
@@ -1,24 +1,24 @@
 ---
 name: optimus-resolve
-description: "Resolves merge conflicts in tasks.md caused by parallel structural edits. Since status and branch data live in state.json (gitignored), tasks.md conflicts are rare — they only occur when structural changes (new tasks, dependency edits, version moves) happen concurrently. This skill detects, parses, and resolves those conflicts — each task's row is independent."
+description: "Resolves merge conflicts in optimus-tasks.md caused by parallel structural edits. Since status and branch data live in state.json (gitignored), optimus-tasks.md conflicts are rare — they only occur when structural changes (new tasks, dependency edits, version moves) happen concurrently. This skill detects, parses, and resolves those conflicts — each task's row is independent."
 trigger: >
-  - When tasks.md has merge conflict markers (<<<<<<, ======, >>>>>>)
-  - When user says "resolve tasks.md conflict" or "fix tasks conflict"
-  - When git merge/rebase fails due to tasks.md conflict
+  - When optimus-tasks.md has merge conflict markers (<<<<<<, ======, >>>>>>)
+  - When user says "resolve optimus-tasks.md conflict" or "fix tasks conflict"
+  - When git merge/rebase fails due to optimus-tasks.md conflict
   - After merging a PR when another feature branch has diverged
 skip_when: >
-  - No conflict markers exist in tasks.md
-  - Conflict is in a file other than tasks.md (use standard git tools)
+  - No conflict markers exist in optimus-tasks.md
+  - Conflict is in a file other than optimus-tasks.md (use standard git tools)
 prerequisite: >
-  - tasks.md exists and contains merge conflict markers
+  - optimus-tasks.md exists and contains merge conflict markers
 NOT_skip_when: >
   - "I can resolve it manually" -- Manual resolution risks losing structural changes (dependencies, versions).
   - "It's just one line" -- Even one-line conflicts can silently lose data.
 examples:
   - name: Resolve after merge
-    invocation: "Resolve tasks.md conflict"
+    invocation: "Resolve optimus-tasks.md conflict"
     expected_flow: >
-      1. Detect conflict markers in tasks.md
+      1. Detect conflict markers in optimus-tasks.md
       2. Parse both sides of each conflict
       3. Resolve structural columns using field-specific merge rules
       4. Present resolution to user
@@ -41,14 +41,14 @@ verification:
     - Format validation passes after resolution
 ---
 
-# Tasks.md Conflict Resolver
+# optimus-tasks.md Conflict Resolver
 
-Resolves merge conflicts in `tasks.md` caused by parallel structural edits across feature branches.
+Resolves merge conflicts in `optimus-tasks.md` caused by parallel structural edits across feature branches.
 Since Status and Branch live in state.json (gitignored), conflicts are limited to structural columns.
 
 **Classification:** Administrative skill — runs on any branch.
 
-**CRITICAL:** Status and Branch live in state.json (gitignored) — they are NOT in tasks.md
+**CRITICAL:** Status and Branch live in state.json (gitignored) — they are NOT in optimus-tasks.md
 and cannot cause merge conflicts. This skill only resolves structural column conflicts
 (Title, Tipo, Depends, Priority, Version, Estimate, TaskSpec).
 
@@ -62,7 +62,15 @@ Execute AGENTS.md Protocol: Resolve Tasks Git Scope. This obtains `TASKS_FILE`,
 `TASKS_GIT_SCOPE`, `TASKS_GIT_REL`, and the `tasks_git` helper. In `separate-repo`
 scope, merge conflicts are resolved inside the tasks repo (not the project repo).
 
-Check if `tasks.md` has merge conflict markers:
+**Legacy file check:** If `<TASKS_DIR>/tasks.md` exists with the optimus format
+marker but `<TASKS_DIR>/optimus-tasks.md` does not, warn the user: "Detected legacy
+`<TASKS_DIR>/tasks.md`. Run any other Optimus skill (e.g., /optimus-tasks) once to
+trigger the rename, then retry /optimus-resolve."
+Do NOT auto-rename from /optimus-resolve since the file may be in a conflict state.
+For the rename context, see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Also check legacy migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir.
+
+Check if `optimus-tasks.md` has merge conflict markers:
 
 ```bash
 # TASKS_FILE was set by Protocol: Resolve Tasks Git Scope
@@ -73,12 +81,12 @@ If no conflict markers found:
 - Check if a merge/rebase is in progress in the correct repo:
   - Same-repo: `git status` in project repo
   - Separate-repo: `tasks_git status` in tasks repo
-- If no merge in progress → **STOP**: "No conflicts found in tasks.md. Nothing to resolve."
-- If merge in progress but tasks.md is not conflicted → **STOP**: "tasks.md is not conflicted. Use `git mergetool` for other files."
+- If no merge in progress → **STOP**: "No conflicts found in optimus-tasks.md. Nothing to resolve."
+- If merge in progress but optimus-tasks.md is not conflicted → **STOP**: "optimus-tasks.md is not conflicted. Use `git mergetool` for other files."
 
 ### Step 1.2: Parse Conflict Regions
 
-Read `tasks.md` and identify each conflict region:
+Read `optimus-tasks.md` and identify each conflict region:
 
 ```
 <<<<<<< HEAD (or current branch)
@@ -117,7 +125,7 @@ For tasks that appear on BOTH sides with different values, proceed to Phase 2.
 
 ## Phase 2: Resolve Structural Conflicts
 
-Since Status and Branch live in state.json (gitignored, not in tasks.md), conflicts
+Since Status and Branch live in state.json (gitignored, not in optimus-tasks.md), conflicts
 are limited to structural columns: ID, Title, Tipo, Depends, Priority, Version,
 Estimate, TaskSpec. No status ordering or "most-advanced-status rule" is needed.
 
@@ -125,8 +133,8 @@ Estimate, TaskSpec. No status ordering or "most-advanced-status rule" is needed.
 
 For each task that differs between current and incoming:
 
-**NOTE:** Status and Branch are NOT in tasks.md — they live in state.json (gitignored).
-Conflicts in tasks.md are limited to structural columns only.
+**NOTE:** Status and Branch are NOT in optimus-tasks.md — they live in state.json (gitignored).
+Conflicts in optimus-tasks.md are limited to structural columns only.
 
 1. Compare the **Estimate** column:
    - If one side has a value and the other has `-` → keep the non-empty value
@@ -140,7 +148,7 @@ Conflicts in tasks.md are limited to structural columns only.
 
 ### Step 2.3: Handle Structural Conflicts
 
-Since Status and Branch live in state.json (not tasks.md), conflicts are limited to
+Since Status and Branch live in state.json (not optimus-tasks.md), conflicts are limited to
 structural fields. If both sides changed the same structural field (e.g., Priority or
 Version), flag for user decision via `AskUser`.
 
@@ -151,7 +159,7 @@ Version), flag for user decision via `AskUser`.
 ### Step 3.1: Show Resolution Summary
 
 ```markdown
-## tasks.md Conflict Resolution
+## optimus-tasks.md Conflict Resolution
 
 ### Conflict Regions: N
 ### Auto-Resolved: M
@@ -179,10 +187,10 @@ and the context of what changed on each side.
 
 ### Step 3.3: Preview Resolved File
 
-Present the full resolved `tasks.md` content (or a diff of changes) to the user:
+Present the full resolved `optimus-tasks.md` content (or a diff of changes) to the user:
 
 ```
-Here is the resolved tasks.md. Review before applying:
+Here is the resolved optimus-tasks.md. Review before applying:
 ```
 
 Ask via `AskUser`:
@@ -198,7 +206,7 @@ Ask via `AskUser`:
 
 ### Step 4.1: Write Resolved File
 
-Write the fully resolved `tasks.md` (no conflict markers remaining).
+Write the fully resolved `optimus-tasks.md` (no conflict markers remaining).
 
 ### Step 4.2: Validate Format
 
@@ -229,7 +237,7 @@ tasks_git add "$TASKS_GIT_REL"
 - Conflicts resolved: N
 - Auto-resolved: M
 - User decisions: K
-- tasks.md staged for commit
+- optimus-tasks.md staged for commit
 
 ### Next Steps
 If you were resolving a merge conflict:
@@ -252,7 +260,7 @@ Run `/optimus-report` to verify the dashboard looks correct.
 - If a conflict involves non-status columns (Title, Priority, Depends) changed on BOTH
   sides, always ask the user — do not guess
 - Validate the resolved file before staging — catch format errors before they propagate
-- This skill is read-then-write — it modifies ONLY tasks.md, never any other file
+- This skill is read-then-write — it modifies ONLY optimus-tasks.md, never any other file
 
 <!-- INLINE-PROTOCOLS:START -->
 ## Shared Protocols (from AGENTS.md)
@@ -260,14 +268,425 @@ Run `/optimus-report` to verify the dashboard looks correct.
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
+### Protocol: Migrate tasks.md to tasksDir
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
+LEGACY_FILE=".optimus/tasks.md"
+if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  # Partial/failed migration OR manual copy. Use new location but WARN the user.
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
+  echo "         This indicates a partial prior migration or manual copy." >&2
+  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
+  NEEDS_MIGRATION=0
+elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  NEEDS_MIGRATION=1
+else
+  NEEDS_MIGRATION=0
+fi
+```
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
+
+```
+[DRY-RUN] Migration would be offered for this task:
+[DRY-RUN]   Legacy: $LEGACY_FILE
+[DRY-RUN]   New:    $TASKS_FILE
+[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
+```
+
+**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
+in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
+are preserved locally but no longer shared via git. Warn user BEFORE untracking:
+
+```bash
+if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
+  if [ -f .optimus/config.json ]; then
+    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
+    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
+    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
+    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
+  fi
+fi
+```
+
+**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
+
+```
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
+Migrate now? (Recommended — keeping the old location will break other skills.)
+```
+
+Options:
+- **Migrate now** — copy → add in target repo → remove from project repo
+- **Skip this time** — continue with the legacy file (emit warning; this will break)
+- **Abort** — stop the current command so you can migrate manually
+
+**Migration flow (when user chooses "Migrate now"):**
+
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
+Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted migrations:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
+```
+
+**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  mkdir -p "$TASKS_DIR"
+  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
+    rm -f .optimus/.migration-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore legacy from HEAD, remove new from working tree
+    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.migration-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
+  mkdir -p "$TASKS_DIR"
+  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
+    echo "ERROR: cp failed. Migration aborted." >&2
+    rm -f .optimus/.migration-in-progress
+    exit 1
+  fi
+  # Commit #1: in tasks repo
+  if ! tasks_git add "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git add failed. Rolling back..." >&2
+    rm -f "$TASKS_FILE"
+    rm -f .optimus/.migration-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
+    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.migration-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+  # Commit #2: in project repo
+  if ! git rm "$LEGACY_FILE"; then
+    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
+    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
+    rm -f .optimus/.migration-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
+    echo "Manual cleanup needed: git commit after resolving." >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.migration-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
+commit exit code; restore index on failure:
+
+```bash
+if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
+  git rm --cached .optimus/config.json
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    # Restore to index so user can retry
+    git reset HEAD .optimus/config.json 2>/dev/null
+    rm -f "$COMMIT_MSG_FILE"
+    echo "ERROR: Failed to untrack config.json. Index restored." >&2
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
+  else
+    rm -f "$COMMIT_MSG_FILE"
+  fi
+fi
+```
+
+**Ensure `.gitignore` includes the operational-files block:**
+Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
+
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
+Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
+file was manually edited and lacks a `## Versions` section), inform user and suggest
+running `/optimus-import` to rebuild:
+
+```bash
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Migration success: clear checkpoint marker and log each step.**
+```bash
+rm -f .optimus/.migration-in-progress
+echo "INFO: Migration completed successfully:" >&2
+echo "  - Legacy location: $LEGACY_FILE" >&2
+echo "  - New location:    $TASKS_FILE" >&2
+echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
+```
+
+**Report success:**
+```
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
+Remember to push both repos (project + tasks) when you're ready.
+```
+
+**Interrupted migration recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.migration-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.migration-in-progress 2>/dev/null)
+  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry migration / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
+for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
+
+
 ### Protocol: Resolve Tasks Git Scope
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -292,7 +711,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -319,7 +738,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -332,9 +751,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -12,7 +12,7 @@ skip_when: >
   - Task is Cancelado
   - User explicitly wants to start a new task (use /optimus-plan T-XXX instead)
 prerequisite: >
-  - tasks.md exists and is valid
+  - optimus-tasks.md exists and is valid
   - (Recommended) state.json has an entry for the task; otherwise resume falls back to the Pendente flow
 NOT_skip_when: >
   - "I remember the path" -- Resume still sets up the Droid session workspace and prints the next recommended command.
@@ -21,7 +21,7 @@ examples:
   - name: Resume by task ID
     invocation: "Resume T-012"
     expected_flow: >
-      1. Validate T-012 in tasks.md
+      1. Validate T-012 in optimus-tasks.md
       2. Read status from state.json (e.g., Em Andamento)
       3. Resolve worktree (navigate or recreate from branch)
       4. Print status + suggested "cd <path>"
@@ -57,7 +57,7 @@ verification:
   manual:
     - Current working directory is the task's worktree (when it exists)
     - Terminal title shows "optimus: RESUME <T-XXX> — <title>"
-    - No changes to tasks.md, stats.json, or session files
+    - No changes to optimus-tasks.md, stats.json, or session files
     - state.json is untouched UNLESS the user explicitly picked "Reset to Pendente" in Step 3.3 Case 3
 ---
 
@@ -66,7 +66,7 @@ verification:
 Administrative skill to retake a task after closing the terminal: resolves the worktree,
 reports the current status, and offers to invoke the next stage. NEVER changes task status.
 
-**Classification:** Administrative skill — runs on any branch. Does not modify `tasks.md`,
+**Classification:** Administrative skill — runs on any branch. Does not modify `optimus-tasks.md`,
 `stats.json`, or session files. Creates a worktree only as a recovery step when the branch
 exists but its worktree is missing.
 
@@ -94,29 +94,30 @@ command -v jq >/dev/null 2>&1
 
 If `jq` is not available, **STOP**: "jq is required by /optimus-resume. Install it and retry."
 
-### Step 1.2: Find and Validate tasks.md (HARD BLOCK)
-
-Find and validate tasks.md — see AGENTS.md Protocol: tasks.md Validation.
+### Step 1.2: Resolve and Validate optimus-tasks.md (HARD BLOCK)
 
 **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/tasks.md` does not, the
+If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
 protocol offers migration before proceeding. (Resume is read-only on state.json,
 but may assist with the migration which writes to git.)
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+
+Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
 ### Step 1.3: Reject Empty Tasks Table (HARD BLOCK)
 
 AGENTS.md Format Validation item 15 requires checking for zero-data-row tables. A valid
-but empty `tasks.md` would otherwise surface as a misleading "No in-progress tasks found"
+but empty `optimus-tasks.md` would otherwise surface as a misleading "No in-progress tasks found"
 message in Step 2.2.
 
 ```bash
-# Step 1.2 resolved TASKS_FILE via Protocol: tasks.md Validation (which calls
+# Step 1.2 resolved TASKS_FILE via Protocol: optimus-tasks.md Validation (which calls
 # Protocol: Resolve Tasks Git Scope). If TASKS_FILE is unset here, that means
 # Step 1.2 did NOT execute — surface the control-flow bug immediately instead
 # of masking it with a silent fallback (which would produce misleading
-# "docs/pre-dev/tasks.md not found" errors for users who customized tasksDir).
+# "docs/pre-dev/optimus-tasks.md not found" errors for users who customized tasksDir).
 if [ -z "${TASKS_FILE:-}" ]; then
-  echo "ERROR: TASKS_FILE is unset — Step 1.2 (tasks.md Validation) did not execute." >&2
+  echo "ERROR: TASKS_FILE is unset — Step 1.2 (optimus-tasks.md Validation) did not execute." >&2
   echo "Protocol: Resolve Tasks Git Scope must run before Step 1.3." >&2
   exit 1
 fi
@@ -173,13 +174,13 @@ if ! [[ "$TASK_ID" =~ ^T-[0-9]+$ ]]; then
 fi
 ```
 
-Verify the task exists in tasks.md:
+Verify the task exists in optimus-tasks.md:
 
 ```bash
 grep -E "^\| ${TASK_ID} \|" "$TASKS_FILE" >/dev/null
 ```
 
-If no match → **STOP**: `"Task ${TASK_ID} not found in tasks.md. Run /optimus-report to see available tasks."`
+If no match → **STOP**: `"Task ${TASK_ID} not found in optimus-tasks.md. Run /optimus-report to see available tasks."`
 
 ### Step 2.2: Auto-Detect (no ID provided)
 
@@ -212,12 +213,12 @@ IN_PROGRESS=$(printf '%s' "$STATE_JSON" | jq -r '
 
 ### Step 2.3: Read Task Metadata (HARD BLOCK)
 
-Extract task metadata from tasks.md. The agent MUST execute the bash snippet literally;
+Extract task metadata from optimus-tasks.md. The agent MUST execute the bash snippet literally;
 prose-level "capture TASK_TITLE…" is not sufficient because downstream steps consume the
 vars directly.
 
 ```bash
-# tasks.md columns by pipe index: | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# optimus-tasks.md columns by pipe index: | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
 TASK_ROW=$(awk -F'|' -v id="$TASK_ID" '
   { gsub(/^ +| +$/,"",$2) }
   $2 == id { print; exit }
@@ -237,7 +238,7 @@ TASK_VERSION=$(_trim "$(printf '%s' "$TASK_ROW" | awk -F'|' '{print $7}')")
 for v in TASK_TITLE TASK_TIPO TASK_DEPENDS TASK_VERSION; do
   eval "val=\${$v}"
   if [ -z "$val" ]; then
-    echo "ERROR: $v is empty for $TASK_ID (could not parse tasks.md row)."
+    echo "ERROR: $v is empty for $TASK_ID (could not parse optimus-tasks.md row)."
     # STOP
   fi
 done
@@ -718,7 +719,7 @@ recommended command whenever they like.
 ## Rules
 
 - **Admin skill** — runs on any branch, does not alter task status.
-- NEVER writes to `stats.json`, `tasks.md`, or `.optimus/sessions/session-T-XXX.json`.
+- NEVER writes to `stats.json`, `optimus-tasks.md`, or `.optimus/sessions/session-T-XXX.json`.
 - **state.json is read-only EXCEPT** for the user-confirmed "Reset to Pendente" recovery
   option in Step 3.3 Case 3 (inconsistent state). No other mutation is permitted.
 - Creates a worktree ONLY in the recovery path (Step 3.3 case 2). Never creates branches.
@@ -752,7 +753,7 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 ### Format Validation
 
-Every stage agent (1-4) MUST validate the tasks.md format before operating:
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
 3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
@@ -774,7 +775,7 @@ running `/optimus-import` to fix the format. Do NOT attempt to interpret malform
 15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
 format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
 format validation and before task identification. If zero data rows: **STOP** and inform the
-user: "No tasks found in tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
 **NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
@@ -786,10 +787,10 @@ in the cycle so the user can fix it with `/optimus-tasks`.
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -814,7 +815,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -841,7 +842,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -854,9 +855,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -938,8 +939,8 @@ Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: R
 
 **Referenced by:** plan, build, review, pr-check, done (workspace auto-navigation)
 
-Branch names are derived deterministically from the task's structural data in tasks.md.
-They are NOT stored in tasks.md — they are stored in state.json for quick reference
+Branch names are derived deterministically from the task's structural data in optimus-tasks.md.
+They are NOT stored in optimus-tasks.md — they are stored in state.json for quick reference
 and can always be re-derived.
 
 **Derivation rule:**
@@ -978,25 +979,23 @@ Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -1033,7 +1032,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -1044,22 +1043,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -1075,7 +1074,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -1103,7 +1102,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -1121,7 +1120,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -1146,7 +1145,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -1156,18 +1155,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -1183,7 +1182,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -1203,7 +1202,190 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: Terminal Identification
@@ -1301,25 +1483,25 @@ will not see a title update.
 Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
 
 
-### Protocol: tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
-Every stage agent MUST validate tasks.md before operating. The full validation rules are
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
 defined in the "Format Validation" section above (items 1-15). This protocol is the
 executable version:
 
 1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
    resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
 3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
 
-**All subsequent references to `tasks.md` in the skill use the resolved `TASKS_FILE` path.
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
 All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on tasks.md use the `tasks_git` helper** (which handles both same-repo
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
 and separate-repo scopes).
 
-Skills reference this as: "Find and validate tasks.md (HARD BLOCK) — see AGENTS.md Protocol: tasks.md Validation."
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -84,18 +84,19 @@ for committed code).
 ### Step 1.0: Verify GitHub CLI (HARD BLOCK)
 Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 
-### Step 1.0.1: Find and Validate tasks.md
-**HARD BLOCK:** Find and validate tasks.md — see AGENTS.md Protocol: tasks.md Validation.
-
+### Step 1.0.1: Resolve and Validate optimus-tasks.md
 **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/tasks.md` does not, the
+If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
 protocol offers migration before proceeding.
+Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+
+**HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
 ### Step 1.0.2: Verify Workspace (HARD BLOCK)
 Resolve workspace — see AGENTS.md Protocol: Workspace Auto-Navigation.
 
-### Step 1.0.3: Check tasks.md Divergence (warning)
-Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
+### Step 1.0.3: Check optimus-tasks.md Divergence (warning)
+Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
 
 ### Step 1.0.4: Branch-Task Cross-Validation
 Branch-task cross-validation — included in AGENTS.md Protocol: Workspace Auto-Navigation.
@@ -175,7 +176,7 @@ _optimus_set_title ""
 
 **HARD BLOCK:** This step is mandatory. Do NOT skip it.
 
-1. Read `tasks.md` and find the row for the confirmed task ID
+1. Read `optimus-tasks.md` and find the row for the confirmed task ID
 2. Read the task's status from state.json — see AGENTS.md Protocol: State Management.
    - If status is `Em Andamento` → proceed (build has completed)
    - If status is `Validando Impl` → proceed (re-execution of this stage)
@@ -183,7 +184,7 @@ _optimus_set_title ""
    - If status is `Validando Spec` → **STOP**: "Task T-XXX is in 'Validando Spec'. Run build first."
    - If status is `DONE` → **STOP**: "Task T-XXX is in 'DONE'. It has already moved past this stage."
    - If status is `Cancelado` → **STOP**: "Task T-XXX was cancelled. Cannot validate a cancelled task."
-3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from tasks.md.
+3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
    - For each dependency ID listed, read its status from state.json:
      - If ALL dependencies have status `DONE` → proceed
@@ -760,7 +761,7 @@ When the loop exits (any status), proceed to Phase 9 (Re-run Guard).
 Execute re-run guard — see AGENTS.md Protocol: Re-run Guard.
 
 - If the user chooses **Re-run with clean context**: go back to Step 1.1 (Discover Project
-  Structure). Skip all prior setup steps (GitHub CLI check, tasks.md validation, workspace
+  Structure). Skip all prior setup steps (GitHub CLI check, optimus-tasks.md validation, workspace
   resolution, task identification, session state, status validation, divergence check).
   Increment stage stats before re-starting analysis.
 - If the user chooses **Advance** (or 0 findings): proceed to Phase 10 (integration tests).
@@ -906,7 +907,7 @@ The `--assignee @me` flag assigns the PR to the authenticated GitHub user automa
 The body should include:
 - Task ID and title
 - Objective (from Ring source via `TaskSpec` column)
-- Link to the task section in tasks.md
+- Link to the task section in optimus-tasks.md
 
 ### Step 13.4: Confirm
 
@@ -1010,7 +1011,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -1025,7 +1026,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -1038,7 +1039,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -1052,7 +1053,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -1074,10 +1075,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -1086,7 +1087,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -1118,13 +1119,13 @@ The subtasks directory is derived automatically from the TaskSpec path:
 - The `T-NNN` identifier is extracted from the task spec filename convention
 
 Agents read objective and acceptance criteria directly from the Ring source files.
-The tasks.md table only tracks structural data (dependencies, versions, priorities)
+The optimus-tasks.md table only tracks structural data (dependencies, versions, priorities)
 — it does NOT duplicate content from Ring.
 
 
 ### Format Validation
 
-Every stage agent (1-4) MUST validate the tasks.md format before operating:
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
 3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
@@ -1146,7 +1147,7 @@ running `/optimus-import` to fix the format. Do NOT attempt to interpret malform
 15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
 format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
 format validation and before task identification. If zero data rows: **STOP** and inform the
-user: "No tasks found in tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
 **NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
@@ -1158,10 +1159,10 @@ in the cycle so the user can fix it with `/optimus-tasks`.
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -1186,7 +1187,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -1213,7 +1214,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -1226,9 +1227,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -1485,7 +1486,7 @@ inform the user which droids need to be installed.
 After the task ID is confirmed and dependencies are validated, check if the task belongs
 to the `Ativa` version. If not, present options before proceeding.
 
-1. Read the task's **Version** column from `tasks.md`
+1. Read the task's **Version** column from `optimus-tasks.md`
 2. Read the **Versions** table and find the version with Status `Ativa`
    - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
 3. **If the task's version matches the `Ativa` version** → proceed silently
@@ -1500,7 +1501,7 @@ to the `Ativa` version. If not, present options before proceeding.
    - **Cancel** — stops execution
 
 5. **If "Move to active version and continue":**
-   - Update the task's Version column in `tasks.md` to the `Ativa` version name
+   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
    - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
      separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
      ```bash
@@ -1687,8 +1688,8 @@ Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage
 
 **Referenced by:** all stage agents (1-4)
 
-Since status and branch data live in state.json (gitignored), tasks.md rarely changes
-on feature branches. This protocol detects the uncommon case where tasks.md WAS modified
+Since status and branch data live in state.json (gitignored), optimus-tasks.md rarely changes
+on feature branches. This protocol detects the uncommon case where optimus-tasks.md WAS modified
 (e.g., Active Version Guard moved a task). It uses `tasks_git` so it works in both
 same-repo and separate-repo scopes.
 
@@ -1727,7 +1728,7 @@ fi
 
 - If diff output is non-empty → warn via `AskUser`:
   ```
-  tasks.md has diverged between your branch and <default_branch>.
+  optimus-tasks.md has diverged between your branch and <default_branch>.
   This may cause merge conflicts when the PR is merged.
   ```
   Options:
@@ -1738,7 +1739,7 @@ fi
 - **NOTE:** In separate-repo scope, "diverged" means the tasks repo branches diverge —
   not the project code branches.
 
-Skills reference this as: "Check tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
+Skills reference this as: "Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning."
 
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
@@ -1789,25 +1790,23 @@ Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Inc
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -1844,7 +1843,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -1855,22 +1854,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -1886,7 +1885,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -1914,7 +1913,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -1932,7 +1931,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -1957,7 +1956,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -1967,18 +1966,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -1994,7 +1993,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -2014,7 +2013,7 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: Notification Hooks
@@ -2455,7 +2454,7 @@ whether to suggest advancement or offer a re-run. This protocol replaces the sta
 
 4. **If "Re-run with clean context":**
    - Increment stage stats (new execution)
-   - **Skip:** GitHub CLI check, tasks.md validation, task identification, session state
+   - **Skip:** GitHub CLI check, optimus-tasks.md validation, task identification, session state
      check, status validation/change, workspace creation, divergence check
    - **Re-execute:** project structure discovery, document loading, static analysis,
      coverage profiling, agent dispatch (ALL agents), finding presentation, fix application,
@@ -2477,6 +2476,189 @@ committed during the previous run. It does NOT revert commits. This validates th
 applied fixes are correct and checks for any issues introduced by the fixes.
 
 Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: Ring Droid Requirement Check
@@ -2757,13 +2939,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do
@@ -2800,7 +2982,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
-1. Read the task's `TaskSpec` column from `tasks.md`
+1. Read the task's `TaskSpec` column from `optimus-tasks.md`
 2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus-tasks` or `/optimus-import`."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
@@ -2924,25 +3106,25 @@ fi
 Skills reference this as: "Resolve workspace (HARD BLOCK) — see AGENTS.md Protocol: Workspace Auto-Navigation."
 
 
-### Protocol: tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
-Every stage agent MUST validate tasks.md before operating. The full validation rules are
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
 defined in the "Format Validation" section above (items 1-15). This protocol is the
 executable version:
 
 1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
    resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
 3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
 
-**All subsequent references to `tasks.md` in the skill use the resolved `TASKS_FILE` path.
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
 All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on tasks.md use the `tasks_git` helper** (which handles both same-repo
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
 and separate-repo scopes).
 
-Skills reference this as: "Find and validate tasks.md (HARD BLOCK) — see AGENTS.md Protocol: tasks.md Validation."
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/scripts/inline-protocols.py
+++ b/scripts/inline-protocols.py
@@ -23,6 +23,14 @@ MARKER_END = "<!-- INLINE-PROTOCOLS:END -->"
 # Max file size (5 MB) — prevents hanging on bloated or corrupted inputs.
 MAX_FILE_SIZE = 5 * 1024 * 1024
 
+# Substring used to detect the format-validation protocol heading. Anchored to a
+# single source of truth so that future heading renames update the matcher in
+# exactly one place. A regression test parses live AGENTS.md and asserts that
+# at least one heading contains this token.
+VALIDATION_PROTOCOL_TOKEN = "optimus-tasks.md Validation"
+MIGRATE_PROTOCOL_KEY = "Protocol: Migrate tasks.md to tasksDir"
+RENAME_PROTOCOL_KEY = "Protocol: Rename tasks.md to optimus-tasks.md"
+
 # Module-level compiled patterns.
 HEADING_RE = re.compile(r'^(?:#{2,3})\s+(.+)$')
 PROTOCOL_RE = re.compile(r'AGENTS\.md Protocol:\s*([^\n"]+)')
@@ -171,7 +179,8 @@ def inline_protocols() -> None:
     for key in ["File Location", "Valid Status Values (stored in state.json)",
                  "Task Spec Resolution", "Format Validation",
                  "Protocol: Resolve Tasks Git Scope",
-                 "Protocol: Migrate tasks.md to tasksDir"]:
+                 MIGRATE_PROTOCOL_KEY,
+                 RENAME_PROTOCOL_KEY]:
         if key in sections:
             foundational[key] = sections[key]
 
@@ -217,10 +226,20 @@ def inline_protocols() -> None:
             if key not in sections_to_inline:
                 sections_to_inline[key] = sections[key]
 
+        # Pair sibling startup protocols: any skill that inlines the legacy
+        # Migrate also needs Rename (and vice versa). Both run on skill startup
+        # to detect/repair filename and location drift.
+        if MIGRATE_PROTOCOL_KEY in sections_to_inline and RENAME_PROTOCOL_KEY in sections \
+                and RENAME_PROTOCOL_KEY not in sections_to_inline:
+            sections_to_inline[RENAME_PROTOCOL_KEY] = sections[RENAME_PROTOCOL_KEY]
+        if RENAME_PROTOCOL_KEY in sections_to_inline and MIGRATE_PROTOCOL_KEY in sections \
+                and MIGRATE_PROTOCOL_KEY not in sections_to_inline:
+            sections_to_inline[MIGRATE_PROTOCOL_KEY] = sections[MIGRATE_PROTOCOL_KEY]
+
         # Also check if State Management is referenced -> include foundational state.json docs
         needs_state = any("State Management" in k for k in sections_to_inline)
         needs_taskspec = any("TaskSpec" in k for k in sections_to_inline)
-        needs_format = any("tasks.md Validation" in k for k in sections_to_inline)
+        needs_format = any(VALIDATION_PROTOCOL_TOKEN in k for k in sections_to_inline)
 
         extra: dict[str, str] = {}
         if needs_state and "File Location" in foundational:
@@ -232,16 +251,22 @@ def inline_protocols() -> None:
         if needs_format and "Format Validation" in foundational:
             extra["Format Validation"] = foundational["Format Validation"]
 
-        # tasks.md Validation depends on Resolve Tasks Git Scope (which defines
-        # TASKS_DIR/TASKS_FILE/TASKS_GIT_SCOPE/tasks_git). Always include the scope
-        # protocol and the migration protocol when validation is referenced.
+        # optimus-tasks.md Validation depends on Resolve Tasks Git Scope (which defines
+        # TASKS_DIR/TASKS_FILE/TASKS_GIT_SCOPE/tasks_git). Defensive scaffold:
+        # the pairing block above already injects Migrate+Rename when either is
+        # explicitly referenced; this block adds them when ONLY Validation is
+        # referenced (currently unreachable from real skills, but kept as a
+        # safety net for future skills that might under-reference).
         if needs_format:
             if "Protocol: Resolve Tasks Git Scope" in foundational and \
                "Protocol: Resolve Tasks Git Scope" not in sections_to_inline:
                 extra["Protocol: Resolve Tasks Git Scope"] = foundational["Protocol: Resolve Tasks Git Scope"]
-            if "Protocol: Migrate tasks.md to tasksDir" in foundational and \
-               "Protocol: Migrate tasks.md to tasksDir" not in sections_to_inline:
-                extra["Protocol: Migrate tasks.md to tasksDir"] = foundational["Protocol: Migrate tasks.md to tasksDir"]
+            if MIGRATE_PROTOCOL_KEY in foundational and \
+               MIGRATE_PROTOCOL_KEY not in sections_to_inline:
+                extra[MIGRATE_PROTOCOL_KEY] = foundational[MIGRATE_PROTOCOL_KEY]
+            if RENAME_PROTOCOL_KEY in foundational and \
+               RENAME_PROTOCOL_KEY not in sections_to_inline:
+                extra[RENAME_PROTOCOL_KEY] = foundational[RENAME_PROTOCOL_KEY]
 
         content = strip_existing_inline(raw_content).rstrip() + "\n"
 

--- a/scripts/test_inline_protocols.py
+++ b/scripts/test_inline_protocols.py
@@ -74,9 +74,9 @@ class TestExtractRefsFromSkill:
         assert "Protocol: PR Title Validation" in refs
 
     def test_protocol_with_dots_in_name(self, tmp_path: Path):
-        p = self._write_skill(tmp_path, "see AGENTS.md Protocol: tasks.md Validation.")
+        p = self._write_skill(tmp_path, "see AGENTS.md Protocol: optimus-tasks.md Validation.")
         refs = ip.extract_refs_from_skill(p)
-        assert "Protocol: tasks.md Validation" in refs
+        assert "Protocol: optimus-tasks.md Validation" in refs
 
     def test_common_pattern_ref(self, tmp_path: Path):
         p = self._write_skill(tmp_path, 'AGENTS.md "Common Patterns > Convergence Loop"')
@@ -114,7 +114,7 @@ class TestExtractRefsFromSkill:
 
 class TestNormalizeKey:
     def test_strips_trailing_parens(self):
-        assert ip._normalize_key("tasks.md Validation (HARD BLOCK)") == "tasks.md validation"
+        assert ip._normalize_key("optimus-tasks.md Validation (HARD BLOCK)") == "optimus-tasks.md validation"
 
     def test_no_parens(self):
         assert ip._normalize_key("Push Commits") == "push commits"
@@ -128,7 +128,7 @@ class TestNormalizeKey:
 class TestMatchRefToSection:
     SECTIONS = {
         "Protocol: State Management": "...",
-        "Protocol: tasks.md Validation (HARD BLOCK)": "...",
+        "Protocol: optimus-tasks.md Validation (HARD BLOCK)": "...",
         "Protocol: TaskSpec Resolution": "...",
         "Protocol: Push Commits (optional)": "...",
         "Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)": "...",
@@ -139,7 +139,7 @@ class TestMatchRefToSection:
         assert ip.match_ref_to_section("Protocol: State Management", self.SECTIONS) == "Protocol: State Management"
 
     def test_match_ignores_parenthetical(self):
-        assert ip.match_ref_to_section("Protocol: tasks.md Validation", self.SECTIONS) == "Protocol: tasks.md Validation (HARD BLOCK)"
+        assert ip.match_ref_to_section("Protocol: optimus-tasks.md Validation", self.SECTIONS) == "Protocol: optimus-tasks.md Validation (HARD BLOCK)"
 
     def test_no_ambiguous_match(self):
         result = ip.match_ref_to_section("Protocol: TaskSpec Resolution", self.SECTIONS)
@@ -181,6 +181,88 @@ class TestMatchRefToSection:
             "Parser, heading, or match logic drifted."
         )
         assert "Convergence Loop" in result
+
+    def test_validation_protocol_token_matches_live_heading(self):
+        """Regression guard for VALIDATION_PROTOCOL_TOKEN constant.
+
+        The needs_format substring matcher in inline-protocols.py uses the
+        VALIDATION_PROTOCOL_TOKEN constant to detect the format-validation
+        protocol heading. If the heading is renamed in AGENTS.md, this test
+        flags the drift before propagation silently breaks foundational
+        injection (Migrate, Rename, Resolve Tasks Git Scope).
+        """
+        agents_md = Path(__file__).parent.parent / "AGENTS.md"
+        sections = _parse_real_agents_md(agents_md)
+        matching = [k for k in sections if ip.VALIDATION_PROTOCOL_TOKEN in k]
+        assert matching, (
+            f"VALIDATION_PROTOCOL_TOKEN ({ip.VALIDATION_PROTOCOL_TOKEN!r}) "
+            "matches no heading in live AGENTS.md. The token in "
+            "inline-protocols.py drifted from the actual heading text."
+        )
+
+    def test_migrate_and_rename_protocol_keys_match_live_headings(self):
+        """Regression guard for MIGRATE_PROTOCOL_KEY and RENAME_PROTOCOL_KEY.
+
+        Both keys are used by the pairing logic to inject the legacy migrate
+        protocol whenever the new rename is referenced and vice versa. If
+        either heading is renamed in AGENTS.md, the pairing silently breaks.
+        """
+        agents_md = Path(__file__).parent.parent / "AGENTS.md"
+        sections = _parse_real_agents_md(agents_md)
+        assert ip.MIGRATE_PROTOCOL_KEY in sections, (
+            f"MIGRATE_PROTOCOL_KEY ({ip.MIGRATE_PROTOCOL_KEY!r}) not found "
+            "as a heading in live AGENTS.md."
+        )
+        assert ip.RENAME_PROTOCOL_KEY in sections, (
+            f"RENAME_PROTOCOL_KEY ({ip.RENAME_PROTOCOL_KEY!r}) not found "
+            "as a heading in live AGENTS.md."
+        )
+
+    def test_pairing_injects_rename_when_only_migrate_referenced(self, tmp_path, monkeypatch):
+        """Pairing branch regression: a SKILL.md that references ONLY Migrate
+        (not optimus-tasks.md Validation) must still get Rename injected via
+        the pairing block in inline-protocols.py. This is the failure mode
+        that bit report/quick-report before the pairing block was added.
+        """
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(
+            "## Protocol: Migrate tasks.md to tasksDir\nMigrate body content\n\n"
+            "## Protocol: Rename tasks.md to optimus-tasks.md\nRename body content\n"
+        )
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
+        skill_dir = tmp_path / "x" / "skills" / "optimus-x"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        skill.write_text("see AGENTS.md Protocol: Migrate tasks.md to tasksDir.\n")
+        ip.inline_protocols()
+        inlined = skill.read_text()
+        assert "Migrate body content" in inlined, "Migrate failed to inline"
+        assert "Rename body content" in inlined, (
+            "Pairing failed: Rename was not auto-injected when SKILL.md only "
+            "references Migrate (regression risk for read-only skills)."
+        )
+
+    def test_pairing_injects_migrate_when_only_rename_referenced(self, tmp_path, monkeypatch):
+        """Symmetric pairing branch regression: ONLY Rename referenced → Migrate auto-paired."""
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(
+            "## Protocol: Migrate tasks.md to tasksDir\nMigrate body content\n\n"
+            "## Protocol: Rename tasks.md to optimus-tasks.md\nRename body content\n"
+        )
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
+        skill_dir = tmp_path / "x" / "skills" / "optimus-x"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        skill.write_text("see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.\n")
+        ip.inline_protocols()
+        inlined = skill.read_text()
+        assert "Rename body content" in inlined
+        assert "Migrate body content" in inlined, (
+            "Symmetric pairing failed: Migrate was not auto-injected when "
+            "SKILL.md only references Rename."
+        )
 
 
 def _parse_real_agents_md(path):
@@ -408,10 +490,10 @@ class TestEdgeCases:
 
     def test_heading_with_special_chars(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         agents = tmp_path / "AGENTS.md"
-        agents.write_text("## Protocol: tasks.md Validation (HARD BLOCK)\nValidation content\n")
+        agents.write_text("## Protocol: optimus-tasks.md Validation (HARD BLOCK)\nValidation content\n")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
         sections = ip.parse_agents_md()
-        assert "Protocol: tasks.md Validation (HARD BLOCK)" in sections
+        assert "Protocol: optimus-tasks.md Validation (HARD BLOCK)" in sections
 
     def test_protocol_with_trailing_paren(self, tmp_path: Path):
         p = tmp_path / "SKILL.md"

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -720,11 +720,11 @@ class TestConvergenceModel:
         assert violations == [], "\n".join(violations)
 
 
-# --- tasks.md format spec: marker, Tipo, versions, state.json ---
+# --- optimus-tasks.md format spec: marker, Tipo, versions, state.json ---
 
 
 class TestTasksFormatSpec:
-    """tasks.md format invariants must be defined in AGENTS.md."""
+    """optimus-tasks.md format invariants must be defined in AGENTS.md."""
 
     def test_agents_md_defines_format_marker(self):
         """AGENTS.md must define the tasks-v1 format marker."""
@@ -745,11 +745,11 @@ class TestTasksFormatSpec:
             assert status in content, f"AGENTS.md missing version status '{status}'"
 
     def test_status_lives_in_state_json(self):
-        """AGENTS.md must state that status is NOT stored in tasks.md."""
+        """AGENTS.md must state that status is NOT stored in optimus-tasks.md."""
         content = AGENTS_MD.read_text()
-        assert "NOT stored in tasks.md" in content or \
-            "NOT in tasks.md" in content, (
-            "AGENTS.md missing statement that status lives in state.json, not tasks.md"
+        assert "NOT stored in optimus-tasks.md" in content or \
+            "NOT in optimus-tasks.md" in content, (
+            "AGENTS.md missing statement that status lives in state.json, not optimus-tasks.md"
         )
 
     def test_agents_md_has_column_spec(self):
@@ -760,7 +760,7 @@ class TestTasksFormatSpec:
                 f"AGENTS.md missing column definition for '{col}'"
 
 
-# --- tasks.md location redesign: tasks.md lives in tasksDir (not in .optimus/) ---
+# --- optimus-tasks.md location redesign: optimus-tasks.md lives in tasksDir (not in .optimus/) ---
 
 SKILLS_THAT_TOUCH_TASKS = [
     "plan", "build", "review", "done", "batch", "resume",
@@ -772,7 +772,7 @@ TASKS_GIT_HELPER_RE = re.compile(r'tasks_git\s*\(\)')
 
 
 class TestTasksDirLocation:
-    """tasks.md lives at <tasksDir>/tasks.md (not .optimus/tasks.md).
+    """optimus-tasks.md lives at <tasksDir>/optimus-tasks.md (not .optimus/tasks.md).
     config.json is gitignored (not versioned).
     """
 
@@ -859,6 +859,19 @@ class TestTasksDirLocation:
         assert "LEGACY_FILE=\".optimus/tasks.md\"" in content, \
             "AGENTS.md migration protocol missing LEGACY_FILE"
 
+    def test_agents_md_has_rename_protocol(self):
+        """AGENTS.md must define Protocol: Rename tasks.md to optimus-tasks.md.
+
+        This protocol handles the secondary rename `<tasksDir>/tasks.md` →
+        `<tasksDir>/optimus-tasks.md` (distinct from the legacy `.optimus/tasks.md`
+        relocation handled by Protocol: Migrate tasks.md to tasksDir).
+        """
+        content = AGENTS_MD.read_text()
+        assert "### Protocol: Rename tasks.md to optimus-tasks.md" in content, \
+            "AGENTS.md missing Protocol: Rename tasks.md to optimus-tasks.md"
+        assert 'OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"' in content, \
+            "AGENTS.md rename protocol missing OLD_TASKS_FILE"
+
     def test_config_json_is_gitignored(self):
         """Protocol: Initialize .optimus Directory must include config.json in the
         gitignore block."""
@@ -873,8 +886,8 @@ class TestTasksDirLocation:
             "Protocol: Initialize .optimus Directory must gitignore .optimus/config.json"
 
     def test_all_tasks_touching_skills_resolve_scope(self):
-        """Every skill that reads or writes tasks.md must reference Protocol:
-        Resolve Tasks Git Scope (directly or via tasks.md Validation)."""
+        """Every skill that reads or writes optimus-tasks.md must reference Protocol:
+        Resolve Tasks Git Scope (directly or via optimus-tasks.md Validation)."""
         missing = []
         for skill in SKILLS_THAT_TOUCH_TASKS:
             paths = list(REPO_ROOT.glob(f"{skill}/skills/*/SKILL.md"))
@@ -1343,7 +1356,7 @@ class TestResumeAdmin:
         )
 
 
-# --- Integration tests for the tasks.md relocation + separate-repo feature ---
+# --- Integration tests for the optimus-tasks.md relocation + separate-repo feature ---
 
 
 def _has_git():
@@ -1389,7 +1402,7 @@ def _extract_protocol_bash(section_title: str) -> str:
 
 @pytest.mark.skipif(not _has_git(), reason="git not available")
 class TestMigrationAndScopeIntegration:
-    """Integration tests for the tasks.md relocation + separate-repo support.
+    """Integration tests for the optimus-tasks.md relocation + separate-repo support.
 
     These tests execute the bash blocks from AGENTS.md against real tmp git repos
     to verify the protocols actually work — not just that their documentation exists.
@@ -1406,7 +1419,7 @@ class TestMigrationAndScopeIntegration:
         assert rc == 0, f"Bash failed: {err}"
         assert "SCOPE=same-repo" in out, f"Expected same-repo scope, got: {out}"
         assert "DIR=docs/pre-dev" in out
-        assert "FILE=docs/pre-dev/tasks.md" in out
+        assert "FILE=docs/pre-dev/optimus-tasks.md" in out
 
     def test_scope_resolution_separate_repo(self, tmp_path: Path):
         """Resolve Tasks Git Scope should detect separate-repo when tasksDir is in a different repo."""
@@ -1423,8 +1436,8 @@ class TestMigrationAndScopeIntegration:
         rc, out, err = _run(["bash", "-c", probe], cwd=project)
         assert rc == 0, f"Bash failed: {err}\n\n{out}"
         assert "SCOPE=separate-repo" in out
-        # Path relative to tasks repo root → just "tasks.md"
-        assert "REL=tasks.md" in out
+        # Path relative to tasks repo root → just "optimus-tasks.md"
+        assert "REL=optimus-tasks.md" in out
 
     def test_scope_resolution_rejects_dash_prefix(self, tmp_path: Path):
         """Resolve Tasks Git Scope must reject TASKS_DIR starting with '-' (git injection)."""
@@ -1484,7 +1497,7 @@ esac
         legacy = tmp_path / ".optimus" / "tasks.md"
         legacy.write_text("<!-- optimus:tasks-v1 -->\n# Tasks\n")
         probe = '''
-TASKS_FILE="docs/pre-dev/tasks.md"
+TASKS_FILE="docs/pre-dev/optimus-tasks.md"
 LEGACY_FILE=".optimus/tasks.md"
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   echo "NEEDS_MIGRATION=0 both exist"
@@ -1504,9 +1517,9 @@ fi
         (tmp_path / ".optimus").mkdir()
         (tmp_path / "docs" / "pre-dev").mkdir(parents=True)
         (tmp_path / ".optimus" / "tasks.md").write_text("legacy\n")
-        (tmp_path / "docs" / "pre-dev" / "tasks.md").write_text("new\n")
+        (tmp_path / "docs" / "pre-dev" / "optimus-tasks.md").write_text("new\n")
         probe = '''
-TASKS_FILE="docs/pre-dev/tasks.md"
+TASKS_FILE="docs/pre-dev/optimus-tasks.md"
 LEGACY_FILE=".optimus/tasks.md"
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   echo "NEEDS_MIGRATION=0 both exist"
@@ -1521,17 +1534,17 @@ fi
         assert "both exist" in out, f"Did not detect both-files case: {out}"
 
 
-# --- F19: Test that inline-protocols.py auto-injects scope+migration when tasks.md Validation is referenced ---
+# --- F19: Test that inline-protocols.py auto-injects scope+migration when optimus-tasks.md Validation is referenced ---
 
 
 class TestInlineProtocolsFoundational:
-    """Verify inline-protocols.py auto-injects foundational protocols for tasks.md Validation refs.
+    """Verify inline-protocols.py auto-injects foundational protocols for optimus-tasks.md Validation refs.
 
     This is the `needs_format` branch added in commit ad0d8d7 — previously untested.
     """
 
     def test_needs_format_injects_scope_and_migration(self, tmp_path: Path):
-        """When a skill references Protocol: tasks.md Validation, the inlined block
+        """When a skill references Protocol: optimus-tasks.md Validation, the inlined block
         MUST contain both Protocol: Resolve Tasks Git Scope AND Protocol: Migrate tasks.md to tasksDir."""
         import importlib.util
         spec = importlib.util.spec_from_file_location(
@@ -1542,14 +1555,15 @@ class TestInlineProtocolsFoundational:
 
         agents = tmp_path / "AGENTS.md"
         agents.write_text(
-            "## Protocol: tasks.md Validation (HARD BLOCK)\nValidation content\n"
+            "## Protocol: optimus-tasks.md Validation (HARD BLOCK)\nValidation content\n"
             "## Protocol: Resolve Tasks Git Scope\nScope resolution content\n"
             "## Protocol: Migrate tasks.md to tasksDir\nMigration content\n"
+            "## Protocol: Rename tasks.md to optimus-tasks.md\nRename content\n"
         )
         skill_dir = tmp_path / "myplugin" / "skills" / "optimus-myplugin"
         skill_dir.mkdir(parents=True)
         skill = skill_dir / "SKILL.md"
-        skill.write_text("Body: see AGENTS.md Protocol: tasks.md Validation.\n")
+        skill.write_text("Body: see AGENTS.md Protocol: optimus-tasks.md Validation.\n")
 
         # Monkey-patch paths
         original_agents = ip.AGENTS_MD
@@ -1567,4 +1581,48 @@ class TestInlineProtocolsFoundational:
             "Resolve Tasks Git Scope was not auto-injected"
         assert "Migration content" in inlined, \
             "Migrate tasks.md to tasksDir was not auto-injected"
+        assert "Validation content" in inlined
+
+    def test_needs_format_injects_rename_protocol(self, tmp_path: Path):
+        """When a skill references Protocol: optimus-tasks.md Validation, the inlined block
+        MUST also contain Protocol: Rename tasks.md to optimus-tasks.md.
+
+        Regression coverage for the secondary rename protocol that handles
+        `<tasksDir>/tasks.md` → `<tasksDir>/optimus-tasks.md` on disk. Mirrors the
+        Migrate protocol regression test above; the Rename protocol must be auto-
+        injected into the same set of skills (those that reference the format
+        validation protocol)."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "inline_protocols", REPO_ROOT / "scripts" / "inline-protocols.py",
+        )
+        ip = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(ip)
+
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(
+            "## Protocol: optimus-tasks.md Validation (HARD BLOCK)\nValidation content\n"
+            "## Protocol: Resolve Tasks Git Scope\nScope resolution content\n"
+            "## Protocol: Migrate tasks.md to tasksDir\nMigration content\n"
+            "## Protocol: Rename tasks.md to optimus-tasks.md\nRename content\n"
+        )
+        skill_dir = tmp_path / "myplugin" / "skills" / "optimus-myplugin"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        skill.write_text("Body: see AGENTS.md Protocol: optimus-tasks.md Validation.\n")
+
+        # Monkey-patch paths
+        original_agents = ip.AGENTS_MD
+        original_root = ip.REPO_ROOT
+        try:
+            ip.AGENTS_MD = agents
+            ip.REPO_ROOT = tmp_path
+            ip.inline_protocols()
+        finally:
+            ip.AGENTS_MD = original_agents
+            ip.REPO_ROOT = original_root
+
+        inlined = skill.read_text()
+        assert "Rename content" in inlined, \
+            "Rename tasks.md to optimus-tasks.md was not auto-injected"
         assert "Validation content" in inlined

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimus-tasks
-description: "Administrative task management for tasks.md. Create, edit, remove, reorder, cancel, and reopen tasks. Manage versions (create, edit, remove, reorder) and move tasks between versions. Validates format, dependencies, and ID uniqueness. Runs on any branch -- this is an administrative skill, not an execution skill."
+description: "Administrative task management for optimus-tasks.md. Create, edit, remove, reorder, cancel, and reopen tasks. Manage versions (create, edit, remove, reorder) and move tasks between versions. Validates format, dependencies, and ID uniqueness. Runs on any branch -- this is an administrative skill, not an execution skill."
 trigger: >
   - When user wants to add a new task (e.g., "add task", "create task", "new task")
   - When user wants to edit a task (e.g., "change priority of T-003", "rename T-005")
@@ -11,20 +11,20 @@ trigger: >
   - When user wants to advance or demote a task status manually (e.g., "advance T-004", "demote T-004")
   - When user wants to manage versions (e.g., "create version", "add version v2", "edit version MVP")
   - When user wants to move tasks between versions (e.g., "move T-003 to v2")
-  - When user says "manage tasks" or "edit tasks.md"
+  - When user says "manage tasks" or "edit optimus-tasks.md"
 skip_when: >
   - User wants to execute a task (use plan instead)
   - User wants to change task status through the lifecycle (status is managed by stage agents -- except cancellation, which is handled here)
 prerequisite: >
-  - <tasksDir>/tasks.md exists in the project (default tasksDir: docs/pre-dev)
+  - <tasksDir>/optimus-tasks.md exists in the project (default tasksDir: docs/pre-dev)
 NOT_skip_when: >
-  - "I can edit tasks.md manually" -- This agent validates format, dependencies, and IDs automatically.
+  - "I can edit optimus-tasks.md manually" -- This agent validates format, dependencies, and IDs automatically.
   - "It's just a small change" -- Even small changes can break format or create circular dependencies.
 examples:
   - name: Add a new task
     invocation: "Add a task: implement password reset"
     expected_flow: >
-      1. Parse tasks.md
+      1. Parse optimus-tasks.md
       2. Generate next ID (T-NNN)
       3. Ask for details (priority, dependencies)
       4. Add row to table with TaskSpec column
@@ -32,14 +32,14 @@ examples:
   - name: Edit task priority
     invocation: "Change T-003 priority to Alta"
     expected_flow: >
-      1. Parse tasks.md
+      1. Parse optimus-tasks.md
       2. Find T-003 row
       3. Update Priority column
       4. Save
   - name: Remove a task
     invocation: "Remove T-004"
     expected_flow: >
-      1. Parse tasks.md
+      1. Parse optimus-tasks.md
       2. Check no other tasks depend on T-004
       3. Remove row from table
       4. Save
@@ -49,14 +49,14 @@ related:
     - optimus-report
 verification:
   manual:
-    - After any operation, verify tasks.md still has valid format marker
+    - After any operation, verify optimus-tasks.md still has valid format marker
     - Verify no duplicate IDs exist
     - Verify no broken dependency references
 ---
 
 # optimus-tasks
 
-Administrative CRUD operations for tasks in `tasks.md`.
+Administrative CRUD operations for tasks in `optimus-tasks.md`.
 
 **Classification:** Administrative skill — runs on any branch, never modifies code.
 
@@ -77,23 +77,24 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 
 For operations that do not use `gh` (create, edit, remove, reorder, version management), skip this check.
 
-### Step 1.0.1: Find and Validate tasks.md
+### Step 1.0.1: Find and Validate optimus-tasks.md
 
 1. **Resolve paths and git scope:** Execute AGENTS.md Protocol: Resolve Tasks Git Scope.
    This obtains `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, `TASKS_GIT_REL`, and the
    `tasks_git` helper.
 
 2. **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-   If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/tasks.md` does not, the
+   If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
    protocol offers migration before proceeding.
+   Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
-3. **Find tasks.md:** Resolve the path using the AGENTS.md Protocol: tasks.md Validation.
-   The file is at `<TASKS_DIR>/tasks.md` (default: `docs/pre-dev/tasks.md`).
+3. **Find optimus-tasks.md:** Resolve the path using the AGENTS.md Protocol: optimus-tasks.md Validation.
+   The file is at `<TASKS_DIR>/optimus-tasks.md` (default: `docs/pre-dev/optimus-tasks.md`).
 
    If not found, ask the user via `AskUser`:
 
-   "No tasks.md found. What should I do?"
-   - **(a) Create at <TASKS_DIR>/tasks.md** (standard location)
+   "No optimus-tasks.md found. What should I do?"
+   - **(a) Create at <TASKS_DIR>/optimus-tasks.md** (standard location)
    - **(b) Run import** — use this if you already have task files in another format
 
    If the user chooses to create:
@@ -117,12 +118,12 @@ For operations that do not use `gh` (create, edit, remove, reorder, version mana
       ```bash
       tasks_git add "$TASKS_GIT_REL"
       COMMIT_MSG_FILE=$(mktemp)
-      printf '%s' "chore(tasks): initialize tasks.md" > "$COMMIT_MSG_FILE"
+      printf '%s' "chore(tasks): initialize optimus-tasks.md" > "$COMMIT_MSG_FILE"
       tasks_git commit -F "$COMMIT_MSG_FILE"
       rm -f "$COMMIT_MSG_FILE"
       ```
 
-4. **Validate format (HARD BLOCK):** See AGENTS.md Protocol: tasks.md Validation.
+4. **Validate format (HARD BLOCK):** See AGENTS.md Protocol: optimus-tasks.md Validation.
 
 ### Step 1.1: Determine Operation
 
@@ -235,11 +236,11 @@ If no similar tasks are found, proceed silently.
 ### Step 2.1.1: Validate Title Characters
 
 **HARD BLOCK:** The task title must not contain unescaped pipe characters (`|`) because
-tasks.md uses markdown tables where `|` is the column delimiter.
+optimus-tasks.md uses markdown tables where `|` is the column delimiter.
 
 If the title contains `|`:
 - Automatically replace `|` with `—` (em dash) or `\|` (escaped pipe)
-- Inform the user: "Title contained pipe characters which would break the tasks.md table format. Replaced with '—'."
+- Inform the user: "Title contained pipe characters which would break the optimus-tasks.md table format. Replaced with '—'."
 
 Also reject titles longer than 120 characters — longer titles break table formatting.
 If too long, ask the user to shorten it.
@@ -248,7 +249,7 @@ If too long, ask the user to shorten it.
 
 Collect IDs from ALL sources to avoid collisions with parallel branches:
 
-1. **Local:** Parse all existing task IDs from the current branch's tasks.md table
+1. **Local:** Parse all existing task IDs from the current branch's optimus-tasks.md table
 2. **Remote:** Fetch and parse IDs from the tasks repo's default branch on origin
    (uses `tasks_git` so it works in both same-repo and separate-repo scopes):
    ```bash
@@ -311,7 +312,7 @@ Options:
 **If "Link existing spec"**, search `<TASKS_DIR>/tasks/*.md` for task files, present
 matches based on keyword overlap with the task title, and let the user select one.
 
-### Step 2.4: Add to tasks.md
+### Step 2.4: Add to optimus-tasks.md
 
 1. Add a new row to the table:
    ```
@@ -337,7 +338,7 @@ Created task T-NNN: <title>
 
 1. Parse the task ID from the user's request
 2. Find the task row in the table
-3. If task not found → **STOP**: "Task T-XXX not found in tasks.md"
+3. If task not found → **STOP**: "Task T-XXX not found in optimus-tasks.md"
 
 Determine which field(s) to edit. Editable fields:
 
@@ -364,7 +365,7 @@ task, use "reopen T-XXX".
 
 ### Step 3.1: Apply Changes
 
-1. Update the relevant column(s) in the table row in tasks.md
+1. Update the relevant column(s) in the table row in optimus-tasks.md
 2. If Depends changed, validate all references exist and no circular dependencies
 3. Save the file
 
@@ -382,7 +383,7 @@ Updated T-XXX:
 
 1. Parse the task ID from the user's request
 2. Find the task row in the table
-3. If task not found → **STOP**: "Task T-XXX not found in tasks.md"
+3. If task not found → **STOP**: "Task T-XXX not found in optimus-tasks.md"
 
 ### Step 4.1: Validate Removal
 
@@ -409,9 +410,9 @@ may cause data loss. Are you sure?
 
 Use `AskUser` for confirmation.
 
-### Step 4.2: Remove from tasks.md
+### Step 4.2: Remove from optimus-tasks.md
 
-1. Remove the table row for T-XXX from tasks.md
+1. Remove the table row for T-XXX from optimus-tasks.md
 2. Save
 
 **NOTE:** Do NOT renumber remaining task IDs. IDs are permanent identifiers.
@@ -449,7 +450,7 @@ Show the new table order.
 
 1. Parse the task ID from the user's request
 2. Find the task row in the table
-3. If task not found → **STOP**: "Task T-XXX not found in tasks.md"
+3. If task not found → **STOP**: "Task T-XXX not found in optimus-tasks.md"
 
 ### Step 6.1: Validate Cancellation
 
@@ -570,7 +571,7 @@ To resolve, run `/optimus-tasks`:
 
 1. Parse the task ID from the user's request
 2. Find the task row in the table
-3. If task not found → **STOP**: "Task T-XXX not found in tasks.md"
+3. If task not found → **STOP**: "Task T-XXX not found in optimus-tasks.md"
 
 ### Step 7.1: Validate Reopen
 
@@ -656,7 +657,7 @@ code manually without using stage-2).
 
 1. Parse the task ID from the user's request
 2. Find the task row in the table
-3. If task not found → **STOP**: "Task T-XXX not found in tasks.md"
+3. If task not found → **STOP**: "Task T-XXX not found in optimus-tasks.md"
 4. Determine the target status. If the user specified one, use it. Otherwise, advance
    to the next status in the lifecycle:
 
@@ -728,7 +729,7 @@ that significant rework is needed and the task should go back to implementation)
 
 1. Parse the task ID from the user's request
 2. Find the task row in the table
-3. If task not found → **STOP**: "Task T-XXX not found in tasks.md"
+3. If task not found → **STOP**: "Task T-XXX not found in optimus-tasks.md"
 4. Determine the target status. If the user specified one, use it. Otherwise, demote
    to the previous status in the lifecycle:
 
@@ -782,7 +783,7 @@ If the user provides multiple tasks to create at once (e.g., a list of tasks), p
 
 1. Generate IDs for all tasks first (to allow cross-references in dependencies)
 2. Validate all dependencies
-3. Add all rows to tasks.md
+3. Add all rows to optimus-tasks.md
 4. Show summary of all created tasks
 
 ## Phase 11: Version Management
@@ -923,13 +924,13 @@ Confirm move?
 
 ## Rules
 
-1. **Status changes are restricted** — the Edit operation cannot change status (use Reopen, Advance, or Demote operations instead, which write to state.json). Status and Branch live in state.json, not in tasks.md.
+1. **Status changes are restricted** — the Edit operation cannot change status (use Reopen, Advance, or Demote operations instead, which write to state.json). Status and Branch live in state.json, not in optimus-tasks.md.
 2. **Always validate format** after any modification (re-check marker, columns, IDs, deps, versions)
 3. **IDs are permanent** — never renumber or reuse deleted IDs
 4. **Circular dependency detection is mandatory** — check before saving
 5. **Confirm destructive operations** (remove) with the user before executing
 6. **Preserve format marker** — first line must always be `<!-- optimus:tasks-v1 -->`
-7. **Commit changes** — after any structural modification to tasks.md, commit with message: `chore(tasks): <operation> T-XXX`. Status changes (state.json) are NOT committed — state.json is gitignored.
+7. **Commit changes** — after any structural modification to optimus-tasks.md, commit with message: `chore(tasks): <operation> T-XXX`. Status changes (state.json) are NOT committed — state.json is gitignored.
 8. **Version validation** — every task must reference a version that exists in the Versions table
 9. **Exactly one Ativa version** — when setting a version to `Ativa`, the current `Ativa` must be demoted (ask user)
 10. **At most one Próxima version** — when setting a version to `Próxima`, the current `Próxima` must be demoted to `Planejada` (ask user)
@@ -959,7 +960,7 @@ Optimus splits its files into two trees:
 
 ```
 <tasksDir>/              # default: docs/pre-dev/
-├── tasks.md             # versioned — structural task data (NO status, NO branch)
+├── optimus-tasks.md     # versioned — structural task data (NO status, NO branch)
 ├── tasks/               # versioned — Ring pre-dev task specs (task_001.md, ...)
 └── subtasks/            # versioned — Ring pre-dev subtask specs (T-001/, ...)
 ```
@@ -974,7 +975,7 @@ Optimus splits its files into two trees:
 ```
 
 - **`tasksDir`** (optional): Path to the Ring pre-dev artifacts root. Default:
-  `docs/pre-dev`. The import and stage agents look for `tasks.md`, `tasks/`, and
+  `docs/pre-dev`. The import and stage agents look for `optimus-tasks.md`, `tasks/`, and
   `subtasks/` inside this directory. Can point to a path inside the project repo
   (default case) OR to a path in a separate git repo (for teams that separate task
   tracking from code).
@@ -987,7 +988,7 @@ Optimus splits its files into two trees:
 Since `config.json` is gitignored, it exists ONLY when the user overrides a default.
 Projects using the defaults do not need a `config.json`.
 
-**Tasks file** is always at `<tasksDir>/tasks.md` (derived from `tasksDir`).
+**Tasks file** is always at `<tasksDir>/optimus-tasks.md` (derived from `tasksDir`).
 
 **Operational state** is stored in `.optimus/state.json` (gitignored):
 
@@ -1001,7 +1002,7 @@ Projects using the defaults do not need a `config.json`.
 - Each key is a task ID. A task with no entry is `Pendente` (implicit default).
 - `status`: current pipeline stage (see Valid Status Values).
 - `branch`: the derived branch name, stored for quick reference (always re-derivable).
-- Stage agents read and write this file — never tasks.md — for status changes.
+- Stage agents read and write this file — never optimus-tasks.md — for status changes.
 - If state.json is lost, status can be reconstructed: task with a worktree = in progress,
   without = Pendente. The agent asks the user to confirm before proceeding.
 
@@ -1023,10 +1024,10 @@ Projects using the defaults do not need a `config.json`.
 
 Agents resolve paths:
 1. **Read `.optimus/config.json`** for `tasksDir` if it exists. Fallback: `docs/pre-dev`.
-2. **Tasks file:** `${tasksDir}/tasks.md` (derived, not configurable separately).
-3. **If `<tasksDir>/tasks.md` not found:** **STOP** and suggest running `import` to create one.
+2. **Tasks file:** `${tasksDir}/optimus-tasks.md` (derived, not configurable separately).
+3. **If `<tasksDir>/optimus-tasks.md` not found:** **STOP** and suggest running `import` to create one.
 
-Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/tasks.md`,
+Everything inside `.optimus/` is gitignored. The planning tree (`<tasksDir>/optimus-tasks.md`,
 `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`) is versioned (structural data shared with
 the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir` is inside
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
@@ -1035,7 +1036,7 @@ repo, it is committed there.
 
 ### Valid Status Values (stored in state.json)
 
-Status lives in `.optimus/state.json`, NOT in tasks.md. A task with no entry in
+Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
 | Status | Set by | Meaning |
@@ -1058,7 +1059,7 @@ These operations require explicit user confirmation.
 
 ### Format Validation
 
-Every stage agent (1-4) MUST validate the tasks.md format before operating:
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
 3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
@@ -1080,7 +1081,7 @@ running `/optimus-import` to fix the format. Do NOT attempt to interpret malform
 15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
 format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
 format validation and before task identification. If zero data rows: **STOP** and inform the
-user: "No tasks found in tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
 **NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
@@ -1123,7 +1124,7 @@ logic (30-day age cap + 500-file count cap). Running both per session is a
 harmless cheap operation.
 
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
 **NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
@@ -1136,25 +1137,23 @@ Skills reference this as: "Initialize .optimus directory — see AGENTS.md Proto
 
 ### Protocol: Migrate tasks.md to tasksDir
 
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
 
 Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/tasks.md`.
+`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
 
-**Detection (run at the start of every skill that reads/writes tasks.md):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
 # (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
 LEGACY_FILE=".optimus/tasks.md"
-BOTH_EXIST=0
 if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
   # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tasks.md exist." >&2
+  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
   echo "         This indicates a partial prior migration or manual copy." >&2
   echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
   NEEDS_MIGRATION=0
-  BOTH_EXIST=1
 elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
   NEEDS_MIGRATION=1
 else
@@ -1191,7 +1190,7 @@ fi
 **If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
 
 ```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE}.
+A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
 Migrate now? (Recommended — keeping the old location will break other skills.)
 ```
 
@@ -1202,22 +1201,22 @@ Options:
 
 **Migration flow (when user chooses "Migrate now"):**
 
+**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
+(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
+so we don't leave an orphan marker if a symlink is detected:
+```bash
+if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
+  exit 1
+fi
+```
+
 Checkpoint file: write `.optimus/.migration-in-progress` BEFORE starting. This marker
 lets subsequent invocations detect interrupted migrations:
 
 ```bash
 mkdir -p .optimus
 printf '%s\n' "$TASKS_FILE" > .optimus/.migration-in-progress
-```
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target):
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  rm -f .optimus/.migration-in-progress
-  exit 1
-fi
 ```
 
 **Scope-branched migration:** explicit `if` so the agent executes the correct branch:
@@ -1233,7 +1232,7 @@ if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): move tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed. Reverting git mv..." >&2
     # Revert: restore legacy from HEAD, remove new from working tree
@@ -1261,7 +1260,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate tasks.md to tasksDir" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: tasks_git commit failed. Rolling back..." >&2
     tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
@@ -1279,7 +1278,7 @@ else
   fi
   COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
   chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: move tasks.md to separate tasks repo (${TASKS_DIR})" > "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
   if ! git commit -F "$COMMIT_MSG_FILE"; then
     echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
     echo "Manual cleanup needed: git commit after resolving." >&2
@@ -1304,7 +1303,7 @@ if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
     git reset HEAD .optimus/config.json 2>/dev/null
     rm -f "$COMMIT_MSG_FILE"
     echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of tasks.md already succeeded; user can retry untrack
+    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
   else
     rm -f "$COMMIT_MSG_FILE"
   fi
@@ -1314,18 +1313,18 @@ fi
 **Ensure `.gitignore` includes the operational-files block:**
 Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
 
-**Post-migration validation:** Verify the migrated tasks.md still passes Format
+**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
 Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
 file was manually edited and lacks a `## Versions` section), inform user and suggest
 running `/optimus-import` to rebuild:
 
 ```bash
 if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md does not have the optimus format marker." >&2
+  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated tasks.md has no ## Versions section." >&2
+  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
   echo "         Run /optimus-import to rebuild in the correct format." >&2
 fi
 ```
@@ -1341,7 +1340,7 @@ echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
 
 **Report success:**
 ```
-Migration complete. tasks.md is now at ${TASKS_FILE}.
+Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
 Remember to push both repos (project + tasks) when you're ready.
 ```
 
@@ -1361,17 +1360,200 @@ remainder of this execution.
 
 **If user chose "Abort":** **STOP** the current command.
 
-Skills reference this as: "Check tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
+
+
+### Protocol: Rename tasks.md to optimus-tasks.md
+
+**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
+
+Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks.md`
+(the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
+(`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
+
+**Detection (run at the start of every skill that reads/writes the tasks tracking file,
+AFTER Protocol: Migrate tasks.md to tasksDir):**
+
+```bash
+# Requires Protocol: Resolve Tasks Git Scope to have been executed first
+# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, TASKS_GIT_REL, tasks_git available).
+# TASKS_FILE already points to <tasksDir>/optimus-tasks.md.
+OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"
+NEEDS_RENAME=0
+
+# Symlink HARD BLOCK — refuse to inspect or operate on symlinked paths.
+# Must run BEFORE detection (head -n 1 follows symlinks).
+if [ -L "$OLD_TASKS_FILE" ] || [ -L "$TASKS_FILE" ]; then
+  echo "ERROR: $OLD_TASKS_FILE or $TASKS_FILE is a symlink — refusing to inspect or rename." >&2
+  exit 1
+fi
+
+if [ -f "$OLD_TASKS_FILE" ] && [ -f "$TASKS_FILE" ]; then
+  if ! head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    # OLD lacks the optimus marker — it is an unrelated file (Ring pre-dev's
+    # Gate 7 tasks.md, etc.). The actual Optimus file is already at TASKS_FILE.
+    NEEDS_RENAME=0
+  else
+    echo "ERROR: Both ${OLD_TASKS_FILE} and ${TASKS_FILE} exist and both appear to be Optimus tracking files." >&2
+    echo "       Confirm which is current, remove the stale one, and re-run the skill." >&2
+    exit 1
+  fi
+elif [ -f "$OLD_TASKS_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
+  # Only proceed if the legacy file actually has the optimus format marker — otherwise
+  # it is some other unrelated tasks.md (e.g., Ring pre-dev's Gate 7 tasks.md) and
+  # MUST NOT be touched.
+  if head -n 1 "$OLD_TASKS_FILE" 2>/dev/null | grep -q '^<!-- optimus:tasks-v1 -->'; then
+    NEEDS_RENAME=1
+  fi
+fi
+```
+
+If `NEEDS_RENAME=0`, the protocol is a no-op (either the new name already exists, the
+legacy file is unrelated to optimus, or neither exists).
+
+**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
+DO NOT execute the rename. Emit the plan and proceed:
+
+```
+[DRY-RUN] Rename would be offered for this task:
+[DRY-RUN]   Old name: $OLD_TASKS_FILE
+[DRY-RUN]   New name: $TASKS_FILE
+[DRY-RUN]   Scope:    $TASKS_GIT_SCOPE
+[DRY-RUN]   Would use: git mv (same-repo) OR tasks_git mv (separate-repo)
+```
+
+**If `NEEDS_RENAME=1`, ask the user via `AskUser`:**
+
+```
+The Optimus tracking file at $OLD_TASKS_FILE uses the previous default name.
+Rename to $TASKS_FILE now? (Recommended — Ring pre-dev also produces a tasks.md
+in this directory, so the previous name causes a collision.)
+```
+
+Options:
+- **Rename now** — perform the rename and commit
+- **Skip this time** — continue with the legacy name (emit warning; this will collide with Ring pre-dev)
+- **Abort** — stop the current command so you can rename manually
+
+**Rename flow (when user chooses "Rename now"):**
+
+Checkpoint file: write `.optimus/.rename-in-progress` BEFORE starting. This marker
+lets subsequent invocations detect interrupted renames:
+
+```bash
+mkdir -p .optimus
+printf '%s\n' "$TASKS_FILE" > .optimus/.rename-in-progress
+```
+
+**Scope-branched rename:** explicit `if` so the agent executes the correct branch:
+
+```bash
+if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
+  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
+  if ! git mv "$OLD_TASKS_FILE" "$TASKS_FILE"; then
+    echo "ERROR: git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed. Reverting git mv..." >&2
+    # Revert: restore old name from HEAD, remove new name from working tree
+    git reset HEAD -- "$OLD_TASKS_FILE" "$TASKS_FILE" 2>/dev/null
+    git checkout HEAD -- "$OLD_TASKS_FILE" 2>/dev/null
+    rm -f "$TASKS_FILE"
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+else
+  # Separate-repo: rename via tasks_git mv, single commit in tasks repo.
+  OLD_TASKS_GIT_REL=$(python3 -c "import os,sys; print(os.path.relpath(sys.argv[1], sys.argv[2]))" \
+    "$OLD_TASKS_FILE" "$TASKS_REPO_ROOT" 2>/dev/null)
+  if [ -z "$OLD_TASKS_GIT_REL" ]; then
+    echo "ERROR: Failed to compute path for legacy file relative to tasks repo." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  if ! tasks_git mv "$OLD_TASKS_GIT_REL" "$TASKS_GIT_REL"; then
+    echo "ERROR: tasks_git mv failed. Rename aborted — no changes made." >&2
+    rm -f .optimus/.rename-in-progress
+    exit 1
+  fi
+  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+  chmod 600 "$COMMIT_MSG_FILE"
+  printf '%s' "chore(tasks): rename tasks.md to optimus-tasks.md" > "$COMMIT_MSG_FILE"
+  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
+    echo "ERROR: Commit failed in tasks repo. Manual cleanup needed:" >&2
+    echo "  cd $TASKS_DIR && git reset HEAD -- $OLD_TASKS_GIT_REL $TASKS_GIT_REL" >&2
+    echo "  git checkout HEAD -- $OLD_TASKS_GIT_REL && rm -f $TASKS_GIT_REL" >&2
+    rm -f "$COMMIT_MSG_FILE" .optimus/.rename-in-progress
+    exit 1
+  fi
+  rm -f "$COMMIT_MSG_FILE"
+fi
+```
+
+**Rename success: clear checkpoint marker and log.**
+```bash
+rm -f .optimus/.rename-in-progress
+echo "INFO: Rename completed successfully:" >&2
+echo "  - Old name:  $OLD_TASKS_FILE" >&2
+echo "  - New name:  $TASKS_FILE" >&2
+echo "  - Git scope: $TASKS_GIT_SCOPE" >&2
+```
+
+**Post-rename validation:** Verify the moved file still passes Format Validation (see
+AGENTS.md Format Validation section). If it fails (e.g., the legacy file was manually
+edited and lost the marker), inform user and suggest running `/optimus-import` to rebuild:
+
+```bash
+# Post-rename validation — verify the moved file still passes Format Validation.
+if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md does not have the optimus format marker." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+if ! grep -q '^## Versions' "$TASKS_FILE"; then
+  echo "WARNING: Renamed optimus-tasks.md has no ## Versions section." >&2
+  echo "         Run /optimus-import to rebuild in the correct format." >&2
+fi
+```
+
+**Report success:**
+```
+Rename complete. The tracking file is now at ${TASKS_FILE}.
+Remember to push the tasks repo when you're ready.
+```
+
+**Interrupted rename recovery (on skill startup):**
+
+```bash
+if [ -f .optimus/.rename-in-progress ]; then
+  INTERRUPTED_FILE=$(cat .optimus/.rename-in-progress 2>/dev/null)
+  echo "WARNING: Previous rename was interrupted. Expected target: $INTERRUPTED_FILE" >&2
+  # AskUser: Retry rename / Clear marker / Abort
+fi
+```
+
+**If user chose "Skip this time":** Emit a warning and proceed using the legacy name
+for this invocation only. The skill MUST use `$OLD_TASKS_FILE` as `$TASKS_FILE` for the
+remainder of this execution.
+
+**If user chose "Abort":** **STOP** the current command.
+
+Skills reference this as: "Check optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md."
 
 
 ### Protocol: Resolve Tasks Git Scope
 
 **Referenced by:** all stage agents (1-4), tasks, batch, resolve, import, resume, report, quick-report
 
-Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/tasks.md`), then
+Resolves `TASKS_DIR` (Ring pre-dev root) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then
 detects whether `tasksDir` lives in the same git repo as the project code or in a
 **separate** git repo. Exposes a `tasks_git` helper function so skills can run git
-commands on tasks.md uniformly regardless of scope.
+commands on optimus-tasks.md uniformly regardless of scope.
 
 ```bash
 # Step 1: Resolve tasksDir from config.json (if present) or fall back to default.
@@ -1396,7 +1578,7 @@ case "$TASKS_DIR" in
 esac
 
 # Step 2: Derive TASKS_FILE.
-TASKS_FILE="${TASKS_DIR}/tasks.md"
+TASKS_FILE="${TASKS_DIR}/optimus-tasks.md"
 
 # Step 3: Detect git scope.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -1423,7 +1605,7 @@ if [ -z "$TASKS_REPO_ROOT" ]; then
     exit 1
   fi
   # Fresh project: tasksDir does not exist yet — assume same-repo.
-  # Skills that create tasks.md will mkdir -p "$TASKS_DIR" first.
+  # Skills that create optimus-tasks.md will mkdir -p "$TASKS_DIR" first.
   TASKS_GIT_SCOPE="same-repo"
 elif [ "$TASKS_REPO_ROOT" = "$PROJECT_ROOT" ]; then
   TASKS_GIT_SCOPE="same-repo"
@@ -1436,9 +1618,9 @@ fi
 # In separate-repo, git runs with -C "$TASKS_DIR" so paths are relative to TASKS_DIR.
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
   # python3 is REQUIRED in separate-repo mode to compute the path from the tasks
-  # repo root. A naive "tasks.md" fallback would be wrong when TASKS_DIR is a
+  # repo root. A naive "optimus-tasks.md" fallback would be wrong when TASKS_DIR is a
   # subdir of the tasks repo (e.g., `tasks-repo/project-alfa/`), because
-  # `git show origin/main:tasks.md` resolves from repo root, not CWD.
+  # `git show origin/main:optimus-tasks.md` resolves from repo root, not CWD.
   if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: python3 is required for separate-repo mode (path computation)." >&2
     echo "Install python3 or point tasksDir inside the project repo." >&2
@@ -1609,13 +1791,13 @@ fi
 
 ```bash
 STATE_FILE=".optimus/state.json"
-# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/tasks.md).
+# TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists
 if [ -f "$STATE_FILE" ] && ! jq empty "$STATE_FILE" 2>/dev/null; then
   echo "WARNING: state.json is corrupted. Treating all tasks as Pendente."
   rm -f "$STATE_FILE"
 fi
-# Get all task IDs from tasks.md
+# Get all task IDs from optimus-tasks.md
 TASK_IDS=$(grep -E '^\| T-[0-9]+ \|' "$TASKS_FILE" | awk -F'|' '{print $2}' | tr -d ' ')
 # For each task, read status from state.json (default: Pendente)
 for TASK_ID in $TASK_IDS; do
@@ -1646,25 +1828,25 @@ appearing as `Pendente` when they actually have active worktrees.
 Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: State Management."
 
 
-### Protocol: tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
-Every stage agent MUST validate tasks.md before operating. The full validation rules are
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
 defined in the "Format Validation" section above (items 1-15). This protocol is the
 executable version:
 
 1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
    resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
 3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
 
-**All subsequent references to `tasks.md` in the skill use the resolved `TASKS_FILE` path.
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
 All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on tasks.md use the `tasks_git` helper** (which handles both same-repo
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
 and separate-repo scopes).
 
-Skills reference this as: "Find and validate tasks.md (HARD BLOCK) — see AGENTS.md Protocol: tasks.md Validation."
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->


### PR DESCRIPTION
## Summary
- Renames the Optimus task-tracking file from `tasks.md` to `optimus-tasks.md` to eliminate collision with Ring pre-dev's Gate 7 output (also `tasks.md`) in the same `<tasksDir>` directory.
- Adds a new `Protocol: Rename tasks.md to optimus-tasks.md` for backward-compat — auto-renames legacy files via `git mv` on first invocation of any tasks-aware skill. Format marker (`<!-- optimus:tasks-v1 -->`) unchanged.
- Includes deep-review fixes (1 CRITICAL + 8 HIGH + 4 MEDIUM + 2 LOW) found by 7 parallel review droids — most critically, reorders 6 stage skills so Migrate/Rename run BEFORE the Validation HARD BLOCK (legacy users were being incorrectly sent to `/optimus-import`).

## Why
Ring pre-dev (Gate 7) writes `<tasksDir>/tasks.md`. Optimus's tracking file had the same name and same path → direct collision when projects use both. Renaming Optimus's file eliminates the conflict. The single `tasksDir` config still drives both tools to the same directory; they just have distinct filenames now.

## Key changes
- **AGENTS.md**: new Rename protocol with symlink HARD BLOCK (reordered before `head -n 1` to prevent TOCTOU info disclosure), marker check before BOTH_EXIST hard-exit (prevents touching Ring's unrelated `tasks.md`), post-rename format validation, checkpoint marker, scope-branched same-repo/separate-repo flow.
- **`scripts/inline-protocols.py`**: pairs Migrate↔Rename auto-injection; extracts `VALIDATION_PROTOCOL_TOKEN`, `MIGRATE_PROTOCOL_KEY`, `RENAME_PROTOCOL_KEY` constants for heading-drift detection.
- **6 stage skills** (build/done/plan/review/resume/batch): reordered so Migrate/Rename run BEFORE Validation HARD BLOCK.
- **report/quick-report/resolve/pr-check**: now reference Migrate/Rename in body.
- **4 marketplace.json/plugin.json** descriptions updated.
- Migrate commit messages standardized to include source path.
- Dead `BOTH_EXIST` variable removed from both protocols.
- **4 new regression tests**: pairing branches (×2), live-AGENTS.md heading resolution for the 3 protocol-key constants.

## Stats
- 27 files changed (+4011 / -841)
- Tests: **136 passing** (+4 new). Lint clean (py_compile, ruff, shellcheck).
- Inline-protocols propagation: 0 unmatched references across 15 skills.

## BREAKING CHANGE
Existing projects with `<tasksDir>/tasks.md` will be prompted to auto-rename on first invocation of any tasks-aware skill. Single `git mv` commit. Legacy `.optimus/tasks.md` users go directly to the new name in one step (Migrate honors the new `TASKS_FILE` indirection — no intermediate `tasks.md` state).

## Deferred to follow-up PR (deep-review findings)
- F7-F8: integration tests for Rename protocol bash (symlink/marker/both-exist/dry-run/separate-repo/rollback)
- F14: concurrency lock (`flock` or document)
- F15: `git diff --quiet` precondition before `git mv`
- F16: separate-repo rollback auto-revert symmetry
- F17: README/CHANGELOG migration note
- F18, F20-F25: naming/test/recovery polish (LOW)

## Test plan
- [x] `make test` (136 passing)
- [x] `make lint` (py_compile, ruff, shellcheck — all green)
- [x] `python3 scripts/inline-protocols.py` produces 0 unmatched references
- [ ] Manual smoke test: project with existing `<tasksDir>/tasks.md` → run `/optimus-build`, verify auto-rename prompt fires (not "run /optimus-import")
- [ ] Manual smoke test: project with `.optimus/tasks.md` (legacy) → verify single-step migration to `<tasksDir>/optimus-tasks.md`
- [ ] Manual smoke test: fresh project + Ring pre-dev's `<tasksDir>/tasks.md` already present → verify Optimus's `optimus-tasks.md` coexists without collision