### PR TITLE
chore(migrations): remove M3 (Revisando PR migration) — closes #16, #20

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2101,12 +2101,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -734,12 +734,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -1868,12 +1868,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -1013,12 +1013,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -697,12 +697,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -2127,12 +2127,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -712,12 +712,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -1198,12 +1198,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -76,11 +76,10 @@ which requires an explicit `AskUser` confirmation before running `jq 'del(.[$id]
 is clearly disclosed to the user.
 
 **Override vs inlined protocol:** The inlined Protocol: State Management (auto-generated
-below the shared-protocols block at the end of this file) contains destructive fallbacks —
-`rm -f "$STATE_FILE"` on corruption and a one-time `Revisando PR → Validando Impl`
-migration. **Resume explicitly DOES NOT apply those fallbacks**: on corruption it STOPs
-with guidance (Step 2.2a), and it NEVER runs the migration. Treat the inlined block as
-foundational context only; the rules in this body override it.
+below the shared-protocols block at the end of this file) contains a destructive fallback
+— `rm -f "$STATE_FILE"` on corruption. **Resume explicitly DOES NOT apply that fallback**:
+on corruption it STOPs with guidance (Step 2.2a). Treat the inlined block as foundational
+context only; the rules in this body override it.
 
 ---
 

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -2531,12 +2531,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -420,16 +420,21 @@ class TestPipelineFourStages:
         )
 
     def test_valid_status_values_in_agents_md(self):
-        """AGENTS.md must define exactly 6 statuses; Revisando PR only in migration code."""
+        """AGENTS.md must define the valid statuses and must NOT reference
+        the legacy `Revisando PR` status anywhere.
+
+        The Revisando PR → Validando Impl migration was removed in issue #16
+        (closed by PR #20 step 3). Any reappearance of `Revisando PR` is a
+        regression.
+        """
         content = AGENTS_MD.read_text()
         for status in VALID_STATUSES:
             assert status in content, f"AGENTS.md missing status '{status}'"
         for i, line in enumerate(content.splitlines(), 1):
-            if "Revisando PR" in line:
-                assert "migration" in line.lower() or "migrat" in line.lower() \
-                    or "jq" in line or "select(" in line or "echo" in line, (
-                    f"AGENTS.md:{i}: 'Revisando PR' outside migration code: {line.strip()}"
-                )
+            assert "Revisando PR" not in line, (
+                f"AGENTS.md:{i}: 'Revisando PR' is a removed legacy status "
+                "and must not reappear (issue #16): {line.strip()}"
+            )
 
 
 # --- Plugin completeness: marketplace matches directory structure ---

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1368,12 +1368,6 @@ if [ -f "$STATE_FILE" ]; then
     # Fall through to missing-file handling below
   fi
 fi
-# One-time migration: Revisando PR → Validando Impl (status removed)
-if [ -f "$STATE_FILE" ] && jq -e 'to_entries[] | select(.value.status == "Revisando PR")' "$STATE_FILE" >/dev/null 2>&1; then
-  jq 'with_entries(if .value.status == "Revisando PR" then .value.status = "Validando Impl" else . end)' "$STATE_FILE" > "${STATE_FILE}.tmp" \
-    && mv "${STATE_FILE}.tmp" "$STATE_FILE"
-  echo "NOTE: Migrated tasks from 'Revisando PR' to 'Validando Impl' (status removed in this version)."
-fi
 if [ -f "$STATE_FILE" ]; then
   TASK_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE")
   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "$STATE_FILE")


### PR DESCRIPTION
> **3 of 3 PRs** for issue #20 — final cleanup. Closes #16.

## Summary

Removes the one-time `Revisando PR → Validando Impl` jq migration from `Protocol: Session State` in AGENTS.md. The legacy `Revisando PR` status was eliminated when pr-check became a standalone tool (commit `23dca72`). The migration helper rewrote any lingering state.json entries on first read; with all personal projects having run at least one stage agent since then, no project still carries the legacy status.

## What's removed

- **AGENTS.md (-6 lines)**: jq migration block in Protocol: Session State
  (the `if ... select(.value.status == "Revisando PR") ... mv ... echo NOTE`
  block at line ~2104)
- **5 SKILL.md inlined copies**: auto-cleaned by re-running
  `python3 scripts/inline-protocols.py` after the AGENTS.md edit
- **resume/SKILL.md prose**: 1 paragraph that explicitly described the
  migration as part of the inlined-vs-overridden discussion

## What's updated

- `test_valid_status_values_in_agents_md` (test_skill_consistency.py:422):
  tightened from "allow Revisando PR only inside migration code" to
  "Revisando PR must NOT appear anywhere in AGENTS.md". Symmetric to the
  M1/M2 negation regression guards.

## Stats

- 12 files changed (+15 / -71)
- Tests: **226 passing** (count unchanged — existing test was tightened, not added/removed)
- Lint: clean
- Inline propagation: 0 unmatched references across 15 skills

## Verification

```bash
grep -rnE "Revisando PR" AGENTS.md */skills/
```
Result: zero matches. The status name is fully purged from the live codebase.

## Total impact of issue #20 (all 3 PRs)

| PR | Migration | Net deletions |
|---|---|---|
| #24 | M1 (`.optimus/tasks.md → tasksDir`) | -3,346 lines |
| #27 | M2 (`tasks.md → optimus-tasks.md`) | -2,689 lines |
| **#28** (this) | M3 (`Revisando PR`) | -56 lines |
| **Total** | | **-6,091 lines** |

Optimus's hot startup path is now lean: every stage skill runs
`Resolve Tasks Git Scope → Validation HARD BLOCK → skill-specific logic`,
with no migration helpers polluting the flow.

## Test plan

- [x] `make test` — 226 passing
- [x] `make lint` — clean
- [x] `python3 scripts/inline-protocols.py` — 0 unmatched
- [x] `grep -rnE "Revisando PR"` — zero matches across AGENTS.md and all SKILL.md

Closes #16.
Closes #20.