### PR TITLE
chore(release)!: bump plugin manifests to 2.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "optimus-import",
       "source": "./import",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Import Ring pre-dev artifacts into optimus format. Creates optimus-tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -20,7 +20,7 @@
     {
       "name": "optimus-report",
       "source": "./report",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Task status dashboard. Shows progress, active/blocked/ready tasks, dependency graph, and parallelization opportunities. Read-only.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -29,7 +29,7 @@
     {
       "name": "optimus-tasks",
       "source": "./tasks",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Administrative: Create, edit, remove, reorder, cancel, and reopen tasks. Manage versions and move tasks between versions. Runs on any branch.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -38,7 +38,7 @@
     {
       "name": "optimus-plan",
       "source": "./plan",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Stage 1: Validates task specifications against project docs before implementation. Catches gaps, contradictions, and test coverage holes. Creates workspace (branch/worktree).",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -47,7 +47,7 @@
     {
       "name": "optimus-build",
       "source": "./build",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Stage 2: End-to-end task implementation with verification gates, code review, and commit approval.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -56,7 +56,7 @@
     {
       "name": "optimus-review",
       "source": "./review",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Stage 3: Validates completed task implementation against spec, coding standards, and best practices using parallel specialist agents.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -65,7 +65,7 @@
     {
       "name": "optimus-pr-check",
       "source": "./pr-check",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Standalone PR review orchestrator. Collects PR metadata and existing comments (Codacy, DeepSource, CodeRabbit, human), dispatches agents, applies fixes, resolves threads. Does not change task status.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -74,7 +74,7 @@
     {
       "name": "optimus-done",
       "source": "./done",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Stage 4: Requires PR in final state (merged or closed) before marking task done. Cleans up worktree and branch interactively.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -83,7 +83,7 @@
     {
       "name": "optimus-batch",
       "source": "./batch",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Pipeline orchestrator: chains stages 1-4 for one or more tasks with user checkpoints between stages.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -92,7 +92,7 @@
     {
       "name": "optimus-resolve",
       "source": "./resolve",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Administrative: Resolves merge conflicts in optimus-tasks.md caused by parallel task execution across feature branches.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -101,7 +101,7 @@
     {
       "name": "optimus-deep-doc-review",
       "source": "./deep-doc-review",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Deep review of project documentation. Finds errors, inconsistencies, gaps, and improvements with interactive one-by-one resolution.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -110,7 +110,7 @@
     {
       "name": "optimus-deep-review",
       "source": "./deep-review",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Parallel code review with consolidation, deduplication, and interactive finding-by-finding resolution. Auto-discovers installed Ring review droids. Flexible scope: entire project, git diff, or specific directory.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -119,7 +119,7 @@
     {
       "name": "optimus-coderabbit-review",
       "source": "./coderabbit-review",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "CodeRabbit-driven code review with TDD fix cycle, secondary validation via review agents, and interactive finding resolution. Requires CodeRabbit CLI.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -128,7 +128,7 @@
     {
       "name": "optimus-help",
       "source": "./help",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Lists all available Optimus skills with descriptions, usage commands, and when to use each one.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -137,7 +137,7 @@
     {
       "name": "optimus-sync",
       "source": "./sync",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Sync all Optimus plugins — install new, update existing, remove orphaned. Recommended after new releases.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -146,7 +146,7 @@
     {
       "name": "optimus-quick-report",
       "source": "./quick-report",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Compact daily status dashboard. Shows version progress, active tasks with current status, ready-to-start, and blocked tasks. Read-only.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",
@@ -155,7 +155,7 @@
     {
       "name": "optimus-resume",
       "source": "./resume",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "description": "Administrative: Resume a task after closing the terminal. Locates/recreates the worktree for a given T-XXX, reports current status, and offers to invoke the next stage. Read-only on state.json except for a user-confirmed Reset-to-Pendente recovery.",
       "homepage": "https://github.com/alexgarzao/optimus",
       "repository": "https://github.com/alexgarzao/optimus",

--- a/batch/.factory-plugin/plugin.json
+++ b/batch/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "batch",
   "description": "Pipeline orchestrator: chains stages 1-4 for one or more tasks with user checkpoints between stages.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/build/.factory-plugin/plugin.json
+++ b/build/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "build",
   "description": "Stage 2: End-to-end task implementation with verification gates, code review, and commit approval.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/coderabbit-review/.factory-plugin/plugin.json
+++ b/coderabbit-review/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "coderabbit-review",
   "description": "CodeRabbit-driven code review with TDD fix cycle, secondary validation via review agents, and interactive finding resolution. Requires CodeRabbit CLI.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/deep-doc-review/.factory-plugin/plugin.json
+++ b/deep-doc-review/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-doc-review",
   "description": "Deep review of project documentation. Finds errors, inconsistencies, gaps, and improvements with interactive one-by-one resolution.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/deep-review/.factory-plugin/plugin.json
+++ b/deep-review/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "deep-review",
   "description": "Parallel code review with consolidation, deduplication, and interactive finding-by-finding resolution. Auto-discovers installed Ring review droids. Flexible scope: entire project, git diff, or specific directory.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/done/.factory-plugin/plugin.json
+++ b/done/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "done",
   "description": "Stage 4: Requires PR in final state (merged or closed) before marking task done. Cleans up worktree and branch interactively.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/help/.factory-plugin/plugin.json
+++ b/help/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "help",
   "description": "Lists all available Optimus skills with descriptions, usage commands, and when to use each one.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/import/.factory-plugin/plugin.json
+++ b/import/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "import",
   "description": "Import Ring pre-dev artifacts into optimus format. Creates optimus-tasks.md with TaskSpec column. Re-runnable — only imports what's new.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/plan/.factory-plugin/plugin.json
+++ b/plan/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan",
   "description": "Stage 1: Validates task specifications against project docs before implementation. Catches gaps, contradictions, and test coverage holes. Creates workspace (branch/worktree).",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/pr-check/.factory-plugin/plugin.json
+++ b/pr-check/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-check",
   "description": "Standalone PR review orchestrator. Collects PR metadata and existing comments (Codacy, DeepSource, CodeRabbit, human), dispatches agents, applies fixes, resolves threads. Does not change task status.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/quick-report/.factory-plugin/plugin.json
+++ b/quick-report/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "quick-report",
   "description": "Compact daily status dashboard. Shows version progress, active tasks with current status, ready-to-start, and blocked tasks. Read-only.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/report/.factory-plugin/plugin.json
+++ b/report/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "report",
   "description": "Task status dashboard. Shows progress, active/blocked/ready tasks, dependency graph, and parallelization opportunities. Read-only.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/resolve/.factory-plugin/plugin.json
+++ b/resolve/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "resolve",
   "description": "Administrative: Resolves merge conflicts in optimus-tasks.md caused by parallel task execution across feature branches.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/resume/.factory-plugin/plugin.json
+++ b/resume/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "resume",
   "description": "Administrative: Resume a task after closing the terminal. Locates/recreates the worktree for a given T-XXX, reports current status, and offers to invoke the next stage. Read-only on state.json except for a user-confirmed Reset-to-Pendente recovery.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/review/.factory-plugin/plugin.json
+++ b/review/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "review",
   "description": "Stage 3: Validates completed task implementation against spec, coding standards, and best practices using parallel specialist agents.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/sync/.factory-plugin/plugin.json
+++ b/sync/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sync",
   "description": "Sync all Optimus plugins — install new, update existing, remove orphaned. Recommended after new releases.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }

--- a/tasks/.factory-plugin/plugin.json
+++ b/tasks/.factory-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tasks",
   "description": "Administrative: Create, edit, remove, reorder, cancel, and reopen tasks. Manage versions and move tasks between versions. Runs on any branch.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Alex Garzao"
   }


### PR DESCRIPTION
## Summary

- Bumps every plugin manifest from `1.0.0` to `2.0.0` so client plugin caches refetch the post-rename SKILL.md content.
- 18 files changed: `.claude-plugin/marketplace.json` (17 entries) + 17 per-plugin `*/.factory-plugin/plugin.json`.
- Treated as a SemVer-major bump because commit `82f3f10` (`feat(tasks)!: rename tasks.md to optimus-tasks.md`, #11) was a breaking change that never made it past the `1.0.0` cache key on Claude Code and Factory droid.

## Why

Real-world report: a session in `/Users/alexgarzao/lerian/projects/plugin-br-payments` (which has both Ring's `tasks.md` Gate-7 output AND Optimus's `optimus-tasks.md` in the same `tasksDir`) hit the wrong code path:

> "Found it — there's a separate optimus-tasks.md file in the same directory. The tasksDir config points at the directory, but optimus expects tasks.md exactly."

Investigation confirmed source code on `main` is correct (rename + Rename protocol + discovery scan all in place). Root cause was the cached install at `~/.claude/plugins/cache/optimus/optimus-import/1.0.0/skills/optimus-import/SKILL.md`: stale, pre-rename, no `Rename tasks.md to optimus-tasks.md` protocol, no `OLD_TASKS_FILE` references. Because the manifest version stayed at `1.0.0`, the plugin manager treated `1.0.0` as already installed and never refetched.

## Notes

- `.factory-plugin/marketplace.json` plugin entries have no `version` field (only `name`, `description`, `source`). Did NOT add one — that would be a schema change unrelated to a version bump. Factory droid cache-busting relies on each plugin's own `*/.factory-plugin/plugin.json` `version`, which is bumped here.
- PR #24 (M1 migrate-protocol removal) left no inlined `SKILL.md` remnants — `grep` was empty, no regeneration needed.
- 17 plugins (not 18 — original spec estimate was off by 1).

## Test plan

- [ ] `grep -r '"version": "1.0.0"' .claude-plugin .factory-plugin */.factory-plugin` is empty.
- [ ] Both marketplaces parse as JSON; all 17 `plugin.json` parse as JSON.
- [ ] After merge + `claude plugin marketplace update optimus` (or `/optimus-sync`), cache shows `~/.claude/plugins/cache/optimus/optimus-import/2.0.0/skills/optimus-import/SKILL.md` with `optimus-tasks.md` content and the `Rename tasks.md to optimus-tasks.md` protocol present.
- [ ] In `plugin-br-payments` (which has both `tasks.md` from Ring and `optimus-tasks.md` from Optimus), invoking `/optimus-import` resolves directly to `<tasksDir>/optimus-tasks.md` instead of the legacy `tasks.md` path.