### PR TITLE
chore(migrations): remove M1 (Migrate tasks.md to tasksDir)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -980,11 +980,6 @@ harmless cheap operation.
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
 separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
-
-**NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
-this change), skills running the migration helper (see Protocol: Migrate tasks.md to
-tasksDir) will offer to run `git rm --cached .optimus/config.json` so the local file
-is preserved but untracked.
 
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
 
@@ -2037,9 +2032,9 @@ would be silently skipped even though ALL local commits are unpushed.
 **Step 2 — Check tasks repo in separate-repo mode:**
 
 If `$TASKS_GIT_SCOPE = "separate-repo"`, the tasks repo is independent from the project
-repo. Commits made via `tasks_git commit` (e.g., Active Version Guard, Migrate tasks.md)
-land in the tasks repo and must be pushed separately. Skipping this makes team members
-pull project main without seeing version/task changes.
+repo. Commits made via `tasks_git commit` (e.g., Active Version Guard) land in the tasks
+repo and must be pushed separately. Skipping this makes team members pull project main
+without seeing version/task changes.
 
 ```bash
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
@@ -2379,239 +2374,6 @@ to the `Ativa` version. If not, present options before proceeding.
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
 
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
-
 ### Protocol: Rename tasks.md to optimus-tasks.md
 
 **Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
@@ -2620,8 +2382,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,15 +37,15 @@ files outside the Ring pre-dev tree.
 `realpath`/`os.path.realpath` and verifies it starts with `$TASKS_DIR_ABS`. Symlinks
 are rejected outright to prevent TOCTOU attacks.
 
-### S3: Symlink attack during migration
+### S3: Symlink attack during rename
 
-**Attack:** Attacker creates `.optimus/tasks.md` as a symlink to a sensitive file.
-Migration's `cp` would overwrite the sensitive target.
+**Attack:** Attacker creates `<tasksDir>/tasks.md` (or its rename target
+`<tasksDir>/optimus-tasks.md`) as a symlink to a sensitive file. The rename would
+move/overwrite the sensitive target via the symlinked path.
 
-**Mitigation:** `Protocol: Migrate tasks.md to tasksDir` rejects with `exit 1` if
-either source or destination is a symlink. The newer `Protocol: Rename tasks.md to
-optimus-tasks.md` similarly refuses to operate on symlinked source or destination
-files.
+**Mitigation:** `Protocol: Rename tasks.md to optimus-tasks.md` rejects with `exit 1`
+if either source or destination is a symlink, refusing to inspect or rename symlinked
+paths.
 
 ### S4: Branch name injection in divergence checks
 

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -62,10 +62,7 @@ Chains stages 1-4 for one or more tasks with user checkpoints between stages.
 
 ### Step 1.1: Resolve and Validate optimus-tasks.md
 
-1. **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-   If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
-   protocol offers migration before proceeding.
-   Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+1. **Rename check:** Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 2. **Find optimus-tasks.md:** Resolve the path using the AGENTS.md Protocol: optimus-tasks.md Validation.
 3. **Validate format:** First line must be `<!-- optimus:tasks-v1 -->`. Full format validation.
 
@@ -643,7 +640,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -665,240 +662,6 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
-
-
 ### Protocol: Rename tasks.md to optimus-tasks.md
 
 **Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
@@ -907,8 +670,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -78,10 +78,7 @@ Executes a validated task specification end-to-end: identifies the task, loads c
 
 ### Step 1.1: Resolve and Validate optimus-tasks.md
 
-**Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
-protocol offers migration before proceeding.
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
 **HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
@@ -904,7 +901,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -1245,240 +1242,6 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
-
-
 ### Protocol: Notification Hooks
 
 **Referenced by:** all stage agents (1-4), tasks
@@ -1727,9 +1490,9 @@ would be silently skipped even though ALL local commits are unpushed.
 **Step 2 — Check tasks repo in separate-repo mode:**
 
 If `$TASKS_GIT_SCOPE = "separate-repo"`, the tasks repo is independent from the project
-repo. Commits made via `tasks_git commit` (e.g., Active Version Guard, Migrate tasks.md)
-land in the tasks repo and must be pushed separately. Skipping this makes team members
-pull project main without seeing version/task changes.
+repo. Commits made via `tasks_git commit` (e.g., Active Version Guard) land in the tasks
+repo and must be pushed separately. Skipping this makes team members pull project main
+without seeing version/task changes.
 
 ```bash
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
@@ -1893,8 +1656,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -633,7 +633,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -900,11 +900,6 @@ Everything inside `.optimus/` is gitignored. The planning tree is versioned
 separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
-**NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
-this change), skills running the migration helper (see Protocol: Migrate tasks.md to
-tasksDir) will offer to run `git rm --cached .optimus/config.json` so the local file
-is preserved but untracked.
-
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
 
 
@@ -1069,9 +1064,9 @@ would be silently skipped even though ALL local commits are unpushed.
 **Step 2 — Check tasks repo in separate-repo mode:**
 
 If `$TASKS_GIT_SCOPE = "separate-repo"`, the tasks repo is independent from the project
-repo. Commits made via `tasks_git commit` (e.g., Active Version Guard, Migrate tasks.md)
-land in the tasks repo and must be pushed separately. Skipping this makes team members
-pull project main without seeing version/task changes.
+repo. Commits made via `tasks_git commit` (e.g., Active Version Guard) land in the tasks
+repo and must be pushed separately. Skipping this makes team members pull project main
+without seeing version/task changes.
 
 ```bash
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -586,7 +586,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -953,11 +953,6 @@ harmless cheap operation.
 Everything inside `.optimus/` is gitignored. The planning tree is versioned
 separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
-
-**NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
-this change), skills running the migration helper (see Protocol: Migrate tasks.md to
-tasksDir) will offer to run `git rm --cached .optimus/config.json` so the local file
-is preserved but untracked.
 
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
 

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -59,10 +59,7 @@ Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 
 ### Step 1.0.1: Resolve and Validate optimus-tasks.md
 
-**Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
-protocol offers migration before proceeding.
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
 **HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
@@ -797,7 +794,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -920,240 +917,6 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
-
-
 ### Protocol: Notification Hooks
 
 **Referenced by:** all stage agents (1-4), tasks
@@ -1230,8 +993,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -145,7 +145,6 @@ I found N task files in this project:
 | # | Path | Optimus format? | Tasks |
 |---|------|-----------------|-------|
 | 1 | docs/pre-dev/optimus-tasks.md | Yes | 42 tasks (27 done, 15 pending) |
-| 2 | .optimus/tasks.md | Yes | Legacy location — will migrate |
 
 How should I proceed?
 ```
@@ -364,8 +363,8 @@ if [ -n "$EXISTING_FILE" ] && [ "$EXISTING_FILE" != "$TASKS_FILE" ]; then
     echo "Keeping old file as reference until all specs are generated."
   else
     EXISTING_TASKS_DIR="$(dirname "$EXISTING_FILE")/tasks"
-    # Remove the existing file using the correct repo (project-repo for legacy
-    # .optimus/tasks.md, tasks-repo for existing files inside tasksDir).
+    # Remove the existing file using the correct repo: tasks-repo when the
+    # file lives inside tasksDir, project-repo otherwise.
     PROJECT_ROOT=$(git rev-parse --show-toplevel)
     TASKS_REPO_ROOT=""
     if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -120,10 +120,7 @@ workflow first (`ring:pre-dev-full` or `ring:pre-dev-feature`) to generate task 
 
 Check if `<TASKS_DIR>/optimus-tasks.md` exists (the new standard location).
 
-**Migration check (HARD BLOCK):** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the protocol
-offers migration before proceeding.
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
 **If optimus-tasks.md exists in optimus format** (first line is `<!-- optimus:tasks-v1 -->`):
 - Read existing tasks from the table
@@ -621,246 +618,7 @@ Everything inside `.optimus/` is gitignored. The planning tree is versioned
 separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
-**NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
-this change), skills running the migration helper (see Protocol: Migrate tasks.md to
-tasksDir) will offer to run `git rm --cached .optimus/config.json` so the local file
-is preserved but untracked.
-
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
-
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: Rename tasks.md to optimus-tasks.md
@@ -871,8 +629,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first
@@ -1093,7 +851,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -83,10 +83,7 @@ spec validation only to discover `gh` is not set up when they try to run Stage-2
 
 ### Step 1.0.1: Resolve and Validate optimus-tasks.md
 
-**Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
-protocol offers migration before proceeding.
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
 **HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
@@ -1182,7 +1179,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -1542,240 +1539,6 @@ times each stage ran on each task — useful for spotting spec churn and review 
 Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
 
 
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
-
-
 ### Protocol: Notification Hooks
 
 **Referenced by:** all stage agents (1-4), tasks
@@ -2005,9 +1768,9 @@ would be silently skipped even though ALL local commits are unpushed.
 **Step 2 — Check tasks repo in separate-repo mode:**
 
 If `$TASKS_GIT_SCOPE = "separate-repo"`, the tasks repo is independent from the project
-repo. Commits made via `tasks_git commit` (e.g., Active Version Guard, Migrate tasks.md)
-land in the tasks repo and must be pushed separately. Skipping this makes team members
-pull project main without seeing version/task changes.
+repo. Commits made via `tasks_git commit` (e.g., Active Version Guard) land in the tasks
+repo and must be pushed separately. Skipping this makes team members pull project main
+without seeing version/task changes.
 
 ```bash
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
@@ -2109,8 +1872,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -120,8 +120,7 @@ Execute AGENTS.md Protocol: Resolve Tasks Git Scope. This obtains `TASKS_DIR`,
 TaskSpec lookups later in this skill (e.g., Step 1.1 PR-creation, Phase 4 attribution)
 depend on `TASKS_DIR` being resolved.
 
-**Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+**Rename check:** Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
 ### Step 1.1: Obtain PR URL
 
@@ -1841,7 +1840,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -2342,246 +2341,7 @@ Everything inside `.optimus/` is gitignored. The planning tree is versioned
 separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
-**NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
-this change), skills running the migration helper (see Protocol: Migrate tasks.md to
-tasksDir) will offer to run `git rm --cached .optimus/config.json` so the local file
-is preserved but untracked.
-
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
-
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: PR Title Validation
@@ -2850,8 +2610,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -57,12 +57,7 @@ and blocked tasks.
 Execute AGENTS.md Protocol: Resolve Tasks Git Scope. This obtains `TASKS_DIR`,
 `TASKS_FILE`, `TASKS_GIT_SCOPE`, `TASKS_GIT_REL`, and the `tasks_git` helper.
 
-Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-Informational only in read-only skills — emit a warning if a legacy
-`.optimus/tasks.md` exists without a new location; do NOT auto-migrate from a
-read-only skill.
-
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 Informational only in read-only skills — emit a warning if `<TASKS_DIR>/tasks.md`
 exists with the optimus format marker but `<TASKS_DIR>/optimus-tasks.md` does not;
 do NOT auto-rename from a read-only skill.
@@ -440,7 +435,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -531,240 +526,6 @@ version name (version names are case-sensitive to match the Versions table).
 Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Default Scope Resolution."
 
 
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
-
-
 ### Protocol: Rename tasks.md to optimus-tasks.md
 
 **Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
@@ -773,8 +534,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -65,12 +65,7 @@ any other project file.
 Execute AGENTS.md Protocol: Resolve Tasks Git Scope. This obtains `TASKS_DIR`,
 `TASKS_FILE`, `TASKS_GIT_SCOPE`, `TASKS_GIT_REL`, and the `tasks_git` helper.
 
-Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-Informational only in read-only skills — emit a warning if a legacy
-`.optimus/tasks.md` exists without a new location; do NOT auto-migrate from a
-read-only skill.
-
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 Informational only in read-only skills — emit a warning if `<TASKS_DIR>/tasks.md`
 exists with the optimus format marker but `<TASKS_DIR>/optimus-tasks.md` does not;
 do NOT auto-rename from a read-only skill.
@@ -882,7 +877,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -1014,246 +1009,7 @@ Everything inside `.optimus/` is gitignored. The planning tree is versioned
 separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
-**NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
-this change), skills running the migration helper (see Protocol: Migrate tasks.md to
-tasksDir) will offer to run `git rm --cached .optimus/config.json` so the local file
-is preserved but untracked.
-
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
-
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: Rename tasks.md to optimus-tasks.md
@@ -1264,8 +1020,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/resolve/skills/optimus-resolve/SKILL.md
+++ b/resolve/skills/optimus-resolve/SKILL.md
@@ -68,7 +68,6 @@ marker but `<TASKS_DIR>/optimus-tasks.md` does not, warn the user: "Detected leg
 trigger the rename, then retry /optimus-resolve."
 Do NOT auto-rename from /optimus-resolve since the file may be in a conflict state.
 For the rename context, see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
-Also check legacy migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir.
 
 Check if `optimus-tasks.md` has merge conflict markers:
 
@@ -309,246 +308,12 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
 
 Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
-
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: Rename tasks.md to optimus-tasks.md
@@ -559,8 +324,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -96,11 +96,7 @@ If `jq` is not available, **STOP**: "jq is required by /optimus-resume. Install 
 
 ### Step 1.2: Resolve and Validate optimus-tasks.md (HARD BLOCK)
 
-**Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
-protocol offers migration before proceeding. (Resume is read-only on state.json,
-but may assist with the migration which writes to git.)
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
 Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
@@ -1006,7 +1002,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -1056,240 +1052,6 @@ Where:
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 
 
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
-
-
 ### Protocol: Rename tasks.md to optimus-tasks.md
 
 **Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
@@ -1298,8 +1060,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -85,10 +85,7 @@ for committed code).
 Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 
 ### Step 1.0.1: Resolve and Validate optimus-tasks.md
-**Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
-protocol offers migration before proceeding.
-Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
 **HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
@@ -1357,7 +1354,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -1852,240 +1849,6 @@ times each stage ran on each task — useful for spotting spec churn and review 
 Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
 
 
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
-
-
 ### Protocol: Notification Hooks
 
 **Referenced by:** all stage agents (1-4), tasks
@@ -2334,9 +2097,9 @@ would be silently skipped even though ALL local commits are unpushed.
 **Step 2 — Check tasks repo in separate-repo mode:**
 
 If `$TASKS_GIT_SCOPE = "separate-repo"`, the tasks repo is independent from the project
-repo. Commits made via `tasks_git commit` (e.g., Active Version Guard, Migrate tasks.md)
-land in the tasks repo and must be pushed separately. Skipping this makes team members
-pull project main without seeing version/task changes.
+repo. Commits made via `tasks_git commit` (e.g., Active Version Guard) land in the tasks
+repo and must be pushed separately. Skipping this makes team members pull project main
+without seeing version/task changes.
 
 ```bash
 if [ "$TASKS_GIT_SCOPE" = "separate-repo" ]; then
@@ -2556,8 +2319,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first

--- a/scripts/inline-protocols.py
+++ b/scripts/inline-protocols.py
@@ -254,11 +254,13 @@ def inline_protocols() -> None:
         if needs_format and "Format Validation" in foundational:
             extra["Format Validation"] = foundational["Format Validation"]
 
-        # optimus-tasks.md Validation depends on Resolve Tasks Git Scope (which defines
-        # TASKS_DIR/TASKS_FILE/TASKS_GIT_SCOPE/tasks_git). Defensive scaffold:
-        # adds these when ONLY Validation is referenced (currently unreachable
-        # from real skills, but kept as a safety net for future skills that
-        # might under-reference).
+        # optimus-tasks.md Validation depends on Resolve Tasks Git Scope (which
+        # defines TASKS_DIR/TASKS_FILE/TASKS_GIT_SCOPE/tasks_git). After M1
+        # (Migrate) was removed in issue #20, this is the SOLE auto-injection
+        # path for the Rename protocol when a skill references only Validation.
+        # Removing this block silently breaks under-referencing skills —
+        # verified by `test_needs_format_injects_scope` and
+        # `test_needs_format_injects_rename_protocol`.
         if needs_format:
             if "Protocol: Resolve Tasks Git Scope" in foundational and \
                "Protocol: Resolve Tasks Git Scope" not in sections_to_inline:
@@ -270,7 +272,7 @@ def inline_protocols() -> None:
         # Auto-inject Resolve Main Worktree Path into any skill that touches
         # .optimus/ operational files. The bug it fixes (worktree isolation)
         # affects every skill that reads/writes state.json, stats.json, sessions,
-        # reports, or migration/rename checkpoint markers.
+        # reports, or rename checkpoint markers (.rename-in-progress).
         if needs_main_worktree and MAIN_WORKTREE_PROTOCOL_KEY in foundational \
                 and MAIN_WORKTREE_PROTOCOL_KEY not in sections_to_inline:
             extra[MAIN_WORKTREE_PROTOCOL_KEY] = foundational[MAIN_WORKTREE_PROTOCOL_KEY]

--- a/scripts/inline-protocols.py
+++ b/scripts/inline-protocols.py
@@ -28,7 +28,6 @@ MAX_FILE_SIZE = 5 * 1024 * 1024
 # exactly one place. A regression test parses live AGENTS.md and asserts that
 # at least one heading contains this token.
 VALIDATION_PROTOCOL_TOKEN = "optimus-tasks.md Validation"
-MIGRATE_PROTOCOL_KEY = "Protocol: Migrate tasks.md to tasksDir"
 RENAME_PROTOCOL_KEY = "Protocol: Rename tasks.md to optimus-tasks.md"
 MAIN_WORKTREE_PROTOCOL_KEY = "Protocol: Resolve Main Worktree Path"
 
@@ -180,7 +179,6 @@ def inline_protocols() -> None:
     for key in ["File Location", "Valid Status Values (stored in state.json)",
                  "Task Spec Resolution", "Format Validation",
                  "Protocol: Resolve Tasks Git Scope",
-                 MIGRATE_PROTOCOL_KEY,
                  RENAME_PROTOCOL_KEY,
                  MAIN_WORKTREE_PROTOCOL_KEY]:
         if key in sections:
@@ -228,16 +226,6 @@ def inline_protocols() -> None:
             if key not in sections_to_inline:
                 sections_to_inline[key] = sections[key]
 
-        # Pair sibling startup protocols: any skill that inlines the legacy
-        # Migrate also needs Rename (and vice versa). Both run on skill startup
-        # to detect/repair filename and location drift.
-        if MIGRATE_PROTOCOL_KEY in sections_to_inline and RENAME_PROTOCOL_KEY in sections \
-                and RENAME_PROTOCOL_KEY not in sections_to_inline:
-            sections_to_inline[RENAME_PROTOCOL_KEY] = sections[RENAME_PROTOCOL_KEY]
-        if RENAME_PROTOCOL_KEY in sections_to_inline and MIGRATE_PROTOCOL_KEY in sections \
-                and MIGRATE_PROTOCOL_KEY not in sections_to_inline:
-            sections_to_inline[MIGRATE_PROTOCOL_KEY] = sections[MIGRATE_PROTOCOL_KEY]
-
         # Also check if State Management is referenced -> include foundational state.json docs
         needs_state = any("State Management" in k for k in sections_to_inline)
         needs_taskspec = any("TaskSpec" in k for k in sections_to_inline)
@@ -253,7 +241,6 @@ def inline_protocols() -> None:
             or any("Increment Stage Stats" in k for k in sections_to_inline)
             or any("Initialize .optimus Directory" in k for k in sections_to_inline)
             or any("Divergence Warning" in k for k in sections_to_inline)
-            or MIGRATE_PROTOCOL_KEY in sections_to_inline
             or RENAME_PROTOCOL_KEY in sections_to_inline
         )
 
@@ -269,17 +256,13 @@ def inline_protocols() -> None:
 
         # optimus-tasks.md Validation depends on Resolve Tasks Git Scope (which defines
         # TASKS_DIR/TASKS_FILE/TASKS_GIT_SCOPE/tasks_git). Defensive scaffold:
-        # the pairing block above already injects Migrate+Rename when either is
-        # explicitly referenced; this block adds them when ONLY Validation is
-        # referenced (currently unreachable from real skills, but kept as a
-        # safety net for future skills that might under-reference).
+        # adds these when ONLY Validation is referenced (currently unreachable
+        # from real skills, but kept as a safety net for future skills that
+        # might under-reference).
         if needs_format:
             if "Protocol: Resolve Tasks Git Scope" in foundational and \
                "Protocol: Resolve Tasks Git Scope" not in sections_to_inline:
                 extra["Protocol: Resolve Tasks Git Scope"] = foundational["Protocol: Resolve Tasks Git Scope"]
-            if MIGRATE_PROTOCOL_KEY in foundational and \
-               MIGRATE_PROTOCOL_KEY not in sections_to_inline:
-                extra[MIGRATE_PROTOCOL_KEY] = foundational[MIGRATE_PROTOCOL_KEY]
             if RENAME_PROTOCOL_KEY in foundational and \
                RENAME_PROTOCOL_KEY not in sections_to_inline:
                 extra[RENAME_PROTOCOL_KEY] = foundational[RENAME_PROTOCOL_KEY]

--- a/scripts/test_inline_protocols.py
+++ b/scripts/test_inline_protocols.py
@@ -189,7 +189,7 @@ class TestMatchRefToSection:
         VALIDATION_PROTOCOL_TOKEN constant to detect the format-validation
         protocol heading. If the heading is renamed in AGENTS.md, this test
         flags the drift before propagation silently breaks foundational
-        injection (Migrate, Rename, Resolve Tasks Git Scope).
+        injection (Rename, Resolve Tasks Git Scope).
         """
         agents_md = Path(__file__).parent.parent / "AGENTS.md"
         sections = _parse_real_agents_md(agents_md)

--- a/scripts/test_inline_protocols.py
+++ b/scripts/test_inline_protocols.py
@@ -200,68 +200,18 @@ class TestMatchRefToSection:
             "inline-protocols.py drifted from the actual heading text."
         )
 
-    def test_migrate_and_rename_protocol_keys_match_live_headings(self):
-        """Regression guard for MIGRATE_PROTOCOL_KEY and RENAME_PROTOCOL_KEY.
+    def test_rename_protocol_key_matches_live_heading(self):
+        """Regression guard for RENAME_PROTOCOL_KEY.
 
-        Both keys are used by the pairing logic to inject the legacy migrate
-        protocol whenever the new rename is referenced and vice versa. If
-        either heading is renamed in AGENTS.md, the pairing silently breaks.
+        The constant is used to detect the rename protocol heading and
+        auto-inject it into the foundational set. If the heading is renamed
+        in AGENTS.md, the inlining silently breaks.
         """
         agents_md = Path(__file__).parent.parent / "AGENTS.md"
         sections = _parse_real_agents_md(agents_md)
-        assert ip.MIGRATE_PROTOCOL_KEY in sections, (
-            f"MIGRATE_PROTOCOL_KEY ({ip.MIGRATE_PROTOCOL_KEY!r}) not found "
-            "as a heading in live AGENTS.md."
-        )
         assert ip.RENAME_PROTOCOL_KEY in sections, (
             f"RENAME_PROTOCOL_KEY ({ip.RENAME_PROTOCOL_KEY!r}) not found "
             "as a heading in live AGENTS.md."
-        )
-
-    def test_pairing_injects_rename_when_only_migrate_referenced(self, tmp_path, monkeypatch):
-        """Pairing branch regression: a SKILL.md that references ONLY Migrate
-        (not optimus-tasks.md Validation) must still get Rename injected via
-        the pairing block in inline-protocols.py. This is the failure mode
-        that bit report/quick-report before the pairing block was added.
-        """
-        agents = tmp_path / "AGENTS.md"
-        agents.write_text(
-            "## Protocol: Migrate tasks.md to tasksDir\nMigrate body content\n\n"
-            "## Protocol: Rename tasks.md to optimus-tasks.md\nRename body content\n"
-        )
-        monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
-        skill_dir = tmp_path / "x" / "skills" / "optimus-x"
-        skill_dir.mkdir(parents=True)
-        skill = skill_dir / "SKILL.md"
-        skill.write_text("see AGENTS.md Protocol: Migrate tasks.md to tasksDir.\n")
-        ip.inline_protocols()
-        inlined = skill.read_text()
-        assert "Migrate body content" in inlined, "Migrate failed to inline"
-        assert "Rename body content" in inlined, (
-            "Pairing failed: Rename was not auto-injected when SKILL.md only "
-            "references Migrate (regression risk for read-only skills)."
-        )
-
-    def test_pairing_injects_migrate_when_only_rename_referenced(self, tmp_path, monkeypatch):
-        """Symmetric pairing branch regression: ONLY Rename referenced → Migrate auto-paired."""
-        agents = tmp_path / "AGENTS.md"
-        agents.write_text(
-            "## Protocol: Migrate tasks.md to tasksDir\nMigrate body content\n\n"
-            "## Protocol: Rename tasks.md to optimus-tasks.md\nRename body content\n"
-        )
-        monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
-        skill_dir = tmp_path / "x" / "skills" / "optimus-x"
-        skill_dir.mkdir(parents=True)
-        skill = skill_dir / "SKILL.md"
-        skill.write_text("see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.\n")
-        ip.inline_protocols()
-        inlined = skill.read_text()
-        assert "Rename body content" in inlined
-        assert "Migrate body content" in inlined, (
-            "Symmetric pairing failed: Migrate was not auto-injected when "
-            "SKILL.md only references Rename."
         )
 
 

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -797,9 +797,10 @@ class TestTasksDirLocation:
 
     def test_skills_no_legacy_tasks_file_as_live_path(self):
         """SKILL.md bodies must not assume `.optimus/tasks.md` as the current location.
-        Mentions are allowed only as legacy/migration context (e.g., 'if a legacy
-        .optimus/tasks.md exists'). Uses a 3-line context window to detect legacy
-        keywords split across lines."""
+        After M1 removal (#20), mentions are allowed ONLY as explicit historical
+        / legacy context (e.g., 'if a legacy .optimus/tasks.md exists'). The
+        previous tolerance for 'migrate'/'migration' keywords was dropped —
+        with M1 gone there is no legitimate reason to use those terms inline."""
         violations = []
         for skill in SKILLS_THAT_TOUCH_TASKS:
             paths = list(REPO_ROOT.glob(f"{skill}/skills/*/SKILL.md"))
@@ -811,17 +812,18 @@ class TestTasksDirLocation:
             for i, line in enumerate(lines, 1):
                 if not LEGACY_TASKS_PATH_RE.search(line):
                     continue
-                # Check a 3-line context window (±1 line) for legacy/migration keywords
+                # Check a 3-line context window (±1 line) for the "legacy"
+                # marker. Only "legacy" remains a valid exemption keyword
+                # post-M1; any other context is a regression.
                 start = max(0, i - 2)
                 end = min(len(lines), i + 1)
                 context = " ".join(lines[start:end]).lower()
-                is_legacy_context = any(k in context for k in [
-                    "legacy", "migrate", "migration", "will migrate", "migrat"
-                ])
+                is_legacy_context = "legacy" in context
                 if not is_legacy_context:
                     violations.append(f"{skill}/SKILL.md:{i}: {line.strip()}")
         assert violations == [], (
-            "SKILL bodies use `.optimus/tasks.md` outside legacy/migration context:\n"
+            "SKILL bodies use `.optimus/tasks.md` outside an explicit legacy "
+            "context (the only valid reason after M1 removal in #20):\n"
             + "\n".join(f"  - {v}" for v in violations)
         )
 
@@ -851,6 +853,41 @@ class TestTasksDirLocation:
             "AGENTS.md missing Protocol: Rename tasks.md to optimus-tasks.md"
         assert 'OLD_TASKS_FILE="${TASKS_DIR}/tasks.md"' in content, \
             "AGENTS.md rename protocol missing OLD_TASKS_FILE"
+
+    def test_agents_md_has_no_migrate_protocol(self):
+        """Negation guard: M1 was removed in issue #20 and must not return.
+
+        Catches accidental re-introduction of `Protocol: Migrate tasks.md to
+        tasksDir` (e.g., via a stale rebase, copy-paste, or merge from a long-
+        lived branch). The protocol's hot-path startup cost is the reason it
+        was removed; a silent regression would re-add it without alerting CI
+        unless this assertion exists.
+        """
+        content = AGENTS_MD.read_text()
+        assert "### Protocol: Migrate tasks.md to tasksDir" not in content, (
+            "AGENTS.md re-introduces `Protocol: Migrate tasks.md to tasksDir` "
+            "(removed in issue #20). This protocol is dead and must stay gone — "
+            "see PR #24 for context."
+        )
+
+    def test_inline_protocols_has_no_migrate_constant(self):
+        """Negation guard: `MIGRATE_PROTOCOL_KEY` was removed alongside M1.
+
+        Re-defining the constant in `inline-protocols.py` is the most likely
+        regression path back into the deleted Migrate logic. This test imports
+        the script and asserts the attribute is absent.
+        """
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "inline_protocols", REPO_ROOT / "scripts" / "inline-protocols.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        assert not hasattr(mod, "MIGRATE_PROTOCOL_KEY"), (
+            "scripts/inline-protocols.py re-introduces MIGRATE_PROTOCOL_KEY "
+            "(removed in issue #20). The legacy Migrate protocol is gone — "
+            "see PR #24 for context."
+        )
 
     def test_config_json_is_gitignored(self):
         """Protocol: Initialize .optimus Directory must include config.json in the
@@ -1411,11 +1448,15 @@ def _extract_protocol_bash(section_title: str) -> str:
 
 
 @pytest.mark.skipif(not _has_git(), reason="git not available")
-class TestMigrationAndScopeIntegration:
-    """Integration tests for the optimus-tasks.md relocation + separate-repo support.
+class TestScopeIntegration:
+    """Integration tests for `Protocol: Resolve Tasks Git Scope` and TaskSpec
+    resolution. After M1 (Migrate) was removed in issue #20, this class no
+    longer covers migration — it focuses on scope detection, dash-prefix
+    rejection, non-git rejection, and path-traversal protection.
 
-    These tests execute the bash blocks from AGENTS.md against real tmp git repos
-    to verify the protocols actually work — not just that their documentation exists.
+    These tests execute the bash blocks from AGENTS.md against real tmp git
+    repos to verify the protocols actually work — not just that their
+    documentation exists.
     """
 
     def test_scope_resolution_same_repo(self, tmp_path: Path):
@@ -1500,7 +1541,8 @@ esac
         rc, out, err = _run(["bash", "-c", probe], cwd=tmp_path)
         assert "BLOCKED" in out, f"Path traversal was not blocked: {out}"
 
-# --- F19: Test that inline-protocols.py auto-injects scope+migration when optimus-tasks.md Validation is referenced ---
+# --- Test that inline-protocols.py auto-injects foundational protocols when
+#     Protocol: optimus-tasks.md Validation is referenced ---
 
 
 class TestInlineProtocolsFoundational:
@@ -1550,11 +1592,10 @@ class TestInlineProtocolsFoundational:
         """When a skill references Protocol: optimus-tasks.md Validation, the inlined block
         MUST also contain Protocol: Rename tasks.md to optimus-tasks.md.
 
-        Regression coverage for the secondary rename protocol that handles
-        `<tasksDir>/tasks.md` → `<tasksDir>/optimus-tasks.md` on disk. Mirrors the
-        Migrate protocol regression test above; the Rename protocol must be auto-
-        injected into the same set of skills (those that reference the format
-        validation protocol)."""
+        Regression coverage for the rename protocol that handles
+        `<tasksDir>/tasks.md` → `<tasksDir>/optimus-tasks.md` on disk. After M1
+        was removed in #20, this is the SOLE auto-injection path for Rename
+        when only Validation is referenced — making the assertion load-bearing."""
         import importlib.util
         spec = importlib.util.spec_from_file_location(
             "inline_protocols", REPO_ROOT / "scripts" / "inline-protocols.py",

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -777,33 +777,21 @@ class TestTasksDirLocation:
     """
 
     def test_agents_md_no_legacy_hardcoded_tasks_file(self):
-        """AGENTS.md must not reference `.optimus/tasks.md` as the live location.
-        The only allowed references are inside Protocol: Migrate tasks.md to tasksDir
-        (where LEGACY_FILE=".optimus/tasks.md" is the source to migrate from).
+        """AGENTS.md must not reference `.optimus/tasks.md` as a live path.
 
-        Uses explicit protocol-end marker ("Skills reference this as: ...") to track
-        section boundaries rather than the fragile line-prefix heuristic.
+        After M1 (Protocol: Migrate tasks.md to tasksDir) was removed in
+        issue #20, NO legitimate reference to `.optimus/tasks.md` remains —
+        the legacy migration that touched it is gone. Any reappearance is a
+        bug.
         """
         content = AGENTS_MD.read_text()
         violations = []
-        in_migration_section = False
         for i, line in enumerate(content.splitlines(), 1):
-            if line.startswith("### Protocol: Migrate tasks.md to tasksDir"):
-                in_migration_section = True
-                continue
-            # Explicit end marker: every protocol closes with
-            # 'Skills reference this as: "... AGENTS.md Protocol: X."'
-            if in_migration_section and line.startswith("Skills reference this as:"):
-                in_migration_section = False
-                continue
-            # Also close on next top-level heading
-            if line.startswith("## ") or (line.startswith("### ") and "Migrate tasks.md to tasksDir" not in line):
-                if in_migration_section:
-                    in_migration_section = False
-            if LEGACY_TASKS_PATH_RE.search(line) and not in_migration_section:
+            if LEGACY_TASKS_PATH_RE.search(line):
                 violations.append(f"AGENTS.md:{i}: {line.strip()}")
         assert violations == [], (
-            "AGENTS.md still references `.optimus/tasks.md` outside migration section:\n"
+            "AGENTS.md references `.optimus/tasks.md` (legacy path); the M1 "
+            "migration that justified those references was removed:\n"
             + "\n".join(f"  - {v}" for v in violations)
         )
 
@@ -851,20 +839,12 @@ class TestTasksDirLocation:
         assert '"separate-repo"' in content, \
             "AGENTS.md missing separate-repo scope case"
 
-    def test_agents_md_has_migration_protocol(self):
-        """AGENTS.md must define Protocol: Migrate tasks.md to tasksDir."""
-        content = AGENTS_MD.read_text()
-        assert "### Protocol: Migrate tasks.md to tasksDir" in content, \
-            "AGENTS.md missing Protocol: Migrate tasks.md to tasksDir"
-        assert "LEGACY_FILE=\".optimus/tasks.md\"" in content, \
-            "AGENTS.md migration protocol missing LEGACY_FILE"
-
     def test_agents_md_has_rename_protocol(self):
         """AGENTS.md must define Protocol: Rename tasks.md to optimus-tasks.md.
 
-        This protocol handles the secondary rename `<tasksDir>/tasks.md` →
-        `<tasksDir>/optimus-tasks.md` (distinct from the legacy `.optimus/tasks.md`
-        relocation handled by Protocol: Migrate tasks.md to tasksDir).
+        This protocol handles the rename `<tasksDir>/tasks.md` →
+        `<tasksDir>/optimus-tasks.md` for projects upgrading from the
+        pre-rename default filename.
         """
         content = AGENTS_MD.read_text()
         assert "### Protocol: Rename tasks.md to optimus-tasks.md" in content, \
@@ -1520,50 +1500,6 @@ esac
         rc, out, err = _run(["bash", "-c", probe], cwd=tmp_path)
         assert "BLOCKED" in out, f"Path traversal was not blocked: {out}"
 
-    def test_migration_detects_legacy_file(self, tmp_path: Path):
-        """Migration detection: given legacy file, NEEDS_MIGRATION=1."""
-        _init_repo(tmp_path)
-        (tmp_path / ".optimus").mkdir()
-        legacy = tmp_path / ".optimus" / "tasks.md"
-        legacy.write_text("<!-- optimus:tasks-v1 -->\n# Tasks\n")
-        probe = '''
-TASKS_FILE="docs/pre-dev/optimus-tasks.md"
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  echo "NEEDS_MIGRATION=0 both exist"
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  echo "NEEDS_MIGRATION=1"
-else
-  echo "NEEDS_MIGRATION=0"
-fi
-'''
-        rc, out, err = _run(["bash", "-c", probe], cwd=tmp_path)
-        assert rc == 0
-        assert "NEEDS_MIGRATION=1" in out
-
-    def test_migration_detects_both_files(self, tmp_path: Path):
-        """Migration detection: given both files exist, should warn and NOT migrate."""
-        _init_repo(tmp_path)
-        (tmp_path / ".optimus").mkdir()
-        (tmp_path / "docs" / "pre-dev").mkdir(parents=True)
-        (tmp_path / ".optimus" / "tasks.md").write_text("legacy\n")
-        (tmp_path / "docs" / "pre-dev" / "optimus-tasks.md").write_text("new\n")
-        probe = '''
-TASKS_FILE="docs/pre-dev/optimus-tasks.md"
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  echo "NEEDS_MIGRATION=0 both exist"
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  echo "NEEDS_MIGRATION=1"
-else
-  echo "NEEDS_MIGRATION=0"
-fi
-'''
-        rc, out, err = _run(["bash", "-c", probe], cwd=tmp_path)
-        assert rc == 0
-        assert "both exist" in out, f"Did not detect both-files case: {out}"
-
-
 # --- F19: Test that inline-protocols.py auto-injects scope+migration when optimus-tasks.md Validation is referenced ---
 
 
@@ -1573,9 +1509,9 @@ class TestInlineProtocolsFoundational:
     This is the `needs_format` branch added in commit ad0d8d7 — previously untested.
     """
 
-    def test_needs_format_injects_scope_and_migration(self, tmp_path: Path):
+    def test_needs_format_injects_scope(self, tmp_path: Path):
         """When a skill references Protocol: optimus-tasks.md Validation, the inlined block
-        MUST contain both Protocol: Resolve Tasks Git Scope AND Protocol: Migrate tasks.md to tasksDir."""
+        MUST contain Protocol: Resolve Tasks Git Scope (validation depends on it)."""
         import importlib.util
         spec = importlib.util.spec_from_file_location(
             "inline_protocols", REPO_ROOT / "scripts" / "inline-protocols.py",
@@ -1587,7 +1523,6 @@ class TestInlineProtocolsFoundational:
         agents.write_text(
             "## Protocol: optimus-tasks.md Validation (HARD BLOCK)\nValidation content\n"
             "## Protocol: Resolve Tasks Git Scope\nScope resolution content\n"
-            "## Protocol: Migrate tasks.md to tasksDir\nMigration content\n"
             "## Protocol: Rename tasks.md to optimus-tasks.md\nRename content\n"
         )
         skill_dir = tmp_path / "myplugin" / "skills" / "optimus-myplugin"
@@ -1609,8 +1544,6 @@ class TestInlineProtocolsFoundational:
         inlined = skill.read_text()
         assert "Scope resolution content" in inlined, \
             "Resolve Tasks Git Scope was not auto-injected"
-        assert "Migration content" in inlined, \
-            "Migrate tasks.md to tasksDir was not auto-injected"
         assert "Validation content" in inlined
 
     def test_needs_format_injects_rename_protocol(self, tmp_path: Path):
@@ -1633,7 +1566,6 @@ class TestInlineProtocolsFoundational:
         agents.write_text(
             "## Protocol: optimus-tasks.md Validation (HARD BLOCK)\nValidation content\n"
             "## Protocol: Resolve Tasks Git Scope\nScope resolution content\n"
-            "## Protocol: Migrate tasks.md to tasksDir\nMigration content\n"
             "## Protocol: Rename tasks.md to optimus-tasks.md\nRename content\n"
         )
         skill_dir = tmp_path / "myplugin" / "skills" / "optimus-myplugin"

--- a/scripts/test_worktree_path_resolution.py
+++ b/scripts/test_worktree_path_resolution.py
@@ -384,14 +384,13 @@ class TestInlineProtocolsInjectsMainWorktree:
 
     def test_state_touching_skills_have_main_worktree_inlined(self):
         """Skills that inline State Management / Session State / Stats /
-        Initialize .optimus / Migrate / Rename must also inline the main
-        worktree resolver."""
+        Initialize .optimus / Rename / Divergence Warning must also inline
+        the main worktree resolver."""
         triggers = (
             "### Protocol: State Management",
             "### Protocol: Session State",
             "### Protocol: Increment Stage Stats",
             "### Protocol: Initialize .optimus Directory",
-            "### Protocol: Migrate tasks.md to tasksDir",
             "### Protocol: Rename tasks.md to optimus-tasks.md",
             "### Protocol: Divergence Warning",
         )

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -83,10 +83,7 @@ For operations that do not use `gh` (create, edit, remove, reorder, version mana
    This obtains `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, `TASKS_GIT_REL`, and the
    `tasks_git` helper.
 
-2. **Migration check:** Execute AGENTS.md Protocol: Migrate tasks.md to tasksDir.
-   If a legacy `.optimus/tasks.md` exists and `<TASKS_DIR>/optimus-tasks.md` does not, the
-   protocol offers migration before proceeding.
-   Also check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
+2. **Rename check:** Check tasks.md → optimus-tasks.md rename — see AGENTS.md Protocol: Rename tasks.md to optimus-tasks.md.
 
 3. **Find optimus-tasks.md:** Resolve the path using the AGENTS.md Protocol: optimus-tasks.md Validation.
    The file is at `<TASKS_DIR>/optimus-tasks.md` (default: `docs/pre-dev/optimus-tasks.md`).
@@ -1130,7 +1127,7 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **What does NOT need this protocol:**
 
 - `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default after Migrate protocol untracks it), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
 - `.gitignore` itself — versioned, propagated via git.
 
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
@@ -1179,246 +1176,7 @@ Everything inside `.optimus/` is gitignored. The planning tree is versioned
 separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
 for Ring specs) — see the File Location section above.
 
-**NOTE:** If a legacy project has `.optimus/config.json` tracked in git (from before
-this change), skills running the migration helper (see Protocol: Migrate tasks.md to
-tasksDir) will offer to run `git rm --cached .optimus/config.json` so the local file
-is preserved but untracked.
-
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
-
-### Protocol: Migrate tasks.md to tasksDir
-
-**Referenced by:** import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check
-
-Detects and migrates projects that have a legacy `.optimus/tasks.md` (versioned inside
-`.optimus/`) to the new location `<tasksDir>/optimus-tasks.md`.
-
-**Detection (run at the start of every skill that reads/writes the tasks tracking file):**
-
-```bash
-# Requires Protocol: Resolve Tasks Git Scope to have been executed first
-# (TASKS_DIR, TASKS_FILE, TASKS_GIT_SCOPE, tasks_git available).
-LEGACY_FILE=".optimus/tasks.md"
-if [ -f "$LEGACY_FILE" ] && [ -f "$TASKS_FILE" ]; then
-  # Partial/failed migration OR manual copy. Use new location but WARN the user.
-  echo "WARNING: Both legacy ($LEGACY_FILE) and new ($TASKS_FILE) tracking files exist." >&2
-  echo "         This indicates a partial prior migration or manual copy." >&2
-  echo "         Using $TASKS_FILE. After confirming contents, remove the legacy file." >&2
-  NEEDS_MIGRATION=0
-elif [ -f "$LEGACY_FILE" ] && [ ! -f "$TASKS_FILE" ]; then
-  NEEDS_MIGRATION=1
-else
-  NEEDS_MIGRATION=0
-fi
-```
-
-**Dry-run mode:** If the skill is running in dry-run (per Dry-Run Mode section above),
-DO NOT offer migration and DO NOT execute any migration step. Emit the plan and proceed:
-
-```
-[DRY-RUN] Migration would be offered for this task:
-[DRY-RUN]   Legacy: $LEGACY_FILE
-[DRY-RUN]   New:    $TASKS_FILE
-[DRY-RUN]   Scope:  $TASKS_GIT_SCOPE
-[DRY-RUN]   Would use: git mv (same-repo) OR cp + two commits (separate-repo)
-```
-
-**Config.json team-shared values warning:** If `.optimus/config.json` is currently tracked
-in git and contains values (e.g., `defaultScope`), migration will untrack it. The values
-are preserved locally but no longer shared via git. Warn user BEFORE untracking:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  if [ -f .optimus/config.json ]; then
-    CONFIG_KEYS=$(jq -r 'keys | join(", ")' .optimus/config.json 2>/dev/null || echo "unknown")
-    echo "WARNING: .optimus/config.json is currently tracked with values: $CONFIG_KEYS" >&2
-    echo "         Untracking will make these per-user. Team members need to re-apply locally." >&2
-    # AskUser: Proceed with untrack? / Keep tracked (deviates from Optimus convention)
-  fi
-fi
-```
-
-**If `NEEDS_MIGRATION=1`, ask the user via `AskUser`:**
-
-```
-A legacy tasks.md was found at .optimus/tasks.md. The new location is ${TASKS_FILE} (optimus-tasks.md).
-Migrate now? (Recommended — keeping the old location will break other skills.)
-```
-
-Options:
-- **Migrate now** — copy → add in target repo → remove from project repo
-- **Skip this time** — continue with the legacy file (emit warning; this will break)
-- **Abort** — stop the current command so you can migrate manually
-
-**Migration flow (when user chooses "Migrate now"):**
-
-**Symlink safety (HARD BLOCK):** refuse to migrate if source or destination is a symlink
-(prevents arbitrary file-write via symlink target). Must run BEFORE the checkpoint write
-so we don't leave an orphan marker if a symlink is detected:
-```bash
-if [ -L "$LEGACY_FILE" ] || [ -L "$TASKS_FILE" ]; then
-  echo "ERROR: Source or destination is a symlink — refusing to migrate." >&2
-  exit 1
-fi
-```
-
-Checkpoint file: write `${MAIN_WORKTREE}/.optimus/.migration-in-progress` BEFORE starting.
-This marker lets subsequent invocations detect interrupted migrations:
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-mkdir -p "${MAIN_WORKTREE}/.optimus"
-printf '%s\n' "$TASKS_FILE" > "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-```
-
-**Scope-branched migration:** explicit `if` so the agent executes the correct branch:
-
-```bash
-if [ "$TASKS_GIT_SCOPE" = "same-repo" ]; then
-  # Same-repo: atomic git mv in a single commit (preserves history via rename-detect).
-  mkdir -p "$TASKS_DIR"
-  if ! git mv "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: git mv failed. Migration aborted — no changes made." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed. Reverting git mv..." >&2
-    # Revert: restore legacy from HEAD, remove new from working tree
-    git reset HEAD -- "$LEGACY_FILE" "$TASKS_FILE" 2>/dev/null
-    git checkout HEAD -- "$LEGACY_FILE" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-else
-  # Separate-repo: two commits in two repos. Rollback is per-repo on failure.
-  mkdir -p "$TASKS_DIR"
-  if ! cp "$LEGACY_FILE" "$TASKS_FILE"; then
-    echo "ERROR: cp failed. Migration aborted." >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  # Commit #1: in tasks repo
-  if ! tasks_git add "$TASKS_GIT_REL"; then
-    echo "ERROR: tasks_git add failed. Rolling back..." >&2
-    rm -f "$TASKS_FILE"
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): migrate legacy .optimus/tasks.md to ${TASKS_DIR}/optimus-tasks.md" > "$COMMIT_MSG_FILE"
-  if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: tasks_git commit failed. Rolling back..." >&2
-    tasks_git reset HEAD -- "$TASKS_GIT_REL" 2>/dev/null
-    rm -f "$TASKS_FILE"
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-  # Commit #2: in project repo
-  if ! git rm "$LEGACY_FILE"; then
-    echo "ERROR: git rm failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: rm $LEGACY_FILE && git add -A && git commit" >&2
-    rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore(tasks): remove legacy .optimus/tasks.md (moved to separate tasks repo at ${TASKS_DIR})" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    echo "ERROR: Commit failed in project repo. Tasks repo already committed." >&2
-    echo "Manual cleanup needed: git commit after resolving." >&2
-    rm -f "$COMMIT_MSG_FILE" "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-    exit 1
-  fi
-  rm -f "$COMMIT_MSG_FILE"
-fi
-```
-
-**Untrack `.optimus/config.json` if previously versioned** (legacy projects). Check
-commit exit code; restore index on failure:
-
-```bash
-if git ls-files --error-unmatch .optimus/config.json >/dev/null 2>&1; then
-  git rm --cached .optimus/config.json
-  COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-  chmod 600 "$COMMIT_MSG_FILE"
-  printf '%s' "chore: untrack .optimus/config.json (now gitignored)" > "$COMMIT_MSG_FILE"
-  if ! git commit -F "$COMMIT_MSG_FILE"; then
-    # Restore to index so user can retry
-    git reset HEAD .optimus/config.json 2>/dev/null
-    rm -f "$COMMIT_MSG_FILE"
-    echo "ERROR: Failed to untrack config.json. Index restored." >&2
-    # Do not exit — migration of optimus-tasks.md already succeeded; user can retry untrack
-  else
-    rm -f "$COMMIT_MSG_FILE"
-  fi
-fi
-```
-
-**Ensure `.gitignore` includes the operational-files block:**
-Execute Protocol: Initialize .optimus Directory. Commit if `.gitignore` was modified.
-
-**Post-migration validation:** Verify the migrated optimus-tasks.md still passes Format
-Validation (see AGENTS.md Format Validation section). If it fails (e.g., legacy
-file was manually edited and lacks a `## Versions` section), inform user and suggest
-running `/optimus-import` to rebuild:
-
-```bash
-if ! grep -q '^<!-- optimus:tasks-v1 -->' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md does not have the optimus format marker." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-if ! grep -q '^## Versions' "$TASKS_FILE"; then
-  echo "WARNING: Migrated optimus-tasks.md has no ## Versions section." >&2
-  echo "         Run /optimus-import to rebuild in the correct format." >&2
-fi
-```
-
-**Migration success: clear checkpoint marker and log each step.**
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress"
-echo "INFO: Migration completed successfully:" >&2
-echo "  - Legacy location: $LEGACY_FILE" >&2
-echo "  - New location:    $TASKS_FILE" >&2
-echo "  - Git scope:       $TASKS_GIT_SCOPE" >&2
-```
-
-**Report success:**
-```
-Migration complete. optimus-tasks.md is now at ${TASKS_FILE}.
-Remember to push both repos (project + tasks) when you're ready.
-```
-
-**Interrupted migration recovery (on skill startup):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -f "${MAIN_WORKTREE}/.optimus/.migration-in-progress" ]; then
-  INTERRUPTED_FILE=$(cat "${MAIN_WORKTREE}/.optimus/.migration-in-progress" 2>/dev/null)
-  echo "WARNING: Previous migration was interrupted. Expected target: $INTERRUPTED_FILE" >&2
-  # AskUser: Retry migration / Clear marker / Abort
-fi
-```
-
-**If user chose "Skip this time":** Emit a warning and proceed using the legacy location
-for this invocation only. The skill MUST use `$LEGACY_FILE` as `$TASKS_FILE` for the
-remainder of this execution.
-
-**If user chose "Abort":** **STOP** the current command.
-
-Skills reference this as: "Check legacy tasks.md migration — see AGENTS.md Protocol: Migrate tasks.md to tasksDir."
 
 
 ### Protocol: Rename tasks.md to optimus-tasks.md
@@ -1429,8 +1187,8 @@ Detects and renames projects whose Optimus tracking file is at `<tasksDir>/tasks
 (the prior default name) to `<tasksDir>/optimus-tasks.md`. The format marker
 (`<!-- optimus:tasks-v1 -->`) is unchanged — this protocol only renames the file on disk.
 
-**Detection (run at the start of every skill that reads/writes the tasks tracking file,
-AFTER Protocol: Migrate tasks.md to tasksDir):**
+**Detection (run at the start of every skill that reads/writes the tasks tracking file
+to detect and offer rename of `<tasksDir>/tasks.md` to `<tasksDir>/optimus-tasks.md`):**
 
 ```bash
 # Requires Protocol: Resolve Tasks Git Scope to have been executed first


### PR DESCRIPTION
> **1 of 3 PRs** for issue #20 — removes the M1 migration protocol. M2 (Rename) and M3 (Revisando PR) follow in separate PRs.

## Summary

Deletes the legacy `Protocol: Migrate tasks.md to tasksDir` (M1) and all its consumers across the codebase. The protocol relocated `.optimus/tasks.md` (legacy gitignored location) to `<tasksDir>/optimus-tasks.md`. All personal projects have already completed the migration; the protocol is now dead code in the hot startup path of every tasks-aware skill.

## Verification (issue #20 step 1)

Before this PR, owner manually verified:
- Pre-PR find scan revealed legacy `.optimus/tasks.md` in 2 active projects (advoga-solo, plugin-br-payments). 
- Owner manually migrated both projects (commands provided in pre-PR conversation).
- Post-migration find scan returned zero legacy state.
- Owner confirmed: no remaining projects use the legacy path.

## What's removed

- **AGENTS.md (-238 lines)**: full `Protocol: Migrate tasks.md to tasksDir` section + all external references (Initialize .optimus Directory NOTE, Resolve Tasks Git Scope passing mention, Rename protocol's "AFTER Migrate" dependency note).
- **12 SKILL.md body invocations**: `Migration check: Execute AGENTS.md Protocol: Migrate...` lines from import, tasks, plan, build, review, done, resume, report, quick-report, batch, resolve, pr-check. Rename invocations preserved.
- **scripts/inline-protocols.py**: `MIGRATE_PROTOCOL_KEY` constant, foundational entry, Migrate↔Rename pairing logic, Migrate side of `needs_format` injection.
- **Tests**: 2 M1-specific integration tests, 2 M1-specific pairing tests, M1 presence test, M1 trigger in worktree-resolver test.
- **SECURITY.md**: S3 attack scenario rewritten to focus on Rename only (M2 still has symlink protection).

## What's preserved

- **Protocol: Rename tasks.md to optimus-tasks.md (M2)** — handles the separate `<tasksDir>/tasks.md` → `<tasksDir>/optimus-tasks.md` rename. Will be removed in a follow-up PR after M1 stabilizes.
- **Scope detection / security tests** in `TestMigrationAndScopeIntegration` — independent of M1, kept as regression coverage for `Protocol: Resolve Tasks Git Scope`.
- **Worktree-isolation fix** (`Protocol: Resolve Main Worktree Path`) — orthogonal to M1.

## Stats

- 20 files changed (+97 / -3346)
- Tests: 229 → **225 passing** (4 M1-specific tests removed; rest unchanged)
- Lint: clean (ruff + py_compile + shellcheck)
- `python3 scripts/inline-protocols.py`: 0 unmatched references across 15 skills

## Risk

- **Reversibility**: trivial via `git revert` if a hidden legacy project surfaces.
- **External users**: none.
- **In-flight migrations**: none on owner's machine (verified).

## Test plan

- [x] `make test` — 225 passing
- [x] `make lint` — clean
- [x] `python3 scripts/inline-protocols.py` — 0 unmatched
- [x] `grep -rE "Protocol: Migrate tasks.md |MIGRATE_PROTOCOL_KEY|migration-in-progress" --include="*.md" --include="*.py"` — 1 result (intentional historical comment in test docstring), no other residuals
- [ ] Manual smoke test: run any optimus skill on a fresh project — startup is faster (no Migrate check), behavior unchanged

## Follow-ups

- **PR 2/3**: remove M2 (`Protocol: Rename tasks.md to optimus-tasks.md`)
- **PR 3/3**: remove M3 (`Revisando PR` jq migration) — closes #16

Closes part of #20.