### PR TITLE
feat(done): add PR review feedback gate before close

### DIFF
--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimus-done
-description: "Stage 4 of the task lifecycle. Requires PR in final state (merged or closed) before marking task as done. Cleans up worktree and branch interactively."
+description: "Stage 4 of the task lifecycle. Validates the PR's review feedback (Gate 3) and final state (Gate 4) before marking task as done. If reviewers flagged unresolved comments, suggests /optimus-pr-check before proceeding. Cleans up worktree and branch interactively."
 trigger: >
   - After the PR has been merged or closed
   - When user requests closing a task (e.g., "close T-012", "mark T-012 as done")
@@ -39,7 +39,8 @@ related:
       - optimus-pr-check
 verification:
   manual:
-    - All 3 gates passed
+    - All 4 gates passed
+    - PR review feedback addressed (or explicitly skipped via override)
     - Task status updated to DONE in state.json
     - Worktree and branch cleaned up
 ---
@@ -241,7 +242,11 @@ git rev-parse --abbrev-ref @{u} 2>/dev/null
   - **PASS:** Output is empty → proceed to Gate 3
   - **FAIL → HARD BLOCK:** "N unpushed commits. Run `git push` first."
 
-### Gate 3: PR in Final State
+### Gate 3: PR Review Feedback
+
+Before validating final PR state (Gate 4), check whether reviewers (CodeRabbit,
+DeepSource, humans) flagged feedback that has not been addressed. The point is
+to make the user aware **before** the PR is merged and the task is closed.
 
 ```bash
 HEAD_BRANCH=$(git branch --show-current 2>/dev/null)
@@ -249,19 +254,69 @@ if [ -z "$HEAD_BRANCH" ]; then
   echo "ERROR: Cannot determine current branch. Checkout the task branch first."
   # STOP — HARD BLOCK
 fi
-PR_JSON=$(gh pr list --head "$HEAD_BRANCH" --json number,state --jq '.[0]')
+
+# Fetch PR metadata ONCE — shared by Gate 3 (review feedback) and Gate 4 (final state).
+PR_JSON=$(gh pr list --head "$HEAD_BRANCH" --json number,state,reviewDecision --jq '.[0]')
 if [ $? -ne 0 ]; then
   echo "ERROR: GitHub CLI failed. Check network and run 'gh auth status'."
   # STOP — HARD BLOCK (cannot verify PR state)
 fi
+
+PR_NUM=$(printf '%s' "$PR_JSON" | jq -r '.number // empty' 2>/dev/null)
+PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.state // empty' 2>/dev/null)
+PR_DECISION=$(printf '%s' "$PR_JSON" | jq -r '.reviewDecision // empty' 2>/dev/null)
 ```
 
 - **gh command failed (non-zero exit):** HARD BLOCK — cannot verify PR state
-- **No PR exists** (PR_JSON is empty or "null"): PASS → proceed (task went directly to default branch)
+- **No PR exists** (PR_NUM empty): PASS → proceed (task went directly to default branch)
+
+**`reviewDecision` values from GitHub:**
+| Value | Meaning |
+|---|---|
+| `APPROVED` | At least one approving review; no requested changes outstanding |
+| `CHANGES_REQUESTED` | At least one reviewer requested changes; not yet resolved |
+| `REVIEW_REQUIRED` | Required reviewers have not reviewed yet |
+| `null`/empty | No reviews yet, or reviews are advisory only |
+
+**Decision logic:**
+
+- **PR_DECISION is empty / null / `APPROVED`:** PASS → proceed to Gate 4
+- **PR_DECISION is `CHANGES_REQUESTED`:** Ask via `AskUser`:
+  ```
+  PR #${PR_NUM} has unresolved review feedback (reviewDecision=CHANGES_REQUESTED).
+  How would you like to proceed?
+  ```
+  Options:
+  - **Run `/optimus-pr-check` now** (Recommended) — invoke the pr-check skill to
+    fetch all comments and address them iteratively. After pr-check completes,
+    re-run `/optimus-done` to re-evaluate this gate.
+  - **Override (I have addressed all comments)** — proceed to Gate 4. Useful when
+    the user has already resolved everything via the GitHub UI but reviewers
+    haven't dismissed/re-approved. Logs a warning to `.optimus/logs/`.
+  - **Cancel** — STOP, do not change task status.
+- **PR_DECISION is `REVIEW_REQUIRED`:** soft warning + `AskUser`:
+  ```
+  PR #${PR_NUM} is awaiting required reviewers. Proceed anyway?
+  ```
+  Options:
+  - **Wait — cancel `done`** — STOP. Re-run when reviewers respond.
+  - **Proceed anyway** — continue to Gate 4 (typical when waiting on a long-tail
+    reviewer and the team agrees to merge async).
+
+If the user picks "Run `/optimus-pr-check` now", invoke the `optimus-pr-check`
+skill via the `Skill` tool. After it completes, re-fetch `PR_JSON` and re-evaluate
+Gate 3. Loop up to 3 times to avoid infinite back-and-forth; if still
+`CHANGES_REQUESTED` after 3 iterations, fall through to the override/cancel
+prompt.
+
+### Gate 4: PR in Final State
+
+Reuses `PR_STATE` from the metadata fetched in Gate 3.
+
 - **PR state is MERGED:** PASS → proceed
 - **PR state is CLOSED (not merged):** Ask via `AskUser`:
   ```
-  PR #N was closed without merging. How should this task be marked?
+  PR #${PR_NUM} was closed without merging. How should this task be marked?
   ```
   Options:
   - **Mark as DONE** — task is complete despite PR closure (e.g., changes landed another way)
@@ -269,7 +324,7 @@ fi
   - **Cancel** — stop, do not change status
 - **PR state is OPEN → HARD BLOCK:**
   ```
-  PR #N is still open. Merge or close the PR before running done.
+  PR #${PR_NUM} is still open. Merge or close the PR before running done.
   Lint, tests, and CI validation happen in the PR pipeline — not in done.
   ```
   **STOP** — do NOT proceed.

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -948,17 +948,47 @@ class TestTasksDirLocation:
 
 
 class TestDoneRedesign:
-    """done must use 3 hard gates and NOT run local lint/test."""
+    """done must use 4 hard gates (incl. PR review feedback) and NOT run local lint/test."""
 
-    def test_done_has_three_hard_gates(self):
-        """done SKILL.md must reference all 3 hard gates."""
+    def test_done_has_four_hard_gates(self):
+        """done SKILL.md must reference all 4 hard gates: uncommitted, unpushed,
+        PR review feedback, PR final state."""
         content = _read_skill("done")
         assert "uncommitted" in content.lower(), \
             "done missing 'uncommitted changes' gate"
         assert "unpushed" in content.lower(), \
             "done missing 'unpushed commits' gate"
+        assert "PR Review Feedback" in content or "review feedback" in content.lower(), \
+            "done missing 'PR review feedback' gate (Gate 3)"
         assert "PR" in content and ("MERGED" in content or "final state" in content.lower()), \
             "done missing 'PR in final state' gate"
+
+    def test_done_pr_review_gate_queries_review_decision(self):
+        """Gate 3 must query reviewDecision via gh pr list/view to detect
+        unresolved reviewer feedback before allowing the task to close."""
+        content = _read_skill("done")
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        assert "reviewDecision" in body, (
+            "done Gate 3 must query GitHub's reviewDecision field "
+            "(via `gh pr list ... --json ... reviewDecision`) to detect feedback"
+        )
+        assert "CHANGES_REQUESTED" in body, (
+            "done Gate 3 must handle the CHANGES_REQUESTED reviewDecision value"
+        )
+
+    def test_done_pr_review_gate_offers_pr_check(self):
+        """When reviewDecision is CHANGES_REQUESTED, Gate 3 must offer to invoke
+        /optimus-pr-check as the recommended path to resolve feedback."""
+        content = _read_skill("done")
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        assert "optimus-pr-check" in body or "/optimus-pr-check" in body, (
+            "done Gate 3 must reference /optimus-pr-check as the suggested action"
+        )
+        # Must offer at least: Run pr-check, Override, Cancel — 3 distinct paths.
+        assert "Override" in body or "I have addressed" in body, (
+            "done Gate 3 must offer an override path for users who already "
+            "addressed feedback outside Optimus"
+        )
 
     def test_done_no_local_lint_test(self):
         """done SKILL.md must NOT contain make lint or make test as execution steps.


### PR DESCRIPTION
## Summary
Adds a soft-gate to `/optimus-done` that detects unresolved PR review feedback via GitHub's `reviewDecision` and offers `/optimus-pr-check` before closing the task. Avoids chaining pr-check into the synchronous `/optimus-batch` pipeline (which would break its "run-and-exit" model — reviews are async events arriving over hours/days).

> **Stacked on top of #11** (the rename PR). Base branch is `feat/rename-tasks-md-to-optimus-tasks-md`. Once #11 merges, the base will retarget to `main`.

## Behavior

When the user runs `/optimus-done`, after Gates 1-2 (uncommitted, unpushed), a new **Gate 3** runs:

1. Query `gh pr list --head <branch> --json number,state,reviewDecision`.
2. Inspect `reviewDecision`:
   - `APPROVED` / `null` / empty → PASS, proceed to Gate 4.
   - `CHANGES_REQUESTED` → AskUser:
     - **Run `/optimus-pr-check` now** (recommended) — invokes the skill, then re-evaluates the gate (up to 3 loops).
     - **Override** — proceed with logged warning (for users who already addressed feedback via the GitHub UI without dismissing the review).
     - **Cancel** — STOP without changing task status.
   - `REVIEW_REQUIRED` → soft warning + AskUser (Wait / Proceed anyway).

The original "PR in Final State" gate becomes **Gate 4**, reusing `PR_JSON` fetched in Gate 3 (no extra `gh` call).

## Why not in `/optimus-batch`?

The original proposal considered chaining `pr-check` between `review` and `done` inside the batch pipeline. Rejected because:

- pr-check depends on **async external events** (CodeRabbit takes minutes; human reviewers take hours/days). Batch would block waiting on async input that may never arrive in-session.
- Mixing reactive (pr-check) and goal-driven (plan/build/review/done) flows in one orchestrator complicates the mental model.
- A gate at `done` preserves batch's synchronous nature while still forcing the user to confront unresolved feedback **before** the task is marked DONE — exactly the right moment.

## Design choices

- **No state.json field for `prCheckLastRun`.** Considered, rejected — would require pr-check to resolve TaskID (currently task-agnostic by design, see `pr-check/SKILL.md:107-110`) and creates drift between local state and live PR. The live `gh` query is the source of truth.
- **No GraphQL / review-thread enumeration.** Just `reviewDecision` (the aggregated GitHub-maintained status). Keeps the gate light and predictable.
- **3-iteration loop limit** on pr-check + re-check to prevent infinite back-and-forth if reviewers keep posting.

## Files changed
- `done/skills/optimus-done/SKILL.md` (+85 / -10): new Gate 3, renumbered Gate 4, updated frontmatter.
- `scripts/test_skill_consistency.py` (+30 / -3): renamed `test_done_has_three_hard_gates` → `test_done_has_four_hard_gates`; added `test_done_pr_review_gate_queries_review_decision` and `test_done_pr_review_gate_offers_pr_check`.

## Test plan
- [x] `make test` — **138 passing** (was 136 on PR #11 base; +2 new gate tests).
- [x] `make lint` — clean.
- [x] `python3 scripts/inline-protocols.py` — 0 unmatched references.
- [ ] Manual smoke test: PR with `reviewDecision=CHANGES_REQUESTED` → run `/optimus-done` → verify Gate 3 fires with the 3-option AskUser.
- [ ] Manual smoke test: PR with `reviewDecision=APPROVED` → Gate 3 silent → Gate 4 runs.
- [ ] Manual smoke test: no PR (task pushed directly to main) → Gate 3 PASSes silently.

## Out of scope (potential follow-ups)
- Per-thread resolution detection via GraphQL (currently only checks aggregated `reviewDecision`).
- pr-check writing `state.json.prCheckLastRun.<TaskID>` for skip-if-recent behavior.
- Mirroring the gate in `/optimus-batch`'s done step (auto-inherits since batch invokes done internally).