### PR TITLE
fix(deep-review): worktree-isolation + sanitize + inliner integrity (F1+F2+F3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,8 @@ rationalize these away.
 
 ## Editing Rules
 
+- **Canonical protocol reference phrasing:** Skills MUST reference protocols using the exact form `see AGENTS.md Protocol: <Exact Heading>` (with optional verb prefix like `Execute`, `Verify`, etc.). Variants like `AGENTS.md "Common Patterns > X"` are tolerated only for Common Patterns. The inliner regex is anchored on these forms; deviations cause silent unmatched refs.
+
 ### SKILL.md Files
 - Preserve YAML frontmatter structure (---, name, description, trigger, skip_when, etc.)
 - Keep phase numbering sequential starting from 1 (Phase 1, Phase 2, ...)
@@ -1004,9 +1006,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1046,10 +1049,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -1062,9 +1067,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -1075,8 +1081,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3
@@ -1169,6 +1185,7 @@ times each stage ran on each task — useful for spotting spec churn and review 
    # Requires Protocol: Resolve Main Worktree Path to have run first
    # (or resolve inline; see that protocol).
    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
    STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
    if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
      echo "WARNING: stats.json is corrupted. Resetting counters."
@@ -1278,6 +1295,7 @@ with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
@@ -1339,12 +1357,13 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
@@ -1715,6 +1734,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -2191,6 +2211,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -2217,6 +2238,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -2249,6 +2271,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -2268,6 +2291,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test lint check-inline sync-plugins
 
 test:
-	python3 -m pytest scripts/test_inline_protocols.py scripts/test_sync_user_plugins.py scripts/test_skill_consistency.py scripts/test_quiet_run.py -v
+	python3 -m pytest scripts/ -v
 
 lint:
 	python3 -m py_compile scripts/inline-protocols.py

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -725,6 +725,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -751,6 +752,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -783,6 +785,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -802,6 +805,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -1224,6 +1224,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -1580,10 +1581,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -1596,9 +1599,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -1609,8 +1613,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3
@@ -1777,6 +1791,7 @@ with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
@@ -1838,12 +1853,13 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
@@ -1901,6 +1917,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -1927,6 +1944,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -1959,6 +1977,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -1978,6 +1997,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -870,9 +870,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1114,10 +1115,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -1130,9 +1133,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -1143,8 +1147,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -681,6 +681,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -707,6 +708,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -739,6 +741,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -758,6 +761,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/build.md
+++ b/commands/build.md
@@ -1162,6 +1162,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -1518,10 +1519,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -1534,9 +1537,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -1547,8 +1551,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3
@@ -1715,6 +1729,7 @@ with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
@@ -1776,12 +1791,13 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
@@ -1839,6 +1855,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -1865,6 +1882,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -1897,6 +1915,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -1916,6 +1935,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -813,9 +813,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1057,10 +1058,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -1073,9 +1076,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -1086,8 +1090,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -873,9 +873,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1037,10 +1038,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -1053,9 +1056,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -1066,8 +1070,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3

--- a/commands/done.md
+++ b/commands/done.md
@@ -332,10 +332,14 @@ the worktree being removed, `cd` to the main repository first:
 
 ### Step 4.2: Check for Task Branch
 
-Identify the task's branch:
+Identify the task's branch (resolve `MAIN_WORKTREE` first so `state.json` is
+read from the main worktree, not from a linked worktree's isolated copy):
 
 ```bash
-TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' .optimus/state.json 2>/dev/null)
+# Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="${MAIN_WORKTREE:-$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')}"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
 if [ -z "$TASK_BRANCH" ]; then
   TASK_BRANCH=$(git branch --list "*$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')*" 2>/dev/null | head -1 | tr -d ' *')
 fi

--- a/commands/done.md
+++ b/commands/done.md
@@ -721,55 +721,6 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
-
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
-
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
-
 ### Protocol: Active Version Guard
 
 **Referenced by:** all stage agents (1-4)
@@ -861,6 +812,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -987,6 +939,55 @@ If `tasks-hooks.sh` does not exist, hooks are silently skipped.
 Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+
+**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
+
+**Recipe:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
+  exit 1
+fi
+```
+
+The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
+
+**Path resolution pattern:**
+
+After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
+
+```bash
+# RIGHT (works from any worktree):
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
+         "${MAIN_WORKTREE}/.optimus/reports" \
+         "${MAIN_WORKTREE}/.optimus/logs"
+
+# WRONG (resolves against PWD, breaks in linked worktrees):
+STATE_FILE=".optimus/state.json"
+SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE=".optimus/stats.json"
+mkdir -p .optimus/sessions .optimus/reports .optimus/logs
+```
+
+**What does NOT need this protocol:**
+
+- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.gitignore` itself — versioned, propagated via git.
+
+**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: State Management
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
@@ -1008,6 +1009,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -1034,6 +1036,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -1066,6 +1069,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -1085,6 +1089,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/import.md
+++ b/commands/import.md
@@ -541,9 +541,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -644,6 +645,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -670,6 +672,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -702,6 +705,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -721,6 +725,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/import.md
+++ b/commands/import.md
@@ -287,13 +287,17 @@ step — skills resolve the default automatically:
 ```bash
 if [ "$TASKS_DIR" != "docs/pre-dev" ]; then
   # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-  if [ ! -f .optimus/config.json ]; then
-    echo '{}' > .optimus/config.json
+  # MAIN_WORKTREE was resolved in Step 1.3 (see line ~195); re-assert here so config.json
+  # writes always land in the main worktree, not in a linked worktree's isolated copy.
+  MAIN_WORKTREE="${MAIN_WORKTREE:-$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')}"
+  MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+  if [ ! -f "${MAIN_WORKTREE}/.optimus/config.json" ]; then
+    echo '{}' > "${MAIN_WORKTREE}/.optimus/config.json"
   fi
-  if jq --arg dir "$TASKS_DIR" '.tasksDir = $dir' .optimus/config.json > .optimus/config.json.tmp; then
-    mv .optimus/config.json.tmp .optimus/config.json
+  if jq --arg dir "$TASKS_DIR" '.tasksDir = $dir' "${MAIN_WORKTREE}/.optimus/config.json" > "${MAIN_WORKTREE}/.optimus/config.json.tmp"; then
+    mv "${MAIN_WORKTREE}/.optimus/config.json.tmp" "${MAIN_WORKTREE}/.optimus/config.json"
   else
-    rm -f .optimus/config.json.tmp
+    rm -f "${MAIN_WORKTREE}/.optimus/config.json.tmp"
     echo "ERROR: Failed to update config.json"
   fi
 fi

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1382,6 +1382,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -1456,6 +1457,7 @@ times each stage ran on each task — useful for spotting spec churn and review 
    # Requires Protocol: Resolve Main Worktree Path to have run first
    # (or resolve inline; see that protocol).
    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
    STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
    if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
      echo "WARNING: stats.json is corrupted. Resetting counters."
@@ -1889,6 +1891,7 @@ with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
@@ -1950,12 +1953,13 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
@@ -2056,6 +2060,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -2082,6 +2087,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -2114,6 +2120,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -2133,6 +2140,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -1335,8 +1335,8 @@ When the loop exits (any status), proceed to Phase 11 (integration tests).
 ## Phase 11: Integration Tests (before push)
 
 **Before pushing**, run integration tests. These are slow and expensive, so they
-run ONCE here — not during the fix/convergence cycle. Run quietly — see AGENTS.md
-Protocol: Quiet Command Execution:
+run ONCE here — not during the fix/convergence cycle. Run quietly —
+see AGENTS.md Protocol: Quiet Command Execution:
 
 ```bash
 _optimus_quiet_run "make-test-integration" make test-integration   # Optional target — SKIP if missing

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -2331,9 +2331,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -2514,10 +2515,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -2530,9 +2533,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -2543,8 +2547,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3

--- a/commands/quick-report.md
+++ b/commands/quick-report.md
@@ -665,6 +665,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -691,6 +692,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -723,6 +725,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -742,6 +745,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/report.md
+++ b/commands/report.md
@@ -929,9 +929,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1144,6 +1145,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -1170,6 +1172,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -1202,6 +1205,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -1221,6 +1225,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/review.md
+++ b/commands/review.md
@@ -196,10 +196,10 @@ This determines which specialist agents to dispatch in Phase 3.
 
 ### Step 2.1: Run Static Analysis (parallel)
 
-Run ALL applicable checks simultaneously via `_optimus_quiet_run` — see AGENTS.md
-Protocol: Quiet Command Execution. The helper redirects each command's output to
-`.optimus/logs/` and prints only a PASS/FAIL line (plus last 50 lines on failure),
-so only the failing checks consume agent context.
+Run ALL applicable checks simultaneously via `_optimus_quiet_run` —
+see AGENTS.md Protocol: Quiet Command Execution. The helper redirects each
+command's output to `.optimus/logs/` and prints only a PASS/FAIL line (plus
+last 50 lines on failure), so only the failing checks consume agent context.
 
 Run `make lint` for lint checks. Optional static analysis tools (vet, imports, format, docs) are auto-detected from the project stack.
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1729,6 +1729,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -1803,6 +1804,7 @@ times each stage ran on each task — useful for spotting spec churn and review 
    # Requires Protocol: Resolve Main Worktree Path to have run first
    # (or resolve inline; see that protocol).
    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
    STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
    if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
      echo "WARNING: stats.json is corrupted. Resetting counters."
@@ -2120,10 +2122,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -2136,9 +2140,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -2149,8 +2154,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3
@@ -2373,6 +2388,7 @@ with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
@@ -2434,12 +2450,13 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
@@ -2497,6 +2514,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -2523,6 +2541,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -2555,6 +2574,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -2574,6 +2594,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -1088,9 +1088,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1119,6 +1120,74 @@ separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir
 for Ring specs) — see the File Location section above.
 
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
+
+
+### Protocol: Notification Hooks
+
+**Referenced by:** all stage agents (1-4), tasks
+
+After writing a status change to state.json, invoke notification hooks if present.
+
+**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
+`OLD_STATUS` BEFORE writing the new status. The sequence is:
+1. Read current status (with guard for missing/empty state.json):
+   ```bash
+   if [ -f "$STATE_FILE" ]; then
+     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
+     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
+   else
+     OLD_STATUS="Pendente"
+   fi
+   ```
+2. Write new status to state.json
+3. Invoke hooks with `OLD_STATUS` and new status
+
+**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
+shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
+interpretation — treat all arguments as untrusted data.
+
+```bash
+# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
+# enable path-traversal if hook args flow into file paths).
+_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
+
+# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
+# `test && echo || (test && echo)` pattern).
+if [ -f ./tasks-hooks.sh ]; then
+  HOOKS_FILE="./tasks-hooks.sh"
+elif [ -f ./docs/tasks-hooks.sh ]; then
+  HOOKS_FILE="./docs/tasks-hooks.sh"
+else
+  HOOKS_FILE=""
+fi
+
+if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
+  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
+fi
+```
+
+Events and their parameter signatures:
+
+| Event | Parameters | Description |
+|-------|-----------|-------------|
+| `status-change` | `event task_id old_status new_status` | Any status transition |
+| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
+| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
+| `task-blocked` | `event task_id current_status current_status reason` | Dependency check failed (5 args — includes reason) |
+
+When a dependency check fails (provide defaults so hook payload is never malformed):
+```bash
+: "${dep_id:=unknown}"
+: "${dep_status:=unknown}"
+if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
+  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
+fi
+```
+
+Hooks run in background (`&`) and their failure does NOT block the pipeline.
+If `tasks-hooks.sh` does not exist, hooks are silently skipped.
+
+Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
 
 
 ### Protocol: Resolve Tasks Git Scope
@@ -1303,6 +1372,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -1329,6 +1399,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -1361,6 +1432,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -1380,6 +1452,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus:tasks.md).
 # Validate state.json if it exists

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -466,9 +466,8 @@ Show the new table order.
 
 1. Update the status to `Cancelado` in state.json — see AGENTS.md Protocol: State Management.
 2. Remove the `branch` field from the task's entry in state.json (if branch was deleted in Step 6.1).
-4. **Invoke notification hooks (if present):**
+4. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
-   _optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_./:'; }
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" task-cancelled "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "<old status>")" "$(_optimus_sanitize "Cancelado")" 2>/dev/null &
@@ -570,9 +569,8 @@ To resolve, run `/optimus:tasks`:
 2. If reopening from `Cancelado`, also remove the `branch` field from state.json (any previous
    branch is stale and should not be reused)
 3. Clean stale session state: `rm -f ".optimus/sessions/session-${TASK_ID}.json"`
-4. **Invoke notification hooks (if present):**
+4. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
-   _optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_./:'; }
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" status-change "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "DONE")" "$(_optimus_sanitize "<target status>")" 2>/dev/null &
@@ -652,9 +650,8 @@ code manually without using stage-2).
 ### Step 8.2: Apply Advance
 
 1. Update the status in state.json to the target status — see AGENTS.md Protocol: State Management.
-2. **Invoke notification hooks (if present):**
+2. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
-   _optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_./:'; }
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" status-change "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "<old status>")" "$(_optimus_sanitize "<target status>")" 2>/dev/null &
@@ -709,9 +706,8 @@ that significant rework is needed and the task should go back to implementation)
 ### Step 9.2: Apply Demotion
 
 1. Update the status in state.json to the target status — see AGENTS.md Protocol: State Management.
-3. **Invoke notification hooks (if present):**
+3. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
-   _optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_./:'; }
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" status-change "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "<old status>")" "$(_optimus_sanitize "<target status>")" 2>/dev/null &

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -924,9 +924,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1088,10 +1089,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -1104,9 +1107,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -1117,8 +1121,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -375,10 +375,14 @@ the worktree being removed, `cd` to the main repository first:
 
 ### Step 4.2: Check for Task Branch
 
-Identify the task's branch:
+Identify the task's branch (resolve `MAIN_WORKTREE` first so `state.json` is
+read from the main worktree, not from a linked worktree's isolated copy):
 
 ```bash
-TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' .optimus/state.json 2>/dev/null)
+# Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="${MAIN_WORKTREE:-$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')}"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
 if [ -z "$TASK_BRANCH" ]; then
   TASK_BRANCH=$(git branch --list "*$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')*" 2>/dev/null | head -1 | tr -d ' *')
 fi

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -764,55 +764,6 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
-
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
-
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
-
 ### Protocol: Active Version Guard
 
 **Referenced by:** all stage agents (1-4)
@@ -904,6 +855,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -1030,6 +982,55 @@ If `tasks-hooks.sh` does not exist, hooks are silently skipped.
 Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+
+**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
+
+**Recipe:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
+  exit 1
+fi
+```
+
+The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
+
+**Path resolution pattern:**
+
+After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
+
+```bash
+# RIGHT (works from any worktree):
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
+         "${MAIN_WORKTREE}/.optimus/reports" \
+         "${MAIN_WORKTREE}/.optimus/logs"
+
+# WRONG (resolves against PWD, breaks in linked worktrees):
+STATE_FILE=".optimus/state.json"
+SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE=".optimus/stats.json"
+mkdir -p .optimus/sessions .optimus/reports .optimus/logs
+```
+
+**What does NOT need this protocol:**
+
+- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.gitignore` itself — versioned, propagated via git.
+
+**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: State Management
 
 **Referenced by:** all stage agents (1-4), tasks, report, quick-report, import, batch
@@ -1051,6 +1052,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -1077,6 +1079,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -1109,6 +1112,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -1128,6 +1132,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -589,9 +589,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -692,6 +693,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -718,6 +720,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -750,6 +753,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -769,6 +773,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -335,13 +335,17 @@ step — skills resolve the default automatically:
 ```bash
 if [ "$TASKS_DIR" != "docs/pre-dev" ]; then
   # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-  if [ ! -f .optimus/config.json ]; then
-    echo '{}' > .optimus/config.json
+  # MAIN_WORKTREE was resolved in Step 1.3 (see line ~195); re-assert here so config.json
+  # writes always land in the main worktree, not in a linked worktree's isolated copy.
+  MAIN_WORKTREE="${MAIN_WORKTREE:-$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')}"
+  MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+  if [ ! -f "${MAIN_WORKTREE}/.optimus/config.json" ]; then
+    echo '{}' > "${MAIN_WORKTREE}/.optimus/config.json"
   fi
-  if jq --arg dir "$TASKS_DIR" '.tasksDir = $dir' .optimus/config.json > .optimus/config.json.tmp; then
-    mv .optimus/config.json.tmp .optimus/config.json
+  if jq --arg dir "$TASKS_DIR" '.tasksDir = $dir' "${MAIN_WORKTREE}/.optimus/config.json" > "${MAIN_WORKTREE}/.optimus/config.json.tmp"; then
+    mv "${MAIN_WORKTREE}/.optimus/config.json.tmp" "${MAIN_WORKTREE}/.optimus/config.json"
   else
-    rm -f .optimus/config.json.tmp
+    rm -f "${MAIN_WORKTREE}/.optimus/config.json.tmp"
     echo "ERROR: Failed to update config.json"
   fi
 fi

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -1444,6 +1444,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -1518,6 +1519,7 @@ times each stage ran on each task — useful for spotting spec churn and review 
    # Requires Protocol: Resolve Main Worktree Path to have run first
    # (or resolve inline; see that protocol).
    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
    STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
    if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
      echo "WARNING: stats.json is corrupted. Resetting counters."
@@ -1951,6 +1953,7 @@ with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
@@ -2012,12 +2015,13 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
@@ -2118,6 +2122,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -2144,6 +2149,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -2176,6 +2182,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -2195,6 +2202,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -1407,8 +1407,8 @@ When the loop exits (any status), proceed to Phase 11 (integration tests).
 ## Phase 11: Integration Tests (before push)
 
 **Before pushing**, run integration tests. These are slow and expensive, so they
-run ONCE here — not during the fix/convergence cycle. Run quietly — see AGENTS.md
-Protocol: Quiet Command Execution:
+run ONCE here — not during the fix/convergence cycle. Run quietly —
+see AGENTS.md Protocol: Quiet Command Execution:
 
 ```bash
 _optimus_quiet_run "make-test-integration" make test-integration   # Optional target — SKIP if missing

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -2403,9 +2403,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -2586,10 +2587,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -2602,9 +2605,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -2615,8 +2619,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -703,6 +703,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -729,6 +730,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -761,6 +763,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -780,6 +783,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -974,9 +974,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1189,6 +1190,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -1215,6 +1217,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -1247,6 +1250,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -1266,6 +1270,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -1794,6 +1794,7 @@ same-repo and separate-repo scopes.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 if [ -z "$TASKS_DEFAULT_BRANCH" ]; then
   echo "WARNING: Cannot determine default branch for tasks repo. Skipping divergence check."
   # Skip — this is a warning, not a HARD BLOCK
@@ -1868,6 +1869,7 @@ times each stage ran on each task — useful for spotting spec churn and review 
    # Requires Protocol: Resolve Main Worktree Path to have run first
    # (or resolve inline; see that protocol).
    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
    STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
    if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
      echo "WARNING: stats.json is corrupted. Resetting counters."
@@ -2185,10 +2187,12 @@ output lines. Capturing that output in the agent's context wastes tokens and slo
 down every turn, even when the command passes cleanly.
 
 This protocol defines `_optimus_quiet_run`, a bash helper that runs a command with
-stdout/stderr redirected to a log file under `.optimus/logs/` and emits **a single
-verdict line** based on the exit code. On failure it also prints the last 50 lines of
-the log so the agent can diagnose without ingesting the full output. The exit code
-is preserved, so downstream control flow (`if ...; then ... fi`) keeps working.
+stdout/stderr redirected to a log file under `${MAIN_WORKTREE}/.optimus/logs/`
+(the **main worktree** copy, so logs survive linked-worktree cleanup) and emits
+**a single verdict line** based on the exit code. On failure it also prints the
+last 50 lines of the log so the agent can diagnose without ingesting the full
+output. The exit code is preserved, so downstream control flow
+(`if ...; then ... fi`) keeps working.
 
 **Helper (auto-inlined — do NOT manually copy):**
 
@@ -2201,9 +2205,10 @@ source of truth is enough.
 _optimus_quiet_run() {
   # Usage: _optimus_quiet_run <label> <command> [args...]
   # Runs <command> with stdout+stderr redirected to
-  # .optimus/logs/<timestamp>-<label>-<pid>.log. Prints a single PASS/FAIL line;
-  # on FAIL also prints last 50 lines of the log (terminal escapes stripped).
-  # Returns the command's exit code unchanged.
+  # ${MAIN_WORKTREE}/.optimus/logs/<timestamp>-<label>-<pid>.log (under the main
+  # worktree, so logs survive linked-worktree cleanup). Prints a single
+  # PASS/FAIL line; on FAIL also prints last 50 lines of the log (terminal
+  # escapes stripped). Returns the command's exit code unchanged.
   local label="$1"; shift
   if [ -z "$label" ] || [ $# -eq 0 ]; then
     echo "ERROR: _optimus_quiet_run requires <label> and <command>" >&2
@@ -2214,8 +2219,18 @@ _optimus_quiet_run() {
   [ -z "$safe" ] && safe="run"
   local ts
   ts=$(date +%Y%m%d-%H%M%S)
+  # Resolve MAIN_WORKTREE if not already set by caller. Helper may be invoked
+  # in unusual contexts (e.g., outside the standard Resolve-Main-Worktree
+  # invocation chain), so fall back to PWD with a WARNING rather than crash.
+  if [ -z "${MAIN_WORKTREE:-}" ]; then
+    MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+  fi
+  if [ -z "$MAIN_WORKTREE" ]; then
+    echo "WARNING: _optimus_quiet_run could not resolve MAIN_WORKTREE; logging to PWD-relative path" >&2
+    MAIN_WORKTREE="."
+  fi
   # PID suffix prevents same-second same-label collisions (parallel or fast sequential).
-  local log=".optimus/logs/${ts}-${safe}-$$.log"
+  local log="${MAIN_WORKTREE}/.optimus/logs/${ts}-${safe}-$$.log"
   if ! mkdir -p "$(dirname "$log")" 2>/dev/null; then
     echo "ERROR: _optimus_quiet_run cannot create $(dirname "$log") (permission denied, disk full, or read-only FS)" >&2
     return 3
@@ -2438,6 +2453,7 @@ with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
 if [ -f "$SESSION_FILE" ]; then
   if ! jq empty "$SESSION_FILE" 2>/dev/null; then
@@ -2499,12 +2515,13 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
@@ -2562,6 +2579,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -2588,6 +2606,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -2620,6 +2639,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -2639,6 +2659,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -261,10 +261,10 @@ This determines which specialist agents to dispatch in Phase 3.
 
 ### Step 2.1: Run Static Analysis (parallel)
 
-Run ALL applicable checks simultaneously via `_optimus_quiet_run` — see AGENTS.md
-Protocol: Quiet Command Execution. The helper redirects each command's output to
-`.optimus/logs/` and prints only a PASS/FAIL line (plus last 50 lines on failure),
-so only the failing checks consume agent context.
+Run ALL applicable checks simultaneously via `_optimus_quiet_run` —
+see AGENTS.md Protocol: Quiet Command Execution. The helper redirects each
+command's output to `.optimus/logs/` and prints only a PASS/FAIL line (plus
+last 50 lines on failure), so only the failing checks consume agent context.
 
 Run `make lint` for lint checks. Optional static analysis tools (vet, imports, format, docs) are auto-detected from the project stack.
 

--- a/scripts/inline-protocols.py
+++ b/scripts/inline-protocols.py
@@ -54,30 +54,37 @@ def parse_agents_md() -> dict[str, str]:
         sys.exit(1)
     lines = AGENTS_MD.read_text().splitlines()
     sections: dict[str, str] = {}
+    seen: set[str] = set()
     current_key = None
     current_lines: list[str] = []
+
+    def _flush(key: str, body_lines: list[str]) -> None:
+        # Warn on duplicate headings — last one wins, which can silently
+        # hide a misnamed protocol if two sections share a title. Track via
+        # `seen` (not `sections`) so the warning fires on the SECOND
+        # occurrence, not the third.
+        if key in seen:
+            print(
+                f"  WARNING: Duplicate heading '{key}' — later "
+                "definition wins",
+                file=sys.stderr,
+            )
+        seen.add(key)
+        sections[key] = "\n".join(body_lines)
 
     for line in lines:
         heading_match = HEADING_RE.match(line)
         if heading_match:
             title = heading_match.group(1).strip()
             if current_key:
-                # Warn on duplicate headings — last one wins, which can silently
-                # hide a misnamed protocol if two sections share a title.
-                if current_key in sections:
-                    print(
-                        f"  WARNING: Duplicate heading '{current_key}' — later "
-                        "definition wins",
-                        file=sys.stderr,
-                    )
-                sections[current_key] = "\n".join(current_lines)
+                _flush(current_key, current_lines)
             current_key = title
             current_lines = [line]
         elif current_key:
             current_lines.append(line)
 
     if current_key:
-        sections[current_key] = "\n".join(current_lines)
+        _flush(current_key, current_lines)
 
     return sections
 
@@ -123,6 +130,31 @@ def _normalize_key(key: str) -> str:
     return PAREN_SUFFIX_RE.sub('', key).strip().lower()
 
 
+def _pick_longest_with_warning(
+    ref: str, candidates: list[str]
+) -> str | None:
+    """Pick the longest candidate from a startswith match list.
+
+    When 2+ keys match the same prefix, prefer the LONGEST match (most specific),
+    and warn to stderr about the ambiguity so the drift is visible.
+    """
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    # Sort by length DESC, then lexicographically for deterministic tie-break.
+    ordered = sorted(candidates, key=lambda k: (-len(k), k))
+    chosen = ordered[0]
+    losers = ordered[1:]
+    for loser in losers:
+        print(
+            f"  WARNING: ambiguous ref {ref!r} resolved to {chosen!r} "
+            f"over {loser!r}",
+            file=sys.stderr,
+        )
+    return chosen
+
+
 def match_ref_to_section(ref: str, sections: dict[str, str]) -> str | None:
     """Match a reference name to a section key in AGENTS.md."""
     if ref.startswith("Protocol: "):
@@ -134,12 +166,15 @@ def match_ref_to_section(ref: str, sections: dict[str, str]) -> str | None:
                 key_base = _normalize_key(key[len("Protocol: "):])
                 if key_base == proto_lower:
                     return key
-        # Try startswith match for partial names
+        # Try startswith match for partial names — collect ALL candidates
+        # and prefer the LONGEST match. Warn on ambiguity.
+        candidates: list[str] = []
         for key in sections:
             if key.startswith("Protocol: "):
                 key_base = _normalize_key(key[len("Protocol: "):])
                 if key_base.startswith(proto_lower):
-                    return key
+                    candidates.append(key)
+        return _pick_longest_with_warning(ref, candidates)
     elif ref.startswith("Common: "):
         pattern_name = ref[len("Common: "):]
         pattern_normalized = _normalize_key(pattern_name)
@@ -147,10 +182,12 @@ def match_ref_to_section(ref: str, sections: dict[str, str]) -> str | None:
         for key in sections:
             if _normalize_key(key) == pattern_normalized:
                 return key
-        # Try startswith match
+        # Try startswith match — collect ALL candidates and prefer LONGEST.
+        candidates = []
         for key in sections:
             if _normalize_key(key).startswith(pattern_normalized):
-                return key
+                candidates.append(key)
+        return _pick_longest_with_warning(ref, candidates)
     return None
 
 
@@ -161,7 +198,11 @@ def strip_existing_inline(content: str) -> str:
         return content
     end_idx = content.find(MARKER_END)
     if end_idx == -1:
-        print("  WARNING: MARKER_START found but MARKER_END missing — skipping strip to avoid data loss")
+        print(
+            "  WARNING: MARKER_START found but MARKER_END missing — "
+            "skipping strip to avoid data loss",
+            file=sys.stderr,
+        )
         return content
     after = content[end_idx + len(MARKER_END):]
     return content[:start_idx].rstrip() + after
@@ -218,6 +259,20 @@ def inline_protocols() -> None:
             else:
                 unmatched.append(ref)
 
+        # F3.3i: Detect ref-alias collisions — when 2+ refs map to the same
+        # section key, surface it via INFO so reviewers can decide if the
+        # aliasing is intentional or if a SKILL.md uses inconsistent phrasing.
+        key_to_refs: dict[str, list[str]] = {}
+        for ref, key in matched.items():
+            key_to_refs.setdefault(key, []).append(ref)
+        for key, alias_refs in key_to_refs.items():
+            if len(alias_refs) > 1:
+                print(
+                    f"  INFO: {plugin_name}: ref alias collapsed: "
+                    f"{sorted(alias_refs)} all -> {key!r}",
+                    file=sys.stderr,
+                )
+
         # Collect the sections to inline (deduplicated, ordered)
         sections_to_inline: dict[str, str] = {}
         for ref, key in sorted(matched.items(), key=lambda x: x[1]):
@@ -267,7 +322,28 @@ def inline_protocols() -> None:
                 and MAIN_WORKTREE_PROTOCOL_KEY not in sections_to_inline:
             extra[MAIN_WORKTREE_PROTOCOL_KEY] = foundational[MAIN_WORKTREE_PROTOCOL_KEY]
 
-        content = strip_existing_inline(raw_content).rstrip() + "\n"
+        body_only = strip_existing_inline(raw_content)
+
+        # F3.3e: Detect manual paste of inlined helper functions in the body.
+        # The inliner appends these as part of shared protocols; if a SKILL
+        # body also defines them, output ends up with duplicate definitions
+        # (and drift risk if one copy diverges). _optimus_sanitize is checked
+        # as a future-regression guard — it was removed in F2.
+        body_function_guards = (
+            "_optimus_quiet_run() {",
+            "_optimus_set_title() {",
+            "_optimus_sanitize() {",
+        )
+        for fn_marker in body_function_guards:
+            if fn_marker in body_only:
+                fn_name = fn_marker.split("()", 1)[0]
+                print(
+                    f"  WARNING: {plugin_name}: body contains manual definition "
+                    f"of {fn_name}() — should use inlined protocol",
+                    file=sys.stderr,
+                )
+
+        content = body_only.rstrip() + "\n"
 
         inline_parts = []
         inline_parts.append(f"\n{MARKER_START}")
@@ -291,10 +367,33 @@ def inline_protocols() -> None:
         inline_parts.append(MARKER_END)
 
         new_content = content + "\n".join(inline_parts) + "\n"
+
+        # F3.3d: Refuse to write through a symlink. Defense-in-depth against
+        # a malicious commit that replaces SKILL.md with a symlink to e.g.
+        # ~/.bashrc — the inliner would otherwise overwrite the target.
+        if skill_path.is_symlink():
+            print(
+                f"  ERROR: refusing to write through symlink: {skill_path}",
+                file=sys.stderr,
+            )
+            continue
+
+        # F3.3c: Atomic write. A direct write_text() interrupted mid-write
+        # leaves the file truncated without MARKER_END; on the next run
+        # strip_existing_inline silently degrades. Write to a temp sibling
+        # and atomically replace.
+        tmp = skill_path.with_suffix(skill_path.suffix + ".tmp")
         try:
-            skill_path.write_text(new_content)
+            tmp.write_text(new_content)
+            tmp.replace(skill_path)
         except OSError as e:
             print(f"  ERROR: Failed to write {skill_path}: {e}", file=sys.stderr)
+            # Best-effort cleanup of the temp file if it was created.
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
             continue
 
         total_inlined += 1

--- a/scripts/test_inline_protocols.py
+++ b/scripts/test_inline_protocols.py
@@ -163,6 +163,33 @@ class TestMatchRefToSection:
         result = ip.match_ref_to_section("Protocol: Task", sections)
         assert result == "Protocol: Task"
 
+    def test_startswith_prefers_longest_match_with_warning(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        """F3.3a: When 2+ keys share the same prefix, prefer the LONGEST match
+        (most specific) and emit a WARNING to stderr about the ambiguity.
+
+        Without this guard, the resolver returned the first key in dict-iteration
+        order — fragile and silently mis-routed refs.
+        """
+        # Use a prefix `Foo` that matches both `Foo` and `Foo Bar Resolution`.
+        # The reference `Protocol: Foo` should resolve to the LONGER key
+        # because the resolver collects all startswith candidates and picks
+        # the longest, with a stderr warning.
+        sections = {
+            "Protocol: Foo Bar Resolution": "long",
+            "Protocol: Foo Bar": "medium",
+        }
+        # Ref `Protocol: Foo Ba` matches BOTH startswith targets;
+        # the longest one (Foo Bar Resolution) must win.
+        result = ip.match_ref_to_section("Protocol: Foo Ba", sections)
+        assert result == "Protocol: Foo Bar Resolution"
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "ambiguous ref" in captured.err
+        assert "Protocol: Foo Bar Resolution" in captured.err
+        assert "Protocol: Foo Bar" in captured.err
+
     def test_convergence_loop_resolves_against_live_agents_md(self):
         """Regression guard: the live AGENTS.md heading must resolve via the parser.
 
@@ -238,10 +265,13 @@ class TestStripExistingInline:
         result = ip.strip_existing_inline(content)
         assert "Trailing" in result
 
-    def test_missing_end_marker_returns_unchanged(self):
+    def test_missing_end_marker_returns_unchanged(self, capsys: pytest.CaptureFixture[str]):
         content = f"Before\n{ip.MARKER_START}\nOrphaned"
         result = ip.strip_existing_inline(content)
         assert result == content
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "MARKER_START found but MARKER_END missing" in captured.err
 
 
 # --- idempotency integration test ---
@@ -293,7 +323,8 @@ class TestIdempotency:
         skill.write_text("see AGENTS.md Protocol: Nonexistent.\n")
 
         ip.inline_protocols()
-        assert "unmatched" in capsys.readouterr().out.lower()
+        captured = capsys.readouterr()
+        assert "WARNING: unmatched ref" in captured.err
 
     def test_includes_foundational_for_state_management(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         agents = tmp_path / "AGENTS.md"
@@ -360,13 +391,36 @@ class TestIdempotency:
 # --- F3: Critical path tests ---
 
 class TestCriticalPaths:
-    def test_duplicate_heading_keeps_last(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    def test_duplicate_heading_keeps_last(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
         agents = tmp_path / "AGENTS.md"
         agents.write_text("## Same\nFirst content\n## Same\nSecond content\n")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
         sections = ip.parse_agents_md()
         assert "Second content" in sections["Same"]
         assert "First content" not in sections["Same"]
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "Duplicate heading" in captured.err
+
+    def test_duplicate_heading_warns_on_second_occurrence(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """Regression guard: warning must fire on the SECOND duplicate, not the third.
+
+        With the bug fixed, exactly two `## Dup` headings produce a WARNING.
+        """
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("## Dup\nA\n## Dup\nB\n")
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        sections = ip.parse_agents_md()
+        assert "Dup" in sections
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "Duplicate heading" in captured.err
+        assert "'Dup'" in captured.err
 
     def test_multiple_mixed_refs_in_single_file(self, tmp_path: Path):
         content = (
@@ -394,7 +448,11 @@ class TestCriticalPaths:
         skill_dir.mkdir(parents=True)
         skill = skill_dir / "SKILL.md"
         skill.write_text("see AGENTS.md Protocol: Y.\n")
-        skill.chmod(0o444)
+        # F3.3c: atomic write uses tmp.replace(), so file permissions on
+        # the target don't block the write — the parent dir must be
+        # write-protected to force OSError. Strip write+execute from the
+        # parent so creating the .tmp sibling fails.
+        skill_dir.chmod(0o555)
 
         try:
             ip.inline_protocols()
@@ -402,7 +460,7 @@ class TestCriticalPaths:
             output = captured.out + captured.err
             assert "ERROR" in output or "Failed to write" in output
         finally:
-            skill.chmod(0o644)
+            skill_dir.chmod(0o755)
 
 
 # --- F4: Edge case tests ---
@@ -478,3 +536,258 @@ class TestEdgeCases:
         captured = capsys.readouterr()
         output = captured.out + captured.err
         assert "ERROR" in output and "skipping" in output.lower()
+
+
+# --- F3.3d: Symlink-write defense ---
+
+class TestSymlinkWrite:
+    def test_refuses_to_write_through_symlink(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """F3.3d: A SKILL.md that is a symlink must NOT be overwritten.
+
+        Defense-in-depth: a malicious commit could replace SKILL.md with a
+        symlink to ~/.bashrc and we'd otherwise clobber the target.
+        """
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("## Protocol: Sym\nSym content\n")
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
+
+        # Create the real target file outside the SKILL path
+        target = tmp_path / "real_target.md"
+        target.write_text("ORIGINAL TARGET CONTENT — must not be overwritten\n")
+
+        # Create the SKILL dir + symlink-as-SKILL.md
+        skill_dir = tmp_path / "linked" / "skills" / "optimus-linked"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        # Stage refs by writing through the symlink target, then convert to symlink
+        target.write_text("see AGENTS.md Protocol: Sym.\n")
+        skill.symlink_to(target)
+
+        ip.inline_protocols()
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.err
+        assert "refusing to write through symlink" in captured.err
+        # Target must remain unchanged.
+        assert target.read_text() == "see AGENTS.md Protocol: Sym.\n"
+        # MARKER_START must NOT appear in target (proves no write happened).
+        assert ip.MARKER_START not in target.read_text()
+
+
+# --- F3.3e: Body-level paste detection ---
+
+class TestBodyLevelInlineGuard:
+    def _setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str):
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("## Protocol: Echo\nEcho content\n")
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
+        skill_dir = tmp_path / "echo" / "skills" / "optimus-echo"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        skill.write_text(body)
+        return skill
+
+    def test_warns_on_quiet_run_in_body(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        body = (
+            "see AGENTS.md Protocol: Echo.\n"
+            "```bash\n"
+            "_optimus_quiet_run() {\n"
+            "  echo manual\n"
+            "}\n"
+            "```\n"
+        )
+        self._setup(tmp_path, monkeypatch, body)
+        ip.inline_protocols()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "_optimus_quiet_run" in captured.err
+        assert "manual definition" in captured.err
+
+    def test_warns_on_set_title_in_body(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        body = (
+            "see AGENTS.md Protocol: Echo.\n"
+            "_optimus_set_title() {\n"
+            "  printf '\\033]0;%s\\007' \"$1\"\n"
+            "}\n"
+        )
+        self._setup(tmp_path, monkeypatch, body)
+        ip.inline_protocols()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "_optimus_set_title" in captured.err
+
+    def test_warns_on_sanitize_regression(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        # _optimus_sanitize was removed in F2; this is a future regression guard.
+        body = (
+            "see AGENTS.md Protocol: Echo.\n"
+            "_optimus_sanitize() {\n"
+            "  echo regression\n"
+            "}\n"
+        )
+        self._setup(tmp_path, monkeypatch, body)
+        ip.inline_protocols()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "_optimus_sanitize" in captured.err
+
+
+# --- F3.3f: Canonical reference phrasing in skills ---
+
+class TestCanonicalReferencePhrasing:
+    """Scan every SKILL.md and assert AGENTS.md Protocol: refs use canonical form."""
+
+    def test_no_unanchored_protocol_references(self):
+        """F3.3f: Every `AGENTS.md Protocol:` mention in a SKILL body must
+        either follow canonical phrasing or live in a code/quote block.
+
+        Canonical form: `AGENTS.md Protocol: <Heading>` (the regex anchor
+        used by the inliner). Deviations (e.g. `AGENTS.md "Protocol: X"`)
+        cause silent unmatched refs.
+        """
+        repo_root = Path(__file__).parent.parent
+        skill_files = sorted(repo_root.glob("*/skills/*/SKILL.md"))
+        assert skill_files, "No SKILL.md files found — fixture broken"
+
+        offenders: list[str] = []
+        # Canonical: literally "AGENTS.md Protocol: <Heading>"
+        # The inliner regex is PROTOCOL_RE = r'AGENTS\.md Protocol:\s*([^\n"]+)'
+        canonical_re = re.compile(r'AGENTS\.md\s+Protocol:\s*[^\n"]+')
+        # Suspicious: an unanchored mention of `Protocol:` adjacent to AGENTS.md
+        # but not matching the canonical form. Examples we'd flag:
+        #   `AGENTS.md "Protocol: X"`           (quoted)
+        #   `AGENTS.md\nProtocol: X`            (newline-separated)
+        suspicious_re = re.compile(r'AGENTS\.md["\s]+Protocol:')
+
+        for skill in skill_files:
+            content = skill.read_text()
+            # Strip out the inlined block — those refs are not authoritative.
+            content = ip.strip_existing_inline(content)
+            # Strip fenced code blocks and block-quotes to avoid false positives.
+            content_no_fences = re.sub(r"```[\s\S]*?```", "", content)
+            content_no_quotes = "\n".join(
+                line for line in content_no_fences.splitlines()
+                if not line.lstrip().startswith(">")
+            )
+            for m in suspicious_re.finditer(content_no_quotes):
+                # Verify it's not actually canonical (the canonical form
+                # also matches the suspicious regex if there's a single space).
+                snippet = content_no_quotes[m.start(): m.start() + 80]
+                # Canonical form has exactly one space and no quote between
+                # `AGENTS.md` and `Protocol:`.
+                head = snippet[: snippet.index("Protocol:")]
+                # Strip "AGENTS.md" prefix.
+                between = head[len("AGENTS.md"):]
+                # Canonical: " " (one space). Anything else (multiple
+                # whitespace, quotes, newlines) is non-canonical.
+                if between != " ":
+                    offenders.append(f"{skill}: {snippet!r}")
+
+        # Cross-check: for every canonical mention we found, drop into the
+        # offender list only if the previous regex did not catch it. (The
+        # canonical regex is a sanity check and not used for offender output.)
+        _ = canonical_re  # kept for future tightening; not used to fail here.
+
+        assert not offenders, (
+            "Non-canonical AGENTS.md Protocol references found:\n"
+            + "\n".join(offenders)
+        )
+
+
+# --- F3.3h: MAX_FILE_SIZE boundary ---
+
+class TestMaxFileSize:
+    def test_oversized_agents_md_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        agents = tmp_path / "AGENTS.md"
+        agents.write_bytes(
+            b"# header\n\n## Protocol: X\n\n" + b"x" * (5 * 1024 * 1024)
+        )
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        with pytest.raises(SystemExit):
+            ip.parse_agents_md()
+
+    def test_oversized_skill_md_skipped_with_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text("## Protocol: Big\nBig content\n")
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
+
+        skill_dir = tmp_path / "big" / "skills" / "optimus-big"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        # Write a payload that exceeds MAX_FILE_SIZE (5 MB).
+        payload = b"see AGENTS.md Protocol: Big.\n" + b"x" * (5 * 1024 * 1024)
+        skill.write_bytes(payload)
+
+        ip.inline_protocols()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "exceeds" in captured.err
+        assert "skipping" in captured.err
+        # MARKER_START must NOT have been added (file was skipped).
+        assert ip.MARKER_START not in skill.read_bytes().decode(
+            "utf-8", errors="ignore"
+        )
+
+
+# --- F3.3i: Ref-alias collision INFO line ---
+
+class TestRefAliasCollision:
+    def test_emits_info_when_two_refs_collapse_to_one_key(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """F3.3i: When 2+ distinct refs map to the same section key, emit
+        an INFO line so reviewers can decide if the aliasing is intentional.
+        """
+        agents = tmp_path / "AGENTS.md"
+        # One heading. Two ways to reference it from the SKILL body:
+        #   1. Exact: `Protocol: Foo Bar Resolution`
+        #   2. Prefix that resolves via startswith: `Protocol: Foo Bar`
+        # Both will map to `Protocol: Foo Bar Resolution`.
+        agents.write_text("## Protocol: Foo Bar Resolution\nFoo content\n")
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
+
+        skill_dir = tmp_path / "alias" / "skills" / "optimus-alias"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        skill.write_text(
+            "see AGENTS.md Protocol: Foo Bar Resolution.\n"
+            "also AGENTS.md Protocol: Foo Bar.\n"
+        )
+
+        ip.inline_protocols()
+        captured = capsys.readouterr()
+        assert "INFO" in captured.err
+        assert "ref alias collapsed" in captured.err
+        assert "Protocol: Foo Bar Resolution" in captured.err

--- a/scripts/test_quiet_run.py
+++ b/scripts/test_quiet_run.py
@@ -112,7 +112,11 @@ class TestQuietRunHelper:
         rc, out, _ = _run_helper(tmp_path, '_optimus_quiet_run "ok" echo hi')
         assert rc == 0, f"expected exit 0, got {rc}; out={out}"
         assert out.startswith("PASS: ok "), f"unexpected output: {out}"
-        assert "log: .optimus/logs/" in out
+        # Path is now resolved against ${MAIN_WORKTREE}/. In tmp_path (no git
+        # repo), MAIN_WORKTREE falls back to "." so the log path is
+        # `./.optimus/logs/...`. Accept either the legacy bare prefix or the
+        # PWD-relative fallback.
+        assert ".optimus/logs/" in out
         log_files = list((tmp_path / ".optimus" / "logs").glob("*-ok-*.log"))
         assert len(log_files) == 1, f"expected 1 log file, got {len(log_files)}"
         assert "hi" in log_files[0].read_text()

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -2096,3 +2096,27 @@ class TestWorkspaceValidationHardening:
             "Stage-specific overrides must point at done/SKILL.md Step 1.0.2 for "
             "the full strict-mode rule."
         )
+
+
+class TestSanitizeCharsetUniformity:
+    """No SKILL body may redefine _optimus_sanitize with a non-canonical charset.
+
+    Path-traversal defense: AGENTS.md canonical _optimus_sanitize forbids '.' and '/'.
+    Body-level overrides that allow them are a security regression.
+    """
+
+    CANONICAL_CHARSET = "[:alnum:][:space:]-_:"
+
+    def test_no_body_redefinition_of_sanitize(self):
+        violations = []
+        for skill_path in REPO_ROOT.glob("*/skills/*/SKILL.md"):
+            content = skill_path.read_text()
+            # Strip inlined block — only check body code
+            marker = "<!-- INLINE-PROTOCOLS:START -->"
+            body = content.split(marker, 1)[0]
+            if "_optimus_sanitize()" in body:
+                violations.append(str(skill_path.relative_to(REPO_ROOT)))
+        assert violations == [], (
+            f"Body-level redefinition of _optimus_sanitize() found in: {violations}. "
+            f"Use the inlined canonical helper from Protocol: Notification Hooks."
+        )

--- a/scripts/test_worktree_path_resolution.py
+++ b/scripts/test_worktree_path_resolution.py
@@ -378,6 +378,135 @@ class TestResolverIntegration:
         assert "T-001" in main_state.read_text()
 
 
+class TestSkillBodiesUseMainWorktrePrefixForReadsAndAppends:
+    """Bodies of SKILL.md files (above INLINE-PROTOCOLS:START), AGENTS.md, and
+    `scripts/inline-protocols.py` must NOT contain unprefixed `.optimus/` reads
+    nor unprefixed `.gitignore` mutations. These caught the F1 incident
+    (worktree-isolation, T-037 — silent state.json data loss).
+
+    Each test method targets one source-class:
+      - F1.1a — `local log=".optimus/...` patterns inside helpers.
+      - F1.1b — `.gitignore` mutations (`>> .gitignore` and
+        `grep -q ... .gitignore`) without `${MAIN_WORKTREE}/` prefix.
+      - F1.1c/1d — inline `jq` reads and `[ -f` checks against `.optimus/<file>.json`
+        without `${MAIN_WORKTREE}/` prefix.
+
+    Detection skips fenced bash blocks that ARE the documented `# WRONG` example
+    of the resolver protocol (see `_strip_wrong_example_block`).
+    """
+
+    # `local <var>=".optimus/...` — caught the F1 1a (_optimus_quiet_run helper).
+    LOCAL_LOG_OPTIMUS_RE = re.compile(
+        r'^\s*local\s+\w+\s*=\s*"\.optimus/',
+        re.MULTILINE,
+    )
+    # `.gitignore` mutations without `${MAIN_WORKTREE}/` (or `$MAIN_WORKTREE/`) prefix.
+    # Catches:  printf '...' >> .gitignore   and   grep -q '...' .gitignore
+    # Skips:    printf '...' >> "${MAIN_WORKTREE}/.gitignore"
+    GITIGNORE_BARE_APPEND_RE = re.compile(
+        r'>>\s*(?!"?\$\{?MAIN_WORKTREE)(?:"\s*)?\.gitignore\b',
+    )
+    GITIGNORE_BARE_GREP_RE = re.compile(
+        r'\bgrep\s+-q\b[^\n]*?\s(?!"?\$\{?MAIN_WORKTREE)(?:"\s*)?\.gitignore\b',
+    )
+    # Inline jq/[ -f reads against bare `.optimus/<file>.json` (no `${MAIN_WORKTREE}/`).
+    # Targets the F1 1c (done state.json read) and F1 1d (import config.json read)
+    # classes. Excludes:
+    #   - LHS assignments (handled by RELATIVE_PATH_ASSIGN_RE)
+    #   - lines mentioning `${MAIN_WORKTREE}` already (the `>` redirection target
+    #     would still match the read on the same line of mv).
+    JQ_READ_BARE_OPTIMUS_RE = re.compile(
+        r'(?:\bjq\b[^\n]*?|\[\s+-f\s+|\bcat\s+|\bmv\s+)(?:"\s*)?\.optimus/(?:state|stats|config|sessions|reports)(?:\.json|/)',
+    )
+
+    def _scan_targets(self) -> list[tuple[str, str]]:
+        """Return [(label, content), ...] for every source we scan.
+
+        - SKILL.md bodies (above INLINE-PROTOCOLS:START)
+        - AGENTS.md (full, minus the documented `# WRONG` example)
+        - scripts/inline-protocols.py (full)
+        """
+        targets: list[tuple[str, str]] = []
+        for skill_path in _all_skill_files():
+            rel = skill_path.relative_to(REPO_ROOT)
+            targets.append((str(rel), _strip_inlined_block(_read(skill_path))))
+        targets.append(
+            ("AGENTS.md", _strip_wrong_example_block(_read(AGENTS_MD)))
+        )
+        inliner = REPO_ROOT / "scripts" / "inline-protocols.py"
+        if inliner.exists():
+            targets.append(("scripts/inline-protocols.py", _read(inliner)))
+        return targets
+
+    def test_no_local_optimus_log_paths(self):
+        """`local log=".optimus/..."` (and similar `local <var>=".optimus/...")
+        leaks PWD-relative paths inside helpers (F1 1a — _optimus_quiet_run
+        was logging to the linked worktree's .optimus/logs/)."""
+        violations: list[str] = []
+        for label, content in self._scan_targets():
+            for m in self.LOCAL_LOG_OPTIMUS_RE.finditer(content):
+                line_no = content[: m.start()].count("\n") + 1
+                ctx = content.splitlines()[line_no - 1].strip()
+                violations.append(f"{label}:{line_no}: {ctx}")
+        assert violations == [], (
+            "Found `local <var>=\".optimus/...\"` patterns. These resolve "
+            "against PWD and write to the linked-worktree's isolated .optimus/, "
+            "losing data on `git worktree remove`:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nFix: build the path from ${MAIN_WORKTREE}/.optimus/... after "
+            "invoking AGENTS.md Protocol: Resolve Main Worktree Path."
+        )
+
+    def test_no_bare_gitignore_mutations(self):
+        """`>> .gitignore` and `grep -q ... .gitignore` without
+        `${MAIN_WORKTREE}/` prefix (F1 1b — Initialize .optimus Directory and
+        Session State were appending to the linked worktree's .gitignore)."""
+        violations: list[str] = []
+        for label, content in self._scan_targets():
+            for regex, kind in (
+                (self.GITIGNORE_BARE_APPEND_RE, "append"),
+                (self.GITIGNORE_BARE_GREP_RE, "grep"),
+            ):
+                for m in regex.finditer(content):
+                    line_no = content[: m.start()].count("\n") + 1
+                    ctx = content.splitlines()[line_no - 1].strip()
+                    violations.append(f"{label}:{line_no} [{kind}]: {ctx}")
+        assert violations == [], (
+            "Found bare `.gitignore` mutations (no ${MAIN_WORKTREE}/ prefix). "
+            "When run from a linked worktree, these update only the linked "
+            "worktree's .gitignore — the main worktree never gets the "
+            "operational-files block:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nFix: use \"${MAIN_WORKTREE}/.gitignore\" after invoking "
+            "AGENTS.md Protocol: Resolve Main Worktree Path."
+        )
+
+    def test_no_inline_optimus_json_reads_without_prefix(self):
+        """Inline `jq ... .optimus/<file>.json` and `[ -f .optimus/<file>.json ]`
+        reads must use ${MAIN_WORKTREE}/ (F1 1c — done was reading state.json
+        from the linked worktree; F1 1d — import was writing config.json to
+        the linked worktree)."""
+        violations: list[str] = []
+        for label, content in self._scan_targets():
+            for m in self.JQ_READ_BARE_OPTIMUS_RE.finditer(content):
+                line_no = content[: m.start()].count("\n") + 1
+                ctx = content.splitlines()[line_no - 1].strip()
+                # Skip if the line ALSO uses ${MAIN_WORKTREE} elsewhere (e.g.,
+                # `mv "${MAIN_WORKTREE}/.optimus/config.json.tmp" "${MAIN_WORKTREE}/.optimus/config.json"`
+                # has only-prefixed references).
+                if "${MAIN_WORKTREE}" in ctx or "$MAIN_WORKTREE" in ctx:
+                    continue
+                violations.append(f"{label}:{line_no}: {ctx}")
+        assert violations == [], (
+            "Found inline reads against bare `.optimus/<file>.json` paths. "
+            "These resolve to the linked worktree's isolated copy, which is "
+            "lost on `git worktree remove` (T-037 silent data-loss class):\n"
+            + "\n".join(f"  - {v}" for v in violations)
+            + "\n\nFix: prefix the path with \"${MAIN_WORKTREE}/\", e.g. "
+            "`jq ... \"${MAIN_WORKTREE}/.optimus/state.json\"`."
+        )
+
+
 class TestInlineProtocolsInjectsMainWorktree:
     """The propagation script must inject Protocol: Resolve Main Worktree Path
     as a foundational dependency for any skill that touches .optimus/ files."""

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -518,9 +518,8 @@ Show the new table order.
 
 1. Update the status to `Cancelado` in state.json — see AGENTS.md Protocol: State Management.
 2. Remove the `branch` field from the task's entry in state.json (if branch was deleted in Step 6.1).
-4. **Invoke notification hooks (if present):**
+4. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
-   _optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_./:'; }
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" task-cancelled "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "<old status>")" "$(_optimus_sanitize "Cancelado")" 2>/dev/null &
@@ -622,9 +621,8 @@ To resolve, run `/optimus-tasks`:
 2. If reopening from `Cancelado`, also remove the `branch` field from state.json (any previous
    branch is stale and should not be reused)
 3. Clean stale session state: `rm -f ".optimus/sessions/session-${TASK_ID}.json"`
-4. **Invoke notification hooks (if present):**
+4. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
-   _optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_./:'; }
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" status-change "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "DONE")" "$(_optimus_sanitize "<target status>")" 2>/dev/null &
@@ -704,9 +702,8 @@ code manually without using stage-2).
 ### Step 8.2: Apply Advance
 
 1. Update the status in state.json to the target status — see AGENTS.md Protocol: State Management.
-2. **Invoke notification hooks (if present):**
+2. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
-   _optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_./:'; }
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" status-change "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "<old status>")" "$(_optimus_sanitize "<target status>")" 2>/dev/null &
@@ -761,9 +758,8 @@ that significant rework is needed and the task should go back to implementation)
 ### Step 9.2: Apply Demotion
 
 1. Update the status in state.json to the target status — see AGENTS.md Protocol: State Management.
-3. **Invoke notification hooks (if present):**
+3. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
-   _optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_./:'; }
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" status-change "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "<old status>")" "$(_optimus_sanitize "<target status>")" 2>/dev/null &

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1140,9 +1140,10 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' .gitignore 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> .gitignore
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
@@ -1171,6 +1172,74 @@ separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir
 for Ring specs) — see the File Location section above.
 
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
+
+
+### Protocol: Notification Hooks
+
+**Referenced by:** all stage agents (1-4), tasks
+
+After writing a status change to state.json, invoke notification hooks if present.
+
+**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
+`OLD_STATUS` BEFORE writing the new status. The sequence is:
+1. Read current status (with guard for missing/empty state.json):
+   ```bash
+   if [ -f "$STATE_FILE" ]; then
+     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
+     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
+   else
+     OLD_STATUS="Pendente"
+   fi
+   ```
+2. Write new status to state.json
+3. Invoke hooks with `OLD_STATUS` and new status
+
+**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
+shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
+interpretation — treat all arguments as untrusted data.
+
+```bash
+# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
+# enable path-traversal if hook args flow into file paths).
+_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
+
+# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
+# `test && echo || (test && echo)` pattern).
+if [ -f ./tasks-hooks.sh ]; then
+  HOOKS_FILE="./tasks-hooks.sh"
+elif [ -f ./docs/tasks-hooks.sh ]; then
+  HOOKS_FILE="./docs/tasks-hooks.sh"
+else
+  HOOKS_FILE=""
+fi
+
+if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
+  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
+fi
+```
+
+Events and their parameter signatures:
+
+| Event | Parameters | Description |
+|-------|-----------|-------------|
+| `status-change` | `event task_id old_status new_status` | Any status transition |
+| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
+| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
+| `task-blocked` | `event task_id current_status current_status reason` | Dependency check failed (5 args — includes reason) |
+
+When a dependency check fails (provide defaults so hook payload is never malformed):
+```bash
+: "${dep_id:=unknown}"
+: "${dep_status:=unknown}"
+if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
+  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
+fi
+```
+
+Hooks run in background (`&`) and their failure does NOT block the pipeline.
+If `tasks-hooks.sh` does not exist, hooks are silently skipped.
+
+Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
 
 
 ### Protocol: Resolve Tasks Git Scope
@@ -1355,6 +1424,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ -f "$STATE_FILE" ]; then
   # Validate JSON integrity before reading
@@ -1381,6 +1451,7 @@ A task with no entry in state.json is implicitly `Pendente`.
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
@@ -1413,6 +1484,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 if [ ! -f "$STATE_FILE" ]; then
   echo "state.json does not exist — task is already implicitly Pendente."
@@ -1432,6 +1504,7 @@ fi
 # Requires Protocol: Resolve Main Worktree Path to have run first
 # (or resolve inline; see that protocol).
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
 # TASKS_FILE is resolved via Protocol: Resolve Tasks Git Scope (<tasksDir>/optimus-tasks.md).
 # Validate state.json if it exists


### PR DESCRIPTION
## Summary

First batch from deep-review session 2026-04-27. Lands the **CRITICAL** findings (F1, F2) plus the **HIGH** inliner-integrity pass (F3). F8 deferred → #34.

**Constraint applied:** source-of-truth only — `AGENTS.md`, `scripts/`, and body code are edited, but `python3 scripts/inline-protocols.py` was NOT run. Reviewers will need a follow-up `make check-inline` PR (or run it locally and amend) to propagate the AGENTS.md changes into the 17 SKILL.md inlined blocks.

`commands/*.md` files were regenerated via `scripts/sync-claude-commands.py` (separate from the inliner; mirrors SKILL.md bodies).

## What's in this PR

### F1 — Worktree-isolation (CRITICAL)
The `Protocol: Resolve Main Worktree Path` defense (T-037 incident, silent state.json data loss across linked worktrees) had 6 specific code violations + 9 unguarded re-resolutions in AGENTS.md + an orphan regression test running nowhere.

- `AGENTS.md` `_optimus_quiet_run`: log path resolves and prefixes `${MAIN_WORKTREE}/.optimus/logs/...` with defensive resolver+fallback
- `AGENTS.md` Initialize .optimus Directory + Session State: `>> .gitignore` and `grep .gitignore` now prefixed
- `AGENTS.md`: 9 `${MAIN_WORKTREE:?…}` guards on inline re-resolutions
- `done/SKILL.md:381`: `${MAIN_WORKTREE}/.optimus/state.json`
- `import/SKILL.md:336-348`: 4 `${MAIN_WORKTREE}/.optimus/config.json` prefixes
- `Makefile`: `pytest scripts/ -v` (was orphaning `test_worktree_path_resolution.py` — 415 LOC of T-037 coverage)
- `scripts/test_worktree_path_resolution.py`: new `TestSkillBodiesUseMainWorktrePrefixForReadsAndAppends` class catches inline `local log=`, `>> .gitignore`, raw `jq ... .optimus/*.json`

### F2 — `_optimus_sanitize` charset regression (CRITICAL)
4 body-level redefinitions in `tasks/SKILL.md` (allowing `.` and `/`) overrode the canonical AGENTS.md helper.

- Removed all 4 redefinitions
- Added `see AGENTS.md Protocol: Notification Hooks` reference at 4 call sites so the canonical helper inlines on next `make check-inline`
- `scripts/test_skill_consistency.py`: new `TestSanitizeCharsetUniformity`

### F3 — `inline-protocols.py` integrity pass (HIGH)
9 sub-fixes for the inlining mechanism:

| # | Fix |
|---|-----|
| 3a | Longest-match guard + ambiguity WARNING for `match_ref_to_section` startswith fallback |
| 3b | Duplicate-heading WARNING fires on 2nd occurrence via `seen` set (was 3rd) |
| 3c | Atomic write via tmp + replace |
| 3d | Refuses to write through symlinks |
| 3e | Detects body-level paste of inlined fns (`_optimus_quiet_run`, `_optimus_set_title`, `_optimus_sanitize`) |
| 3f | AGENTS.md adds canonical reference phrasing rule under Editing Rules; new `TestCanonicalReferencePhrasing::test_no_unanchored_protocol_references` (caught real line-wrap bugs in `pr-check/SKILL.md:1410` and `review/SKILL.md:264`) |
| 3g | capsys assertions for duplicate-heading / MARKER_END / unmatched-ref WARNINGs |
| 3h | `TestMaxFileSize` boundary tests for both `parse_agents_md` and `inline_protocols` 5MB limits |
| 3i | Ref-alias collision detection (INFO when 2+ refs collapse to one key) |

### F8 — Architectural deferral
SKILL.md inlined-protocol bloat (build = 75% inlined) is an architectural decision; tracked at #34.

## Punch list — remaining deep-review findings (Option-A approved by user)

To be landed in follow-up PRs:

- [ ] **F4** HIGH — Claude Code sync resilience: `_claude()` timeout wrapper, single-pass retry, `1.0.0` fallback → version-glob, drop unenforceable 90s SKILL claim
- [ ] **F5** HIGH — Bash hygiene: `set -euo pipefail` adoption across SKILL bash blocks, `_compute_diffs` refactor, `_read_result` builtin, heredoc accumulator, pipeline collapse
- [ ] **F6** HIGH — Phase/numbering + semantic anchors: fix `resolve` missing Step 2.1, `tasks` Step 6.2/9.2 number gaps, `pr-check` 1.3.4→1.8 jump; replace numeric assertions in tests with stable anchors
- [ ] **F7** HIGH — Cross-skill contracts: all-deps-cancelled message in 5 stage skills; `resolve` 7-of-15 → full Format Validation; AskUser template scope clarification
- [ ] **F9** HIGH — Test infrastructure (residual): TestPlatformDetection log evidence, marker-file polling vs `time.sleep(2)`, root-skip chmod tests, tighten pid-suffix `== 2`, `next()` defaults, module-level non-empty asserts, importlib chain guards
- [ ] **F10** HIGH — Metadata drift: "Read-only" desc correction (6+ surfaces), owner identity normalization (Alex Garzão / alexgarzao@gmail.com), Droid marketplace schema parity (version/homepage/repository/license)
- [ ] **F11** HIGH — Done robustness: `git push origin --delete` recovery handler, deterministic `DEFAULT_BRANCH` via `show-ref --verify`, awk-based worktree match (no substring grep), parse `TASK_TITLE` early
- [ ] **F12** HIGH — Stage-agent prompt quality: subtask-context propagation in `build`; Re-run Guard reset semantics; `pr-check` HARD BLOCK semantics; promote pr-check's CodeRabbit parser to AGENTS.md `Protocol: Parse CodeRabbit Review Body`; `Discover Review Droids` deny-list; `_optimus_set_title` auto-inline; document coderabbit-review TDD vs pr-check as-is divergence
- [ ] **F13** MEDIUM — Operational hygiene: stale stage names in `tasks/SKILL.md`, legacy import LEGACY_STATUS validation, document Cancelado state.json shape, `task-blocked` arg shape, `resolve` legacy schema handling, post-mutation re-validation
- [ ] **F14** LOW (full sweep — Option B approved) — ~25 cosmetic/perf/housekeeping items

## Test plan

- [x] `python3 -m pytest scripts/ -v` — 252 passed, 1 failed (pre-existing on main)
- [x] `make lint` — passes (ruff + py_compile + shellcheck)
- [x] `python3 -m py_compile scripts/inline-protocols.py` — passes
- [ ] `make check-inline` should be run before merge to propagate AGENTS.md edits into 17 SKILL.md inlined blocks
- [ ] CI on this PR

## Pre-existing test failure

`TestDualPlatformParity::test_claude_marketplace_has_single_optimus_plugin` asserts `plugins[0]["source"] == "."` but commit 5b73d9c (#33) changed the schema to `"./"`. The test wasn't updated. **Unrelated to this PR; reproduces on main.**