### PR TITLE
feat(workspace): defense-in-depth validation against default-branch mutations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1519,7 +1519,53 @@ fi
      ```
      Then change working directory to the new worktree.
 
+**Stage-specific overrides:**
+
+- **Stage 4 (`/optimus-done`)** applies a STRICTER form of resolution: it does NOT
+  present a multi-task chooser and does NOT auto-navigate across tasks. If invoked
+  without an explicit `T-XXX` argument, `done` closes ONLY the task corresponding to
+  the current feature branch/worktree. If the user is on the default branch with no
+  task argument, `done` STOPS with an error rather than choosing a task. See
+  `done/skills/optimus-done/SKILL.md` Step 1.0.2 for the full strict-mode rule.
+
+**Defense-in-depth — refusal on default branch:** even after this protocol runs,
+mutating stages MUST reject execution if the current branch is still the default
+branch. See **Protocol: Default Branch Refusal** below.
+
 Skills reference this as: "Resolve workspace (HARD BLOCK) — see AGENTS.md Protocol: Workspace Auto-Navigation."
+
+### Protocol: Default Branch Refusal (HARD BLOCK)
+
+**Referenced by:** build, review, done
+
+**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
+in edge cases (user cancels the AskUser prompt, silent failure, future skill that
+forgets to invoke the protocol). A second, unconditional refusal at the start of any
+mutating stage prevents accidental commits, worktree removals, or status writes on
+the default branch.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$DEFAULT_BRANCH" ]; then
+  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+CURRENT=$(git branch --show-current 2>/dev/null)
+if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
+  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
+  exit 1
+fi
+```
+
+**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
+the skill performs any state.json write, git commit, git worktree mutation, or
+status transition.
+
+Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
 
 ### Protocol: Discover Review Droids
 

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -198,6 +198,14 @@ Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning
 
 Branch-task cross-validation is part of the workspace protocol above.
 
+### Step 1.4.1: Refuse Default Branch (HARD BLOCK)
+
+**HARD BLOCK:** Refuse to run on default branch — see AGENTS.md Protocol: Default Branch Refusal.
+
+Defense-in-depth: even if Workspace Auto-Navigation was bypassed (user cancelled the
+prompt, silent failure, etc.), this guard prevents commits or state mutations on the
+default branch.
+
 ### Step 1.5: Validate PR Title (if PR exists)
 
 Validate PR title — see AGENTS.md Protocol: PR Title Validation.
@@ -1165,6 +1173,40 @@ Flag business-logic functions with 0% as HIGH, infrastructure/generated code wit
 Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
 
 
+### Protocol: Default Branch Refusal (HARD BLOCK)
+
+**Referenced by:** build, review, done
+
+**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
+in edge cases (user cancels the AskUser prompt, silent failure, future skill that
+forgets to invoke the protocol). A second, unconditional refusal at the start of any
+mutating stage prevents accidental commits, worktree removals, or status writes on
+the default branch.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$DEFAULT_BRANCH" ]; then
+  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+CURRENT=$(git branch --show-current 2>/dev/null)
+if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
+  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
+  exit 1
+fi
+```
+
+**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
+the skill performs any state.json write, git commit, git worktree mutation, or
+status transition.
+
+Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
+
+
 ### Protocol: Divergence Warning
 
 **Referenced by:** all stage agents (1-4)
@@ -2100,6 +2142,19 @@ fi
      git worktree add "$WORKTREE_DIR" "<branch-name>"
      ```
      Then change working directory to the new worktree.
+
+**Stage-specific overrides:**
+
+- **Stage 4 (`/optimus-done`)** applies a STRICTER form of resolution: it does NOT
+  present a multi-task chooser and does NOT auto-navigate across tasks. If invoked
+  without an explicit `T-XXX` argument, `done` closes ONLY the task corresponding to
+  the current feature branch/worktree. If the user is on the default branch with no
+  task argument, `done` STOPS with an error rather than choosing a task. See
+  `done/skills/optimus-done/SKILL.md` Step 1.0.2 for the full strict-mode rule.
+
+**Defense-in-depth — refusal on default branch:** even after this protocol runs,
+mutating stages MUST reject execution if the current branch is still the default
+branch. See **Protocol: Default Branch Refusal** below.
 
 Skills reference this as: "Resolve workspace (HARD BLOCK) — see AGENTS.md Protocol: Workspace Auto-Navigation."
 

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -80,6 +80,15 @@ feature branch/worktree. Never offer a list of multiple tasks to close.
      ```
 3. Do NOT scan all `Validando Impl` tasks and do NOT present a multi-task chooser.
 
+### Step 1.0.2.1: Refuse Default Branch (HARD BLOCK)
+
+Refuse to run on default branch — see AGENTS.md Protocol: Default Branch Refusal.
+
+Defense-in-depth: even though Step 1.0.2 already STOPs on the default branch when no
+task ID is given, this guard catches the explicit-task-ID path as well — closing a
+task while sitting on the default branch is never correct, regardless of how the
+skill was invoked.
+
 ### Step 1.0.3: Identify Task to Close
 
 **If the user specified a task ID** (e.g., "close T-012"):
@@ -838,6 +847,40 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: Default Branch Refusal (HARD BLOCK)
+
+**Referenced by:** build, review, done
+
+**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
+in edge cases (user cancels the AskUser prompt, silent failure, future skill that
+forgets to invoke the protocol). A second, unconditional refusal at the start of any
+mutating stage prevents accidental commits, worktree removals, or status writes on
+the default branch.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$DEFAULT_BRANCH" ]; then
+  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+CURRENT=$(git branch --show-current 2>/dev/null)
+if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
+  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
+  exit 1
+fi
+```
+
+**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
+the skill performs any state.json write, git commit, git worktree mutation, or
+status transition.
+
+Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
 
 
 ### Protocol: Divergence Warning

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -198,6 +198,40 @@ PR title validation follows AGENTS.md Protocol: PR Title Validation, with the ad
 
 **If validation passes:** no action needed, proceed.
 
+### Step 1.2.2: Cross-Check PR Branch Against Current Branch
+
+**Why:** When the user invokes `/optimus-pr-check <num>` with an explicit PR number,
+the PR may belong to a different branch than the one the user is currently on. The
+review still works (pr-check operates on the PR's diff, not the current worktree),
+but the user may have meant a different PR. A silent mismatch is a recipe for
+confusion — fixes get committed to the right branch (because Step 1.4 checks out
+the PR), but the user's mental model can be misaligned.
+
+This guard surfaces the mismatch BEFORE proceeding, but only when the PR was given
+explicitly. If pr-check inferred the PR from the current branch (Step 1.1), the
+branches always match by construction — skip this check.
+
+**Procedure:**
+
+1. If the user did NOT pass an explicit PR number/URL (Step 1.1 inferred it from the
+   current branch), SKIP this check.
+2. Otherwise, compare `headRefName` (from Step 1.2) with the current branch:
+   ```bash
+   CURRENT=$(git branch --show-current 2>/dev/null)
+   ```
+3. If `CURRENT` is non-empty and differs from `headRefName`, present an `AskUser`
+   warning:
+   ```
+   PR #<num> is for branch '<headRefName>' but you are on branch '<CURRENT>'.
+   Continue reviewing PR #<num>?
+   ```
+   Options:
+   - **Continue** — proceed with PR #<num> (Step 1.4 will check out the PR's branch)
+   - **Switch and continue** — explicitly checkout the PR's branch first, then proceed
+   - **Cancel** — stop the review
+
+**BLOCKING:** Do NOT proceed past this step until the user responds.
+
 ### Step 1.3: Collect ALL Existing PR Comments and Threads
 
 **IMPORTANT:** Static analysis tools post comments in TWO different ways:

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -90,6 +90,12 @@ Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 ### Step 1.0.2: Verify Workspace (HARD BLOCK)
 Resolve workspace — see AGENTS.md Protocol: Workspace Auto-Navigation.
 
+### Step 1.0.2.1: Refuse Default Branch (HARD BLOCK)
+Refuse to run on default branch — see AGENTS.md Protocol: Default Branch Refusal.
+
+Defense-in-depth: even if Workspace Auto-Navigation was bypassed, this guard prevents
+review state mutations (status writes, etc.) on the default branch.
+
 ### Step 1.0.3: Check optimus-tasks.md Divergence (warning)
 Check optimus-tasks.md divergence — see AGENTS.md Protocol: Divergence Warning.
 
@@ -1737,6 +1743,40 @@ Flag business-logic functions with 0% as HIGH, infrastructure/generated code wit
 Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
 
 
+### Protocol: Default Branch Refusal (HARD BLOCK)
+
+**Referenced by:** build, review, done
+
+**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
+in edge cases (user cancels the AskUser prompt, silent failure, future skill that
+forgets to invoke the protocol). A second, unconditional refusal at the start of any
+mutating stage prevents accidental commits, worktree removals, or status writes on
+the default branch.
+
+```bash
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$DEFAULT_BRANCH" ]; then
+  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
+    DEFAULT_BRANCH="main"
+  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
+    DEFAULT_BRANCH="master"
+  fi
+fi
+CURRENT=$(git branch --show-current 2>/dev/null)
+if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
+  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
+  exit 1
+fi
+```
+
+**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
+the skill performs any state.json write, git commit, git worktree mutation, or
+status transition.
+
+Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
+
+
 ### Protocol: Divergence Warning
 
 **Referenced by:** all stage agents (1-4)
@@ -2763,6 +2803,19 @@ fi
      git worktree add "$WORKTREE_DIR" "<branch-name>"
      ```
      Then change working directory to the new worktree.
+
+**Stage-specific overrides:**
+
+- **Stage 4 (`/optimus-done`)** applies a STRICTER form of resolution: it does NOT
+  present a multi-task chooser and does NOT auto-navigate across tasks. If invoked
+  without an explicit `T-XXX` argument, `done` closes ONLY the task corresponding to
+  the current feature branch/worktree. If the user is on the default branch with no
+  task argument, `done` STOPS with an error rather than choosing a task. See
+  `done/skills/optimus-done/SKILL.md` Step 1.0.2 for the full strict-mode rule.
+
+**Defense-in-depth — refusal on default branch:** even after this protocol runs,
+mutating stages MUST reject execution if the current branch is still the default
+branch. See **Protocol: Default Branch Refusal** below.
 
 Skills reference this as: "Resolve workspace (HARD BLOCK) — see AGENTS.md Protocol: Workspace Auto-Navigation."
 

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -1819,3 +1819,117 @@ class TestDualPlatformParity:
             "Command alias files that don't redirect to their plugin's main "
             "slash command:\n  - " + "\n  - ".join(broken_redirects)
         )
+
+
+class TestWorkspaceValidationHardening:
+    """Defense-in-depth checks for branch/worktree validation across stage skills.
+
+    Covers three independent guarantees layered on top of Workspace Auto-Navigation:
+
+    1. Mutating stages (build, review, done) reference Protocol: Default Branch
+       Refusal so a bypass of Workspace Auto-Navigation cannot silently mutate the
+       default branch.
+    2. pr-check cross-checks the PR's headRefName against the user's current branch
+       and surfaces a confirmation when the user passed an explicit PR number that
+       belongs to a different branch.
+    3. Protocol: Workspace Auto-Navigation documents the stage-specific override that
+       `done` applies (no multi-task chooser, no auto-navigation across tasks).
+    """
+
+    def test_default_branch_hard_block_in_stage_skills(self):
+        """build, review, done must reference Protocol: Default Branch Refusal.
+
+        Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
+        (user cancels AskUser, silent failure, future skill that forgets to invoke
+        the protocol). Each mutating stage MUST invoke Default Branch Refusal as a
+        second, unconditional guard before any state mutation.
+        """
+        missing = []
+        for skill in WORKSPACE_SKILLS:
+            content = _read_skill(skill)
+            if "Protocol: Default Branch Refusal" not in content:
+                missing.append(skill)
+        assert missing == [], (
+            "Stage skills missing Protocol: Default Branch Refusal reference "
+            "(defense-in-depth against commits/mutations on the default branch):\n"
+            + "\n".join(f"  - {v}" for v in missing)
+        )
+
+    def test_default_branch_refusal_protocol_defined_in_agents_md(self):
+        """AGENTS.md must define the Protocol: Default Branch Refusal sub-protocol
+        that the stage skills reference.
+        """
+        content = AGENTS_MD.read_text()
+        assert "### Protocol: Default Branch Refusal" in content, (
+            "AGENTS.md is missing the `### Protocol: Default Branch Refusal` "
+            "section that build/review/done reference."
+        )
+        # Body must contain the actual guard logic — keyword sanity check so a
+        # future edit that empties the section still trips the test.
+        section_start = content.index("### Protocol: Default Branch Refusal")
+        # Slice to next top-level `### Protocol` heading
+        next_heading = content.find("### Protocol:", section_start + 1)
+        section = content[section_start:next_heading] if next_heading != -1 else content[section_start:]
+        assert "DEFAULT_BRANCH" in section and "git branch --show-current" in section, (
+            "Protocol: Default Branch Refusal must contain the DEFAULT_BRANCH "
+            "resolution and current-branch comparison shell snippet."
+        )
+        assert "refusing to run" in section.lower(), (
+            "Protocol: Default Branch Refusal must include the refusal error "
+            "message ('refusing to run ... on default branch')."
+        )
+
+    def test_pr_check_validates_task_branch_consistency(self):
+        """pr-check must cross-check the PR's headRefName with the current branch
+        when the user passed an explicit PR number, and AskUser on mismatch.
+
+        Without this guard, `/optimus-pr-check 30` from branch `feat/t-007` silently
+        operates on PR #30 (which may belong to a different branch) — the user's
+        mental model becomes misaligned with what pr-check is actually reviewing.
+        """
+        content = _read_skill("pr-check")
+        # The cross-check step must exist as a discrete step (any sub-step number
+        # under Phase 1 is acceptable so we don't pin to 1.2.2 specifically).
+        assert "headRefName" in content and "git branch --show-current" in content, (
+            "pr-check must compare the PR's `headRefName` with the user's current "
+            "branch (`git branch --show-current`) and AskUser on mismatch. The "
+            "cross-check belongs to Phase 1 after Step 1.2 (Fetch PR Metadata)."
+        )
+        # The mismatch warning must be presented via AskUser (BLOCKING), not as a
+        # silent log line.
+        assert re.search(
+            r"PR #.*is for branch.*but you are on", content, re.DOTALL
+        ), (
+            "pr-check must surface the PR-vs-current-branch mismatch via an "
+            "AskUser prompt (warning text 'PR #<num> is for branch ... but you "
+            "are on ...')."
+        )
+
+    def test_workspace_auto_navigation_documents_done_override(self):
+        """Protocol: Workspace Auto-Navigation must document that `done` applies a
+        stricter form of resolution (no multi-task chooser, no auto-navigation
+        across tasks).
+
+        Without this note in the canonical protocol, contributors reading
+        AGENTS.md assume `done` follows the same logic as build/review and may
+        introduce drift. The note tells them where to look for the strict-mode
+        rule (done/SKILL.md Step 1.0.2).
+        """
+        content = AGENTS_MD.read_text()
+        protocol_start = content.index("### Protocol: Workspace Auto-Navigation")
+        next_heading = content.find("### Protocol:", protocol_start + 1)
+        section = content[protocol_start:next_heading] if next_heading != -1 else content[protocol_start:]
+
+        assert "Stage-specific overrides" in section, (
+            "Protocol: Workspace Auto-Navigation must include a 'Stage-specific "
+            "overrides' subsection documenting `done`'s stricter rule."
+        )
+        assert "/optimus-done" in section, (
+            "Stage-specific overrides must reference `/optimus-done` explicitly."
+        )
+        # Must point readers at the concrete location of the strict-mode rule so
+        # they don't have to grep blindly.
+        assert "Step 1.0.2" in section, (
+            "Stage-specific overrides must point at done/SKILL.md Step 1.0.2 for "
+            "the full strict-mode rule."
+        )


### PR DESCRIPTION
## Summary

Adds three layered safeguards on top of `Protocol: Workspace Auto-Navigation`,
addressing gaps where the existing protocol can be bypassed and where pr-check
silently operates on a PR that doesn't match the user's mental model.

### 1. Default Branch Refusal (HARD BLOCK) — new sub-protocol
- New `Protocol: Default Branch Refusal` in AGENTS.md.
- build/review/done invoke it immediately after Workspace Auto-Navigation,
  before any state.json write, git commit, or worktree mutation.
- Catches the edge cases the primary protocol cannot:
  - User cancels the AskUser auto-nav prompt
  - Silent failure inside Workspace Auto-Navigation
  - Future skill that forgets to invoke the primary protocol

### 2. pr-check task↔branch consistency check
- New Step 1.2.2 in pr-check.
- When the user passes an explicit PR number, compare PR's `headRefName`
  with the user's current branch.
- AskUser BLOCKING warning on mismatch (Continue / Switch and continue / Cancel).
- Skipped when pr-check inferred the PR from the current branch (mismatch
  impossible by construction).

### 3. Document done's strict-mode override
- `Protocol: Workspace Auto-Navigation` now documents that `done` applies a
  stricter form: no multi-task chooser, no auto-navigation across tasks.
- Points contributors at `done/skills/optimus-done/SKILL.md` Step 1.0.2 for
  the full strict-mode rule, preventing future drift.

## Tests

4 new regression tests in `scripts/test_skill_consistency.py`:

- `test_default_branch_hard_block_in_stage_skills` — build/review/done
  reference Protocol: Default Branch Refusal
- `test_default_branch_refusal_protocol_defined_in_agents_md` — protocol
  body contains DEFAULT_BRANCH resolution + refusal message
- `test_pr_check_validates_task_branch_consistency` — pr-check compares
  headRefName with current branch and shows the mismatch warning
- `test_workspace_auto_navigation_documents_done_override` — Stage-specific
  overrides subsection exists and points at done Step 1.0.2

## Test plan
- [x] `python3 scripts/inline-protocols.py` — propagates AGENTS.md edits
- [x] `make test` — 221 passed (was 217)
- [x] `make lint` — clean
- [ ] Smoke: `git checkout main && /optimus-build T-001` → should HARD BLOCK
- [ ] Smoke: explicit PR number from a different branch → should AskUser warning