### PR TITLE
test: enforce Claude Code ↔ Droid plugin parity via consistency tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,28 @@ Both schemas list the same set of plugins, but with different name conventions
 
 ## Plugin Lifecycle
 
+### Dual-platform parity (Claude Code ↔ Droid) — ENFORCED
+
+Every Optimus plugin MUST ship surfaces for both platforms. This is enforced
+by the `TestDualPlatformParity` class in `scripts/test_skill_consistency.py`,
+which asserts three invariants:
+
+1. **Marketplace parity** — every plugin in `.claude-plugin/marketplace.json`
+   must also be in `.factory-plugin/marketplace.json` (Claude uses
+   `optimus-<name>`, Droid uses bare `<name>`; the test normalizes the prefix).
+2. **Surface parity** — every plugin must ship both `<plugin>/skills/optimus-<plugin>/SKILL.md`
+   (Claude Code) and `<plugin>/.factory-plugin/plugin.json` (Droid).
+3. **Command alias integrity** — every `<plugin>/commands/<alias>.md` must
+   correspond to a real plugin in the marketplace AND its body must redirect
+   to `/optimus-<plugin>`. (Aliases are Claude Code only — Droid does not
+   support slash-command aliases.)
+
+A plugin that only ships one platform's surface will fail tests and CI. Without
+these guards, a contributor could add a plugin to one marketplace and forget
+the other; the sync script reads ONE marketplace and applies it to both
+platforms, so the missing-side plugin would silently disappear from the
+discovered set on `/optimus-sync`.
+
 ### Adding a new plugin
 1. Add directory to repo (e.g., `myplugin/skills/optimus-myplugin/SKILL.md`)
 2. Add entry to `.factory-plugin/marketplace.json` (bare name: `myplugin`)

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -1699,3 +1699,123 @@ class TestInlineProtocolsFoundational:
             "idempotency check (skip reply if it already exists) matches this "
             "string verbatim to handle re-runs after a crash."
         )
+
+
+class TestDualPlatformParity:
+    """Optimus ships to BOTH Claude Code and Droid (Factory). Every plugin must
+    have surfaces on both sides. These tests catch divergence at commit time —
+    without them, a contributor can add a plugin to one platform's marketplace,
+    forget the other, and the gap ships silently (the sync script reads ONE
+    marketplace and applies the same list to both platforms, so a missing
+    plugin on the other side just disappears from the discovered set).
+
+    See AGENTS.md "Dual-platform parity (Claude Code ↔ Droid)" for the
+    contributor workflow these tests enforce.
+    """
+
+    def test_marketplaces_have_identical_plugin_sets(self):
+        """Both marketplace.json files must list the SAME set of plugins.
+        Claude Code uses ``optimus-<name>`` while Droid uses bare ``<name>``;
+        the test normalizes the prefix before comparing.
+        """
+        claude_path = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+        factory_path = REPO_ROOT / ".factory-plugin" / "marketplace.json"
+        claude_data = json.loads(claude_path.read_text())
+        factory_data = json.loads(factory_path.read_text())
+
+        claude_names = {
+            p["name"].removeprefix("optimus-")
+            for p in claude_data["plugins"]
+        }
+        factory_names = {p["name"] for p in factory_data["plugins"]}
+
+        only_in_claude = sorted(claude_names - factory_names)
+        only_in_factory = sorted(factory_names - claude_names)
+
+        assert not only_in_claude and not only_in_factory, (
+            f"Marketplace divergence between .claude-plugin and .factory-plugin: "
+            f"only in .claude-plugin: {only_in_claude}; only in .factory-plugin: "
+            f"{only_in_factory}. Both marketplaces MUST list the same plugins. "
+            f"To add a plugin: edit BOTH .claude-plugin/marketplace.json AND "
+            f".factory-plugin/marketplace.json (Claude uses optimus-<name>, "
+            f"Droid uses bare <name>)."
+        )
+
+    def test_every_plugin_has_both_platform_surfaces(self):
+        """Every plugin in the marketplace must ship BOTH platform surfaces:
+        a SKILL.md (Claude Code, also used by Droid) and a .factory-plugin/
+        plugin.json (Droid). Missing one means the plugin will fail to install
+        on that platform.
+        """
+        factory_path = REPO_ROOT / ".factory-plugin" / "marketplace.json"
+        factory_data = json.loads(factory_path.read_text())
+
+        missing_claude = []
+        missing_droid = []
+        for plugin in factory_data["plugins"]:
+            name = plugin["name"]
+            plugin_dir = REPO_ROOT / name
+            skill_md = plugin_dir / "skills" / f"optimus-{name}" / "SKILL.md"
+            droid_config = plugin_dir / ".factory-plugin" / "plugin.json"
+            if not skill_md.exists():
+                missing_claude.append(
+                    f"{name} (expected {skill_md.relative_to(REPO_ROOT)})"
+                )
+            if not droid_config.exists():
+                missing_droid.append(
+                    f"{name} (expected {droid_config.relative_to(REPO_ROOT)})"
+                )
+
+        assert not missing_claude, (
+            f"Plugins missing Claude Code surface "
+            f"(skills/optimus-<name>/SKILL.md): {missing_claude}. The sync "
+            f"would install these on Droid only — Claude Code users would "
+            f"not see them."
+        )
+        assert not missing_droid, (
+            f"Plugins missing Droid surface (.factory-plugin/plugin.json): "
+            f"{missing_droid}. The sync would install these on Claude Code "
+            f"only — Droid users would not see them."
+        )
+
+    def test_command_aliases_correspond_to_real_plugins(self):
+        """Every ``<plugin>/commands/<alias>.md`` slash-command alias file
+        must be inside a directory that corresponds to a real plugin listed
+        in the marketplace, and the alias body must redirect to the matching
+        ``/optimus-<plugin>`` slash command. Catches orphan command files
+        and aliases that point to non-existent skills.
+
+        Note: command aliases are Claude Code only — Droid does not support
+        slash-command aliases (platform limitation, documented in AGENTS.md).
+        """
+        factory_path = REPO_ROOT / ".factory-plugin" / "marketplace.json"
+        factory_data = json.loads(factory_path.read_text())
+        plugin_names = {p["name"] for p in factory_data["plugins"]}
+
+        orphans = []
+        broken_redirects = []
+        for cmd_file in sorted(REPO_ROOT.glob("*/commands/*.md")):
+            plugin_name = cmd_file.parent.parent.name
+            if plugin_name not in plugin_names:
+                orphans.append(
+                    f"{cmd_file.relative_to(REPO_ROOT)} (plugin '{plugin_name}' "
+                    f"not in marketplace)"
+                )
+                continue
+            body = cmd_file.read_text()
+            expected_redirect = f"/optimus-{plugin_name}"
+            if expected_redirect not in body:
+                broken_redirects.append(
+                    f"{cmd_file.relative_to(REPO_ROOT)} does not redirect to "
+                    f"{expected_redirect} (alias should forward to the main "
+                    f"slash command)"
+                )
+
+        assert not orphans, (
+            "Orphan command alias files (alias exists but plugin is not in "
+            "the marketplace):\n  - " + "\n  - ".join(orphans)
+        )
+        assert not broken_redirects, (
+            "Command alias files that don't redirect to their plugin's main "
+            "slash command:\n  - " + "\n  - ".join(broken_redirects)
+        )


### PR DESCRIPTION
## Summary

Optimus ships every plugin to both Claude Code (\`.claude-plugin\`) and Droid (\`.factory-plugin\`). Until now, parity was enforced only by convention — \`scripts/test_skill_consistency.py:14\` read \`.factory-plugin/marketplace.json\` and ignored \`.claude-plugin\` entirely. No test verified per-plugin surface files exist on both sides. No test checked alias integrity.

This PR adds 3 tests in a new \`TestDualPlatformParity\` class plus an AGENTS.md note documenting the invariants. **No production behavior changes.**

## Why now

The user asked: \"varios novos agentes e plugins foram feitos no optimus, e funcionam no claude. verifique se também serão corretamente instalados no droid e serão funcionais.\"

Audit confirmed the **current state is healthy** (all 17 plugins listed in both marketplaces, all surfaces present, last \`/optimus-sync\` succeeded with 0 failures). But future divergence is invisible to CI: a contributor adds a plugin to one marketplace and forgets the other → tests pass → \`/optimus-sync\` silently drops the missing-side plugin (the script reads ONE marketplace and applies the same list to both platforms).

## What changed (2 files)

| File | Δ | Purpose |
|---|---|---|
| \`scripts/test_skill_consistency.py\` | +131 / -0 | New \`TestDualPlatformParity\` class with 3 tests |
| \`AGENTS.md\` | +22 / -0 | New \"Dual-platform parity — ENFORCED\" subsection at the top of \"Plugin Lifecycle\" pointing contributors at the test class |

### The three invariants

1. **Marketplace parity** — both \`marketplace.json\` files list the same plugins (normalizing the \`optimus-\` prefix on the Claude side).
2. **Surface parity** — every plugin ships both \`<plugin>/skills/optimus-<plugin>/SKILL.md\` (Claude) and \`<plugin>/.factory-plugin/plugin.json\` (Droid).
3. **Alias integrity** — every \`<plugin>/commands/<alias>.md\` corresponds to a real plugin AND its body redirects to \`/optimus-<plugin>\`. (Aliases are Claude Code only by platform design.)

## Mutation testing (verified)

| Mutation | Test that should fail | Actual result |
|---|---|---|
| Remove \`optimus-help\` from \`.claude-plugin/marketplace.json\` | \`test_marketplaces_have_identical_plugin_sets\` | ✅ Fails: \"only in .factory-plugin: ['help']\" |
| Rename \`help/skills/optimus-help/SKILL.md\` to .bak | \`test_every_plugin_has_both_platform_surfaces\` | ✅ Fails: \"Plugins missing Claude Code surface: ['help (expected ...)']\" |
| Tamper \`plan/commands/sp.md\` redirect to \`/optimus-WRONG\` | \`test_command_aliases_correspond_to_real_plugins\` | ✅ Fails: \"does not redirect to /optimus-plan\" |

All mutations reverted; clean run shows **94 passed** (91 baseline + 3 new).

## Out of scope

- Refactoring \`sync/scripts/sync-user-plugins.sh\` to read both marketplaces at runtime. The new commit-time tests catch divergence upstream, which is cheaper and more reliable.
- Migrating Droid to support slash-command aliases (platform limitation, not in our control).
- Adding tests for Ring droid availability (user-environment concern, not repo invariant).

## Test plan

- [x] \`pytest scripts/test_skill_consistency.py\` → 94/94 pass (91 baseline + 3 new)
- [x] Mutation tests for all 3 assertions (see table above)
- [x] \`python3 scripts/inline-protocols.py\` → 0 unmatched (AGENTS.md note doesn't introduce \`Protocol: …\` references)
- [ ] **Empirical (post-merge):** run \`/optimus-sync\` once and confirm parity is preserved (expected: 0 added, 0 removed, all updated; both platforms in sync)