### PR TITLE
fix(deep-review): phase numbering + cross-skill contracts (F6+F7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -983,6 +983,46 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus-tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
+
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 
 **Referenced by:** all stage agents (1-4), tasks, batch
@@ -1577,7 +1617,8 @@ fi
   without an explicit `T-XXX` argument, `done` closes ONLY the task corresponding to
   the current feature branch/worktree. If the user is on the default branch with no
   task argument, `done` STOPS with an error rather than choosing a task. See
-  `done/skills/optimus-done/SKILL.md` Step 1.0.2 for the full strict-mode rule.
+  `done/skills/optimus-done/SKILL.md` (anchor `step-resolve-current-workspace`) for
+  the full strict-mode rule.
 
 **Defense-in-depth — refusal on default branch:** even after this protocol runs,
 mutating stages MUST reject execution if the current branch is still the default
@@ -2558,6 +2599,20 @@ All cycle review skills follow this pattern:
    [option] Skip
    [option] Tell me more
    ```
+
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
 
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -82,8 +82,9 @@ dependencies `DONE`. Prioritize by version (`Ativa` first), then priority, then 
 For each task:
 1. **Read status from state.json** — see AGENTS.md Protocol: State Management. Check that the task's status allows the requested starting stage
    - **Exclude tasks with status `Cancelado`** — cancelled tasks cannot be processed through the pipeline
-2. Check that all dependencies are `DONE` (read Depends from optimus-tasks.md, status for each dependency from state.json)
-3. If any task is blocked, report it and exclude from the batch
+2. Check that all dependencies are `DONE` (read Depends from optimus-tasks.md, status for each dependency from state.json — collect them into a `DEP_STATUSES` array)
+3. **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
+4. If any task is blocked, report it and exclude from the batch
 
 **NOTE:** Eligibility is re-evaluated after each task completes (Step 2.4). Tasks that
 become eligible during batch execution (e.g., because a dependency was just completed)
@@ -645,6 +646,47 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
 
 Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus-tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -164,10 +164,11 @@ _optimus_set_title ""
    - If status is `Validando Impl`, `DONE`, or `Cancelado` → **STOP**: "Task T-XXX is in '<status>'. It has already moved past this stage or was cancelled."
 3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
-   - For each dependency ID listed, read its status from state.json:
+   - For each dependency ID listed, read its status from state.json (collecting all statuses into a `DEP_STATUSES` array as you go):
      - If ALL dependencies have status `DONE` → proceed
      - If ANY dependency is NOT `DONE`:
        - Invoke notification hooks (event=`task-blocked`) — see AGENTS.md Protocol: Notification Hooks.
+       - **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
        - If the dependency has status `Cancelado` → **STOP**: `"T-YYY was cancelled (Cancelado). Consider removing this dependency via /optimus-tasks."`
        - Otherwise → **STOP**: `"Task T-XXX depends on T-YYY (status: '<status>'). T-YYY must be DONE first."`
 3.1. **Active version guard:** Check active version guard — see AGENTS.md Protocol: Active Version Guard.
@@ -949,6 +950,20 @@ All cycle review skills follow this pattern:
    [option] Tell me more
    ```
 
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
+
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
@@ -1006,6 +1021,47 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus-tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)
@@ -2170,7 +2226,8 @@ fi
   without an explicit `T-XXX` argument, `done` closes ONLY the task corresponding to
   the current feature branch/worktree. If the user is on the default branch with no
   task argument, `done` STOPS with an error rather than choosing a task. See
-  `done/skills/optimus-done/SKILL.md` Step 1.0.2 for the full strict-mode rule.
+  `done/skills/optimus-done/SKILL.md` (anchor `step-resolve-current-workspace`) for
+  the full strict-mode rule.
 
 **Defense-in-depth — refusal on default branch:** even after this protocol runs,
 mutating stages MUST reject execution if the current branch is still the default

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -675,6 +675,20 @@ All cycle review skills follow this pattern:
    [option] Tell me more
    ```
 
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
+
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -38,8 +38,9 @@ dependencies `DONE`. Prioritize by version (`Ativa` first), then priority, then 
 For each task:
 1. **Read status from state.json** — see AGENTS.md Protocol: State Management. Check that the task's status allows the requested starting stage
    - **Exclude tasks with status `Cancelado`** — cancelled tasks cannot be processed through the pipeline
-2. Check that all dependencies are `DONE` (read Depends from optimus-tasks.md, status for each dependency from state.json)
-3. If any task is blocked, report it and exclude from the batch
+2. Check that all dependencies are `DONE` (read Depends from optimus-tasks.md, status for each dependency from state.json — collect them into a `DEP_STATUSES` array)
+3. **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
+4. If any task is blocked, report it and exclude from the batch
 
 **NOTE:** Eligibility is re-evaluated after each task completes (Step 2.4). Tasks that
 become eligible during batch execution (e.g., because a dependency was just completed)
@@ -601,6 +602,47 @@ mkdir -p .optimus/sessions .optimus/reports .optimus/logs
 **Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
 
 Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus:tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)

--- a/commands/build.md
+++ b/commands/build.md
@@ -102,10 +102,11 @@ _optimus_set_title ""
    - If status is `Validando Impl`, `DONE`, or `Cancelado` → **STOP**: "Task T-XXX is in '<status>'. It has already moved past this stage or was cancelled."
 3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
-   - For each dependency ID listed, read its status from state.json:
+   - For each dependency ID listed, read its status from state.json (collecting all statuses into a `DEP_STATUSES` array as you go):
      - If ALL dependencies have status `DONE` → proceed
      - If ANY dependency is NOT `DONE`:
        - Invoke notification hooks (event=`task-blocked`) — see AGENTS.md Protocol: Notification Hooks.
+       - **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
        - If the dependency has status `Cancelado` → **STOP**: `"T-YYY was cancelled (Cancelado). Consider removing this dependency via /optimus:tasks."`
        - Otherwise → **STOP**: `"Task T-XXX depends on T-YYY (status: '<status>'). T-YYY must be DONE first."`
 3.1. **Active version guard:** Check active version guard — see AGENTS.md Protocol: Active Version Guard.
@@ -887,6 +888,20 @@ All cycle review skills follow this pattern:
    [option] Tell me more
    ```
 
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
+
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
@@ -944,6 +959,47 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus:tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)
@@ -2108,7 +2164,8 @@ fi
   without an explicit `T-XXX` argument, `done` closes ONLY the task corresponding to
   the current feature branch/worktree. If the user is on the default branch with no
   task argument, `done` STOPS with an error rather than choosing a task. See
-  `done/skills/optimus:done/SKILL.md` Step 1.0.2 for the full strict-mode rule.
+  `done/skills/optimus:done/SKILL.md` (anchor `step-resolve-current-workspace`) for
+  the full strict-mode rule.
 
 **Defense-in-depth — refusal on default branch:** even after this protocol runs,
 mutating stages MUST reject execution if the current branch is still the default

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -618,6 +618,20 @@ All cycle review skills follow this pattern:
    [option] Tell me more
    ```
 
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
+
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -577,6 +577,20 @@ All cycle review skills follow this pattern:
    [option] Tell me more
    ```
 
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
+
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.

--- a/commands/done.md
+++ b/commands/done.md
@@ -18,6 +18,7 @@ Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 
 **HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
+<a id="step-resolve-current-workspace"></a>
 ### Step 1.0.2: Resolve Current Workspace (HARD BLOCK)
 
 Use the Workspace Auto-Navigation guardrails, but for `done` apply a stricter rule:
@@ -138,10 +139,11 @@ _optimus_set_title ""
    - If status is `Cancelado` → **STOP**: "Task T-XXX was cancelled. Cannot close a cancelled task."
 3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
-   - For each dependency ID listed, read its status from state.json:
+   - For each dependency ID listed, read its status from state.json (collecting all statuses into a `DEP_STATUSES` array as you go):
      - If ALL dependencies have status `DONE` → proceed
      - If ANY dependency is NOT `DONE`:
        - Invoke notification hooks (event=`task-blocked`) — see AGENTS.md Protocol: Notification Hooks.
+       - **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
        - If the dependency has status `Cancelado` → **STOP**: `"T-YYY was cancelled (Cancelado). Consider removing this dependency via /optimus:tasks."`
        - Otherwise → **STOP**: `"Task T-XXX depends on T-YYY (status: '<status>'). T-YYY must be DONE first."`
 3.1. **Active version guard:** Check active version guard — see AGENTS.md Protocol: Active Version Guard.
@@ -759,6 +761,47 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus:tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: Default Branch Refusal (HARD BLOCK)

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -110,10 +110,11 @@ _optimus_set_title ""
      ```
 3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
-   - For each dependency ID listed, read its status from state.json:
+   - For each dependency ID listed, read its status from state.json (collecting all statuses into a `DEP_STATUSES` array as you go):
      - If ALL dependencies have status `DONE` → proceed
      - If ANY dependency is NOT `DONE`:
        - Invoke notification hooks (event=`task-blocked`) — see AGENTS.md Protocol: Notification Hooks.
+       - **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
        - If the dependency has status `Cancelado` → **STOP**: `"T-YYY was cancelled (Cancelado). Consider removing this dependency via /optimus:tasks."`
        - Otherwise → **STOP**: `"Task T-XXX depends on T-YYY (status: '<status>'). T-YYY must be DONE first."`
 3.1. **Active version guard:** Check active version guard — see AGENTS.md Protocol: Active Version Guard.
@@ -1230,6 +1231,47 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus:tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: Branch Name Derivation

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -1390,6 +1390,7 @@ This phase has TWO sub-flows with independent mode gates:
 
 **HARD BLOCK (when running):** Every thread in scope MUST receive a reply AND be resolved. Phase 14 verifies zero unresolved threads remain.
 
+<a id="step-cleanup-outdated-threads"></a>
 ### Step 13.0: Auto-resolve outdated threads (runs in `findings` and `diff` modes)
 
 For EACH thread in `outdated_threads` collected at Step 1.3.1 where `is_resolved` is `false` (skip already-resolved ones):
@@ -1970,6 +1971,20 @@ All cycle review skills follow this pattern:
    [option] Skip
    [option] Tell me more
    ```
+
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
 
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**

--- a/commands/resolve.md
+++ b/commands/resolve.md
@@ -82,7 +82,7 @@ Since Status and Branch live in state.json (gitignored, not in optimus-tasks.md)
 are limited to structural columns: ID, Title, Tipo, Depends, Priority, Version,
 Estimate, TaskSpec. No status ordering or "most-advanced-status rule" is needed.
 
-### Step 2.2: Resolve Each Conflicted Task
+### Step 2.1: Resolve Each Conflicted Task
 
 For each task that differs between current and incoming:
 
@@ -99,7 +99,7 @@ Conflicts in optimus-tasks.md are limited to structural columns only.
    - If changed on one side → keep the change
    - If changed on BOTH sides → flag for user decision (cannot auto-resolve)
 
-### Step 2.3: Handle Structural Conflicts
+### Step 2.2: Handle Structural Conflicts
 
 Since Status and Branch live in state.json (not optimus-tasks.md), conflicts are limited to
 structural fields. If both sides changed the same structural field (e.g., Priority or
@@ -163,14 +163,12 @@ Write the fully resolved `optimus-tasks.md` (no conflict markers remaining).
 
 ### Step 4.2: Validate Format
 
-Run the standard format validation (from AGENTS.md) on the resolved file:
-1. Format marker present (`<!-- optimus:tasks-v1 -->`)
-2. Versions table valid
-3. Task table columns correct
-4. All IDs, statuses, types, priorities valid
-5. No circular dependencies
-6. No duplicate IDs
-7. No unescaped pipe characters in titles
+**Validate the resolved file** — see AGENTS.md Protocol: optimus-tasks.md Validation.
+
+This protocol enforces all 15 format-validation rules (format marker, exactly-one-Ativa,
+at-most-one-Próxima, valid Tipo/Priority/Status enumerations, all Version/Depends
+references resolve to existing rows, no duplicates, no circular dependencies, no
+unescaped pipes, no empty table). Failing validation aborts the apply phase.
 
 If validation fails, inform the user and offer to fix or abort.
 
@@ -220,6 +218,38 @@ Run `/optimus:report` to verify the dashboard looks correct.
 
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
+
+### Format Validation
+
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
+1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
+2. A `## Versions` section exists with a table containing columns: Version, Status, Description
+3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
+4. Exactly one version has Status `Ativa`
+5. At most one version has Status `Próxima`
+6. A markdown table exists with columns: ID, Title, Tipo, Depends, Priority, Version (Estimate and TaskSpec are optional — tables without them are still valid). **Status and Branch columns are NOT expected** — they live in state.json.
+7. All task IDs follow the `T-NNN` pattern
+8. All Tipo values are one of: `Feature`, `Fix`, `Refactor`, `Chore`, `Docs`, `Test`
+9. All Depends values are either `-` or comma-separated valid task IDs that exist as rows in the tasks table (not just matching `T-NNN` pattern — the referenced task must actually exist)
+10. All Priority values are one of: `Alta`, `Media`, `Baixa`
+11. All Version values reference a version name that exists in the Versions table
+12. No duplicate task IDs
+13. No circular dependencies in the dependency graph (e.g., T-001 → T-002 → T-001)
+
+If the format marker is missing or validation fails, the agent must **STOP** and suggest
+running `/optimus:import` to fix the format. Do NOT attempt to interpret malformed data.
+
+14. No unescaped pipe characters (`|`) in task titles (breaks markdown table parsing)
+15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
+format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
+format validation and before task identification. If zero data rows: **STOP** and inform the
+user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
+to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
+
+**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
+each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
+in the cycle so the user can fix it with `/optimus:tasks`.
+
 
 ### Protocol: Resolve Tasks Git Scope
 
@@ -380,6 +410,27 @@ Raw `git` on `$TASKS_FILE` breaks in separate-repo mode.
 project repo). `tasks_git push` pushes the tasks repo. The project repo is unaffected.
 
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
+
+
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+
+**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
+defined in the "Format Validation" section above (items 1-15). This protocol is the
+executable version:
+
+1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
+   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
+3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
+
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
+All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
+and separate-repo scopes).
+
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -153,6 +153,7 @@ IN_PROGRESS=$(printf '%s' "$STATE_JSON" | jq -r '
 - **If exactly 1 task** → use that ID as `TASK_ID` (no AskUser — resume does not change status, so there is no expanded-confirmation requirement).
 - **If N tasks** → present via `AskUser` with one option per task (`T-XXX — <title> (<status>, updated <relative-time>)`) plus **Cancel**. Do NOT offer Resume/Start fresh/Continue.
 
+<a id="step-read-task-metadata"></a>
 ### Step 2.3: Read Task Metadata (HARD BLOCK)
 
 Extract task metadata from optimus-tasks.md. The agent MUST execute the bash snippet literally;
@@ -362,6 +363,7 @@ fi
    fi
    ```
 
+<a id="step-reset-to-pendente-recovery"></a>
 3. **Worktree missing AND branch missing:**
    - **If status is `Pendente` or has no state.json entry:** present via `AskUser`:
      ```
@@ -431,6 +433,7 @@ fi
 
      - **Abort** — **STOP** with: `"Inconsistency not resolved. Investigate via /optimus:tasks edit T-$TASK_ID before retrying."`
 
+<a id="step-dry-run-short-circuit"></a>
 ### Step 3.4: Dry-Run Short-Circuit
 
 If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
@@ -438,8 +441,9 @@ If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
 - Perform Steps 3.1–3.2 normally (read-only)
 - Do NOT run `git worktree add`
 - Do NOT `cd`
-- Do NOT run the Step 3.3 Case 3 "Reset to Pendente, then /optimus:plan" recovery — if
-  reached, STOP with: `"dry-run: no recovery attempted. Re-run without dry-run to repair state."`
+- Do NOT run the "Reset to Pendente, then /optimus:plan" recovery (anchor
+  `step-reset-to-pendente-recovery`) — if reached, STOP with: `"dry-run: no recovery
+  attempted. Re-run without dry-run to repair state."`
 - Do NOT delegate to any other skill (no `Skill` tool invocation)
 - Proceed to Phase 4 and label the summary as **(dry-run, no changes applied)**
 - Skip Phase 5 entirely

--- a/commands/review.md
+++ b/commands/review.md
@@ -122,10 +122,11 @@ _optimus_set_title ""
    - If status is `Cancelado` → **STOP**: "Task T-XXX was cancelled. Cannot validate a cancelled task."
 3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
-   - For each dependency ID listed, read its status from state.json:
+   - For each dependency ID listed, read its status from state.json (collecting all statuses into a `DEP_STATUSES` array as you go):
      - If ALL dependencies have status `DONE` → proceed
      - If ANY dependency is NOT `DONE`:
        - Invoke notification hooks (event=`task-blocked`) — see AGENTS.md Protocol: Notification Hooks.
+       - **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
        - If the dependency has status `Cancelado` → **STOP**: `"T-YYY was cancelled (Cancelado). Consider removing this dependency via /optimus:tasks."`
        - Otherwise → **STOP**: `"Task T-XXX depends on T-YYY (status: '<status>'). T-YYY must be DONE first."`
 3.1. **Active version guard:** Check active version guard — see AGENTS.md Protocol: Active Version Guard.
@@ -1404,6 +1405,20 @@ All cycle review skills follow this pattern:
    [option] Tell me more
    ```
 
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
+
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
@@ -1511,6 +1526,47 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus:tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus:tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)
@@ -2767,7 +2823,8 @@ fi
   without an explicit `T-XXX` argument, `done` closes ONLY the task corresponding to
   the current feature branch/worktree. If the user is on the default branch with no
   task argument, `done` STOPS with an error rather than choosing a task. See
-  `done/skills/optimus:done/SKILL.md` Step 1.0.2 for the full strict-mode rule.
+  `done/skills/optimus:done/SKILL.md` (anchor `step-resolve-current-workspace`) for
+  the full strict-mode rule.
 
 **Defense-in-depth — refusal on default branch:** even after this protocol runs,
 mutating stages MUST reject execution if the current branch is still the default

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -466,14 +466,14 @@ Show the new table order.
 
 1. Update the status to `Cancelado` in state.json — see AGENTS.md Protocol: State Management.
 2. Remove the `branch` field from the task's entry in state.json (if branch was deleted in Step 6.1).
-4. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
+3. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" task-cancelled "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "<old status>")" "$(_optimus_sanitize "Cancelado")" 2>/dev/null &
    fi
    ```
-5. **Fire `task-blocked` hook for affected dependents:** For each non-cancelled task that
+4. **Fire `task-blocked` hook for affected dependents:** For each non-cancelled task that
    depends on T-XXX (identified in Step 6.1, item 3), fire the `task-blocked` hook:
    ```bash
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
@@ -618,8 +618,8 @@ code manually without using stage-2).
    - If target status is `Cancelado` → **STOP**: "Cannot advance to Cancelado. Use the cancel operation (`cancel T-XXX`) which handles cleanup."
 2. **Current status validation:**
    - If status is `DONE` or `Cancelado` → **STOP**: "Task T-XXX is in terminal status '<status>'. Use 'reopen' for DONE tasks."
-2. **Check dependencies (HARD BLOCK):** same rules as stage agents — all dependencies must be `DONE`.
-3. **Workspace check (warning):** If the target status is `Validando Spec` or later, verify
+3. **Check dependencies (HARD BLOCK):** same rules as stage agents — all dependencies must be `DONE`.
+4. **Workspace check (warning):** If the target status is `Validando Spec` or later, verify
    that a workspace exists for this task (stage-1 normally creates the workspace when
    setting `Validando Spec` — advancing manually bypasses this):
    - Read the `branch` field from state.json for the task (or search by task ID pattern)
@@ -632,7 +632,7 @@ code manually without using stage-2).
      - Advance anyway (I'll create the workspace manually)
      - Cancel (run /optimus:plan first to create the workspace)
      ```
-4. Warn via `AskUser`:
+5. Warn via `AskUser`:
    ```
    You are manually advancing task T-XXX status.
 
@@ -706,7 +706,7 @@ that significant rework is needed and the task should go back to implementation)
 ### Step 9.2: Apply Demotion
 
 1. Update the status in state.json to the target status — see AGENTS.md Protocol: State Management.
-3. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
+2. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -628,6 +628,20 @@ All cycle review skills follow this pattern:
    [option] Tell me more
    ```
 
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
+
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -61,6 +61,7 @@ Verify GitHub CLI — see AGENTS.md Protocol: GitHub CLI Check.
 
 **HARD BLOCK:** Find and validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
 
+<a id="step-resolve-current-workspace"></a>
 ### Step 1.0.2: Resolve Current Workspace (HARD BLOCK)
 
 Use the Workspace Auto-Navigation guardrails, but for `done` apply a stricter rule:
@@ -181,10 +182,11 @@ _optimus_set_title ""
    - If status is `Cancelado` → **STOP**: "Task T-XXX was cancelled. Cannot close a cancelled task."
 3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
-   - For each dependency ID listed, read its status from state.json:
+   - For each dependency ID listed, read its status from state.json (collecting all statuses into a `DEP_STATUSES` array as you go):
      - If ALL dependencies have status `DONE` → proceed
      - If ANY dependency is NOT `DONE`:
        - Invoke notification hooks (event=`task-blocked`) — see AGENTS.md Protocol: Notification Hooks.
+       - **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
        - If the dependency has status `Cancelado` → **STOP**: `"T-YYY was cancelled (Cancelado). Consider removing this dependency via /optimus-tasks."`
        - Otherwise → **STOP**: `"Task T-XXX depends on T-YYY (status: '<status>'). T-YYY must be DONE first."`
 3.1. **Active version guard:** Check active version guard — see AGENTS.md Protocol: Active Version Guard.
@@ -802,6 +804,47 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus-tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: Default Branch Refusal (HARD BLOCK)

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -172,10 +172,11 @@ _optimus_set_title ""
      ```
 3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
-   - For each dependency ID listed, read its status from state.json:
+   - For each dependency ID listed, read its status from state.json (collecting all statuses into a `DEP_STATUSES` array as you go):
      - If ALL dependencies have status `DONE` → proceed
      - If ANY dependency is NOT `DONE`:
        - Invoke notification hooks (event=`task-blocked`) — see AGENTS.md Protocol: Notification Hooks.
+       - **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
        - If the dependency has status `Cancelado` → **STOP**: `"T-YYY was cancelled (Cancelado). Consider removing this dependency via /optimus-tasks."`
        - Otherwise → **STOP**: `"Task T-XXX depends on T-YYY (status: '<status>'). T-YYY must be DONE first."`
 3.1. **Active version guard:** Check active version guard — see AGENTS.md Protocol: Active Version Guard.
@@ -1292,6 +1293,47 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus-tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: Branch Name Derivation

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -1462,6 +1462,7 @@ This phase has TWO sub-flows with independent mode gates:
 
 **HARD BLOCK (when running):** Every thread in scope MUST receive a reply AND be resolved. Phase 14 verifies zero unresolved threads remain.
 
+<a id="step-cleanup-outdated-threads"></a>
 ### Step 13.0: Auto-resolve outdated threads (runs in `findings` and `diff` modes)
 
 For EACH thread in `outdated_threads` collected at Step 1.3.1 where `is_resolved` is `false` (skip already-resolved ones):
@@ -2042,6 +2043,20 @@ All cycle review skills follow this pattern:
    [option] Skip
    [option] Tell me more
    ```
+
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
 
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**

--- a/resolve/skills/optimus-resolve/SKILL.md
+++ b/resolve/skills/optimus-resolve/SKILL.md
@@ -121,7 +121,7 @@ Since Status and Branch live in state.json (gitignored, not in optimus-tasks.md)
 are limited to structural columns: ID, Title, Tipo, Depends, Priority, Version,
 Estimate, TaskSpec. No status ordering or "most-advanced-status rule" is needed.
 
-### Step 2.2: Resolve Each Conflicted Task
+### Step 2.1: Resolve Each Conflicted Task
 
 For each task that differs between current and incoming:
 
@@ -138,7 +138,7 @@ Conflicts in optimus-tasks.md are limited to structural columns only.
    - If changed on one side → keep the change
    - If changed on BOTH sides → flag for user decision (cannot auto-resolve)
 
-### Step 2.3: Handle Structural Conflicts
+### Step 2.2: Handle Structural Conflicts
 
 Since Status and Branch live in state.json (not optimus-tasks.md), conflicts are limited to
 structural fields. If both sides changed the same structural field (e.g., Priority or
@@ -202,14 +202,12 @@ Write the fully resolved `optimus-tasks.md` (no conflict markers remaining).
 
 ### Step 4.2: Validate Format
 
-Run the standard format validation (from AGENTS.md) on the resolved file:
-1. Format marker present (`<!-- optimus:tasks-v1 -->`)
-2. Versions table valid
-3. Task table columns correct
-4. All IDs, statuses, types, priorities valid
-5. No circular dependencies
-6. No duplicate IDs
-7. No unescaped pipe characters in titles
+**Validate the resolved file** — see AGENTS.md Protocol: optimus-tasks.md Validation.
+
+This protocol enforces all 15 format-validation rules (format marker, exactly-one-Ativa,
+at-most-one-Próxima, valid Tipo/Priority/Status enumerations, all Version/Depends
+references resolve to existing rows, no duplicates, no circular dependencies, no
+unescaped pipes, no empty table). Failing validation aborts the apply phase.
 
 If validation fails, inform the user and offer to fix or abort.
 
@@ -259,6 +257,38 @@ Run `/optimus-report` to verify the dashboard looks correct.
 
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
+
+### Format Validation
+
+Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
+1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
+2. A `## Versions` section exists with a table containing columns: Version, Status, Description
+3. All Version Status values are valid (`Ativa`, `Próxima`, `Planejada`, `Backlog`, `Concluída`)
+4. Exactly one version has Status `Ativa`
+5. At most one version has Status `Próxima`
+6. A markdown table exists with columns: ID, Title, Tipo, Depends, Priority, Version (Estimate and TaskSpec are optional — tables without them are still valid). **Status and Branch columns are NOT expected** — they live in state.json.
+7. All task IDs follow the `T-NNN` pattern
+8. All Tipo values are one of: `Feature`, `Fix`, `Refactor`, `Chore`, `Docs`, `Test`
+9. All Depends values are either `-` or comma-separated valid task IDs that exist as rows in the tasks table (not just matching `T-NNN` pattern — the referenced task must actually exist)
+10. All Priority values are one of: `Alta`, `Media`, `Baixa`
+11. All Version values reference a version name that exists in the Versions table
+12. No duplicate task IDs
+13. No circular dependencies in the dependency graph (e.g., T-001 → T-002 → T-001)
+
+If the format marker is missing or validation fails, the agent must **STOP** and suggest
+running `/optimus-import` to fix the format. Do NOT attempt to interpret malformed data.
+
+14. No unescaped pipe characters (`|`) in task titles (breaks markdown table parsing)
+15. **Empty table handling:** If the tasks table exists but has zero data rows (only headers),
+format validation PASSES. Stage agents (1-4) MUST check for this condition immediately after
+format validation and before task identification. If zero data rows: **STOP** and inform the
+user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
+to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
+
+**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
+each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
+in the cycle so the user can fix it with `/optimus-tasks`.
+
 
 ### Protocol: Resolve Tasks Git Scope
 
@@ -419,6 +449,27 @@ Raw `git` on `$TASKS_FILE` breaks in separate-repo mode.
 project repo). `tasks_git push` pushes the tasks repo. The project repo is unaffected.
 
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
+
+
+### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+
+**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+
+Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
+defined in the "Format Validation" section above (items 1-15). This protocol is the
+executable version:
+
+1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
+   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
+2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
+3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
+
+**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
+All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
+**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
+and separate-repo scopes).
+
+Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -212,6 +212,7 @@ IN_PROGRESS=$(printf '%s' "$STATE_JSON" | jq -r '
 - **If exactly 1 task** → use that ID as `TASK_ID` (no AskUser — resume does not change status, so there is no expanded-confirmation requirement).
 - **If N tasks** → present via `AskUser` with one option per task (`T-XXX — <title> (<status>, updated <relative-time>)`) plus **Cancel**. Do NOT offer Resume/Start fresh/Continue.
 
+<a id="step-read-task-metadata"></a>
 ### Step 2.3: Read Task Metadata (HARD BLOCK)
 
 Extract task metadata from optimus-tasks.md. The agent MUST execute the bash snippet literally;
@@ -421,6 +422,7 @@ fi
    fi
    ```
 
+<a id="step-reset-to-pendente-recovery"></a>
 3. **Worktree missing AND branch missing:**
    - **If status is `Pendente` or has no state.json entry:** present via `AskUser`:
      ```
@@ -490,6 +492,7 @@ fi
 
      - **Abort** — **STOP** with: `"Inconsistency not resolved. Investigate via /optimus-tasks edit T-$TASK_ID before retrying."`
 
+<a id="step-dry-run-short-circuit"></a>
 ### Step 3.4: Dry-Run Short-Circuit
 
 If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
@@ -497,8 +500,9 @@ If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
 - Perform Steps 3.1–3.2 normally (read-only)
 - Do NOT run `git worktree add`
 - Do NOT `cd`
-- Do NOT run the Step 3.3 Case 3 "Reset to Pendente, then /optimus-plan" recovery — if
-  reached, STOP with: `"dry-run: no recovery attempted. Re-run without dry-run to repair state."`
+- Do NOT run the "Reset to Pendente, then /optimus-plan" recovery (anchor
+  `step-reset-to-pendente-recovery`) — if reached, STOP with: `"dry-run: no recovery
+  attempted. Re-run without dry-run to repair state."`
 - Do NOT delegate to any other skill (no `Skill` tool invocation)
 - Proceed to Phase 4 and label the summary as **(dry-run, no changes applied)**
 - Skip Phase 5 entirely

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -187,10 +187,11 @@ _optimus_set_title ""
    - If status is `Cancelado` → **STOP**: "Task T-XXX was cancelled. Cannot validate a cancelled task."
 3. **Check dependencies (HARD BLOCK):** Read the Depends column for this task from optimus-tasks.md.
    - If Depends is `-` → proceed (no dependencies)
-   - For each dependency ID listed, read its status from state.json:
+   - For each dependency ID listed, read its status from state.json (collecting all statuses into a `DEP_STATUSES` array as you go):
      - If ALL dependencies have status `DONE` → proceed
      - If ANY dependency is NOT `DONE`:
        - Invoke notification hooks (event=`task-blocked`) — see AGENTS.md Protocol: Notification Hooks.
+       - **Check all-deps-cancelled** — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution.
        - If the dependency has status `Cancelado` → **STOP**: `"T-YYY was cancelled (Cancelado). Consider removing this dependency via /optimus-tasks."`
        - Otherwise → **STOP**: `"Task T-XXX depends on T-YYY (status: '<status>'). T-YYY must be DONE first."`
 3.1. **Active version guard:** Check active version guard — see AGENTS.md Protocol: Active Version Guard.
@@ -1469,6 +1470,20 @@ All cycle review skills follow this pattern:
    [option] Tell me more
    ```
 
+   **Scope of the structured AskUser template:**
+
+   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
+   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
+   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
+   the template so the user gets consistent UX and the test suite can verify the contract.
+
+   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
+   admin operations like task creation/cancellation, resume reset confirmations, etc. —
+   MAY use prose. Authors should still aim for clarity and explicit option labels, but
+   the structured template is not required outside finding loops.
+
+   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
+
 9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
@@ -1576,6 +1591,47 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+
+### Protocol: All-Dependencies-Cancelled Resolution
+
+**Referenced by:** plan, build, review, done, batch
+
+When all dependencies of a task are status `Cancelado`, emit a multi-option resolution
+message AFTER the per-dependency status check (i.e., after detecting that every dep is
+`Cancelado`, before the per-dep error-and-exit). The check supplements the per-dep loop;
+it does not replace it.
+
+**Variable contract:** the caller's dep-check loop populates an array `DEP_STATUSES`
+with one status string per dependency (the same status read from `state.json` for each
+dep ID listed in the Depends column). If the existing skill code uses a different
+variable name, adapt the recipe below to match — the contract is "an iterable of
+dependency status strings".
+
+**Bash recipe:**
+
+```bash
+# Assumes DEP_STATUSES is an array of dependency status strings,
+# already populated by the caller's dep-check loop.
+ALL_CANCELLED=true
+for dep_status in "${DEP_STATUSES[@]}"; do
+  if [ "$dep_status" != "Cancelado" ]; then
+    ALL_CANCELLED=false
+    break
+  fi
+done
+
+if [ "$ALL_CANCELLED" = true ] && [ "${#DEP_STATUSES[@]}" -gt 0 ]; then
+  echo "All dependencies of $TASK_ID are cancelled. To unblock:" >&2
+  echo "  (a) remove all dependencies: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (b) replace with alternative task IDs: /optimus-tasks edit $TASK_ID" >&2
+  echo "  (c) cancel $TASK_ID: /optimus-tasks cancel $TASK_ID" >&2
+  exit 1
+fi
+# Per-dep message follows here (existing logic).
+```
+
+Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: All-Dependencies-Cancelled Resolution."
 
 
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)
@@ -2832,7 +2888,8 @@ fi
   without an explicit `T-XXX` argument, `done` closes ONLY the task corresponding to
   the current feature branch/worktree. If the user is on the default branch with no
   task argument, `done` STOPS with an error rather than choosing a task. See
-  `done/skills/optimus-done/SKILL.md` Step 1.0.2 for the full strict-mode rule.
+  `done/skills/optimus-done/SKILL.md` (anchor `step-resolve-current-workspace`) for
+  the full strict-mode rule.
 
 **Defense-in-depth — refusal on default branch:** even after this protocol runs,
 mutating stages MUST reject execution if the current branch is still the default

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -1327,21 +1327,28 @@ class TestResumeAdmin:
         )
 
     def test_resume_step_2_3_has_explicit_extraction(self):
-        """Step 2.3 must have bash extracting TASK_TITLE/TIPO/DEPENDS/VERSION with
-        non-empty assertions — prose-only is insufficient. (R1)
+        """The Read-Task-Metadata step (anchor `step-read-task-metadata`) must have
+        bash extracting TASK_TITLE/TIPO/DEPENDS/VERSION with non-empty assertions —
+        prose-only is insufficient. (R1)
+
+        Anchor-based reference replaces the verbatim numeric step ID for stability.
         """
         content = _read_skill("resume")
         body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        assert '<a id="step-read-task-metadata"></a>' in body, (
+            "resume must define a `step-read-task-metadata` anchor above the "
+            "metadata-extraction step."
+        )
         assert "TASK_ROW=" in body, (
-            "resume Step 2.3 must capture the row into TASK_ROW via awk/grep"
+            "resume read-task-metadata step must capture the row into TASK_ROW via awk/grep"
         )
         assert re.search(r"awk -F'\|'.*print\s*\$3", body) or "print $3" in body, (
-            "resume Step 2.3 must extract columns 3/4/5/7 via awk -F'|'"
+            "resume read-task-metadata step must extract columns 3/4/5/7 via awk -F'|'"
         )
         # Must loop over the captured vars and STOP if any is empty
         assert "TASK_TITLE TASK_TIPO TASK_DEPENDS TASK_VERSION" in body or \
                all(v in body for v in ["TASK_TITLE", "TASK_TIPO", "TASK_DEPENDS", "TASK_VERSION"]), (
-            "resume Step 2.3 must reference all four extracted vars"
+            "resume read-task-metadata step must reference all four extracted vars"
         )
 
     def test_resume_git_worktree_add_checks_exit(self):
@@ -1371,21 +1378,24 @@ class TestResumeAdmin:
         )
 
     def test_resume_case3_no_unsafe_plan_delegation(self):
-        """Step 3.3 Case 3 must NOT offer a bare 'Re-run /optimus-plan' option — plan's
-        anti-pulo rejects in-progress statuses. Use the chained "Reset then plan" option.
-        (R3)
+        """The Reset-to-Pendente recovery (anchor `step-reset-to-pendente-recovery`)
+        must NOT offer a bare 'Re-run /optimus-plan' option — plan's anti-pulo rejects
+        in-progress statuses. Use the chained "Reset then plan" option. (R3)
+
+        Anchor reference instead of verbatim step number keeps the test stable across
+        phase renumbering.
         """
         content = _read_skill("resume")
         body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
-        # The in-progress Case 3 sub-case must use the chained option
+        # The in-progress recovery sub-case must use the chained option
         assert "Reset to Pendente, then run /optimus-plan" in body, (
-            "resume Step 3.3 must offer 'Reset to Pendente, then run /optimus-plan'"
+            "resume reset-to-pendente recovery must offer 'Reset to Pendente, then run /optimus-plan'"
         )
         # And must not offer a bare "Re-run /optimus-plan" alongside
         case3_section = body.split("Inconsistency: T-XXX has status")[-1]
         case3_section = case3_section.split("**Abort**")[0] if "**Abort**" in case3_section else case3_section
         assert "**Re-run /optimus-plan**" not in case3_section, (
-            "resume Step 3.3 Case 3 must NOT offer a bare 'Re-run /optimus-plan' option"
+            "resume reset-to-pendente recovery must NOT offer a bare 'Re-run /optimus-plan' option"
         )
 
     def test_resume_reset_tracks_success(self):
@@ -1403,11 +1413,30 @@ class TestResumeAdmin:
         )
 
     def test_resume_dry_run_forbids_reset(self):
-        """Step 3.4 must explicitly forbid the Reset-to-Pendente recovery in dry-run mode. (R25)"""
+        """The dry-run short-circuit step (anchor `step-dry-run-short-circuit`) must
+        explicitly forbid the Reset-to-Pendente recovery (anchor
+        `step-reset-to-pendente-recovery`) in dry-run mode. (R25)
+
+        Anchor-based check stays stable across phase renumbering.
+        """
         content = _read_skill("resume")
         body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
-        assert re.search(r"Do NOT run the Step 3.3 Case 3.*Reset", body), (
-            "resume Step 3.4 must forbid the Step 3.3 Case 3 Reset-to-Pendente recovery in dry-run mode"
+        # Both anchors must be present (locating the steps is not number-dependent).
+        assert '<a id="step-dry-run-short-circuit"></a>' in body, (
+            "resume must define a `step-dry-run-short-circuit` anchor above the "
+            "dry-run short-circuit step."
+        )
+        assert '<a id="step-reset-to-pendente-recovery"></a>' in body, (
+            "resume must define a `step-reset-to-pendente-recovery` anchor above "
+            "the inconsistent-state recovery option."
+        )
+        # The dry-run section must explicitly forbid the Reset-to-Pendente recovery.
+        # Match on the action description, not on a verbatim step number.
+        assert re.search(
+            r"Do NOT run the .*Reset to Pendente.*recovery", body
+        ), (
+            "resume dry-run short-circuit must forbid the Reset-to-Pendente recovery "
+            "(prose 'Do NOT run the ... Reset to Pendente ... recovery')."
         )
 
     def test_resume_whitelists_non_terminal_status(self):
@@ -1650,10 +1679,13 @@ class TestInlineProtocolsFoundational:
 
     def test_pr_check_has_outdated_thread_cleanup(self):
         """pr-check MUST collect outdated threads into a separate `outdated_threads`
-        list (NOT discard them) and auto-resolve them in Step 13.0. Without this,
-        outdated threads remain open on the PR — CodeRabbit and similar approval
-        gates withhold approval as long as ANY thread (active or outdated) is
-        unresolved.
+        list (NOT discard them) and auto-resolve them in the cleanup step (anchor
+        `step-cleanup-outdated-threads`). Without this, outdated threads remain
+        open on the PR — CodeRabbit and similar approval gates withhold approval
+        as long as ANY thread (active or outdated) is unresolved.
+
+        References use a stable semantic anchor instead of the verbatim numeric
+        step ID so this test does not break when phases are renumbered.
         """
         path = REPO_ROOT / "pr-check/skills/optimus-pr-check/SKILL.md"
         content = path.read_text()
@@ -1662,40 +1694,41 @@ class TestInlineProtocolsFoundational:
         # references to the old discard-only model. These assertions catch regressions
         # where future edits accidentally re-introduce filter terminology.
         stale_phrases = [
-            "Outdated (filtered)",         # Step 1.3.4 summary template (F2)
-            "outdated filtered",            # Step 1.3.4 totals line (F2)
-            "filtered set",                  # Step 1.8 findings_total formula (F1)
-            "filtered out by Step 1.3.1",   # Step 1.3.3 narrative (F3)
+            "Outdated (filtered)",         # summary template (F2)
+            "outdated filtered",            # totals line (F2)
+            "filtered set",                  # findings_total formula (F1)
+            "filtered out by Step 1.3.1",   # narrative (F3)
         ]
         remaining = [p for p in stale_phrases if p in content]
         assert not remaining, (
             f"Stale 'filter/filtered' prose found in pr-check after the partition "
-            f"refactor at Step 1.3.1. The partition model replaced the old discard "
-            f"semantics; these phrases are vestigial and contradict the new flow: "
-            f"{remaining}. See Step 13.0 for the hygiene path."
+            f"refactor at the thread-collection step. The partition model replaced "
+            f"the old discard semantics; these phrases are vestigial and contradict "
+            f"the new flow: {remaining}. See the cleanup step anchored at "
+            f"`step-cleanup-outdated-threads` for the hygiene path."
         )
 
-        # Step 1.3.1 must partition into active + outdated lists, not discard.
+        # Thread-collection step must partition into active + outdated lists, not discard.
         assert "outdated_threads" in content, (
-            "pr-check Step 1.3.1 must collect outdated threads into an "
+            "pr-check thread-collection step must collect outdated threads into an "
             "`outdated_threads` list (not discard via filter). Without the list, "
-            "Step 13.0 has no input to clean up."
+            "the cleanup step has no input to clean up."
         )
         # Old discard-only language must be gone.
         assert "Filter outdated threads:** Remove all threads" not in content, (
-            "pr-check Step 1.3.1 still uses the old discard-only language for "
-            "outdated threads. Replace with the partition-into-two-lists pattern."
+            "pr-check thread-collection step still uses the old discard-only language "
+            "for outdated threads. Replace with the partition-into-two-lists pattern."
         )
-        # Step 13.0 must exist and target outdated threads.
-        assert "Step 13.0:" in content, (
-            "pr-check is missing Step 13.0 (auto-resolve outdated threads). "
-            "Outdated threads block CodeRabbit approval and must be hygienically "
-            "auto-resolved regardless of REVIEW_MODE."
+        # Cleanup step must exist (located via stable anchor) and target outdated threads.
+        assert '<a id="step-cleanup-outdated-threads"></a>' in content, (
+            "pr-check is missing the outdated-thread cleanup step (semantic anchor "
+            "`step-cleanup-outdated-threads`). Outdated threads block CodeRabbit "
+            "approval and must be hygienically auto-resolved regardless of REVIEW_MODE."
         )
         # The auto-reply text must be present so runtime LLMs use a stable phrase
-        # (Step 13.0's idempotency check matches against this exact string).
+        # (the cleanup step's idempotency check matches against this exact string).
         assert "Outdated — this thread references code that was modified" in content, (
-            "pr-check Step 13.0 must specify the exact auto-reply text. The "
+            "pr-check cleanup step must specify the exact auto-reply text. The "
             "idempotency check (skip reply if it already exists) matches this "
             "string verbatim to handle re-runs after a crash."
         )
@@ -2076,7 +2109,10 @@ class TestWorkspaceValidationHardening:
         Without this note in the canonical protocol, contributors reading
         AGENTS.md assume `done` follows the same logic as build/review and may
         introduce drift. The note tells them where to look for the strict-mode
-        rule (done/SKILL.md Step 1.0.2).
+        rule (anchored in done/SKILL.md as `step-resolve-current-workspace`).
+
+        Anchor reference instead of verbatim step number keeps the test stable
+        across phase renumbering.
         """
         content = AGENTS_MD.read_text()
         protocol_start = content.index("### Protocol: Workspace Auto-Navigation")
@@ -2091,10 +2127,17 @@ class TestWorkspaceValidationHardening:
             "Stage-specific overrides must reference `/optimus-done` explicitly."
         )
         # Must point readers at the concrete location of the strict-mode rule so
-        # they don't have to grep blindly.
-        assert "Step 1.0.2" in section, (
-            "Stage-specific overrides must point at done/SKILL.md Step 1.0.2 for "
-            "the full strict-mode rule."
+        # they don't have to grep blindly. The location is identified by a stable
+        # semantic anchor (kebab-case, prefixed `step-`) embedded in done/SKILL.md.
+        assert "step-resolve-current-workspace" in section, (
+            "Stage-specific overrides must point at the `step-resolve-current-workspace` "
+            "anchor in done/SKILL.md for the full strict-mode rule."
+        )
+        # And the anchor MUST actually exist in done/SKILL.md.
+        done_skill = (REPO_ROOT / "done/skills/optimus-done/SKILL.md").read_text()
+        assert '<a id="step-resolve-current-workspace"></a>' in done_skill, (
+            "done/SKILL.md must define the `step-resolve-current-workspace` anchor "
+            "above the workspace-resolution step."
         )
 
 
@@ -2164,4 +2207,247 @@ class TestBashBlockHygiene:
         content = AGENTS_MD.read_text()
         assert "Bash code-block contract" in content, (
             "AGENTS.md must document the bash code-block contract under Editing Rules."
+        )
+
+
+class TestSemanticAnchorConvention:
+    """Stable semantic anchors (`<a id="step-..."></a>`) replace verbatim numeric
+    step IDs in cross-skill / cross-test references. This prevents test rigidity
+    when SKILL.md phases are renumbered."""
+
+    ANCHOR_PATTERN = re.compile(r'<a id="(step|phase)-([a-z0-9][a-z0-9-]*[a-z0-9])"></a>')
+
+    def test_anchors_are_kebab_lowercase(self):
+        violations = []
+        for path in REPO_ROOT.glob("*/skills/*/SKILL.md"):
+            content = path.read_text()
+            for match in re.finditer(r'<a id="([^"]+)"></a>', content):
+                anchor = match.group(1)
+                if not self.ANCHOR_PATTERN.fullmatch(f'<a id="{anchor}"></a>'):
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}: invalid anchor '{anchor}' "
+                        f"(must be 'step-<kebab>' or 'phase-<kebab>')"
+                    )
+        assert violations == [], "\n".join(violations)
+
+    def test_no_duplicate_anchors_within_a_skill(self):
+        violations = []
+        for path in REPO_ROOT.glob("*/skills/*/SKILL.md"):
+            content = path.read_text()
+            anchors = re.findall(r'<a id="([^"]+)"></a>', content)
+            seen = set()
+            for a in anchors:
+                if a in seen:
+                    violations.append(f"{path.relative_to(REPO_ROOT)}: duplicate anchor '{a}'")
+                seen.add(a)
+        assert violations == [], "\n".join(violations)
+
+
+class TestPhaseNumberingNoGaps:
+    """Step/Phase numbering inside a phase must be sequential — no gaps allowed
+    (e.g., Step 6.2 numbered 1,2,4,5 is a bug because the markdown-rendered
+    list shows 1,2,3,4 regardless, hiding the gap from readers).
+
+    Scans ordered-list items (`^\\d+\\. `) directly under Step/Phase headings and
+    asserts the integer prefixes form a sequential 1..K range. Skips ordered
+    lists inside fenced code blocks.
+    """
+
+    # Match an ordered-list item at the start of a line (no leading spaces, since
+    # nested lists belong to a sub-context — we only check the top-level list under
+    # a heading). Captures the integer prefix.
+    OL_ITEM_RE = re.compile(r"^(\d+)\.\s+\S")
+    # Sub-numbered items like `3.1.` or `1.0.2.` — these are "labels", not list
+    # entries. They appear inline with top-level lists in some skills. Treat them
+    # as neutral: don't capture them into the sequence, but also don't reset it.
+    SUB_NUM_RE = re.compile(r"^\d+\.\d")
+    HEADING_RE = re.compile(r"^#{1,6}\s+(Step|Phase)\s+([\d.]+)\b")
+
+    def _scan_skill(self, path):
+        """Yield (heading_label, expected_seq, actual_seq) for each numbered list
+        directly under a Step/Phase heading.
+
+        Implementation: collect ALL top-level (zero-indent) `^\\d+\\. ` items
+        between consecutive Step/Phase headings as one logical group. This is
+        intentionally tolerant of intervening narrative paragraphs, tables, and
+        bold-emphasis lines, because those forms commonly appear inside a single
+        instruction list in our SKILL.md style guide. Sub-numbered items
+        (`3.1. ...`) and content inside fenced code blocks are excluded. A
+        "group" is only checked when it has >= 2 items (single-item lists are
+        meaningless for sequence detection). If the same heading section
+        contains multiple discontiguous lists (e.g., separated by another
+        heading), each is checked independently.
+        """
+        content = path.read_text()
+        # Strip the inlined-protocols block — those steps belong to AGENTS.md and
+        # are not authored in the skill body.
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+
+        lines = body.splitlines()
+        in_fence = False
+        current_heading = None
+        current_seq = []
+
+        results = []
+
+        def flush():
+            if current_heading is not None and len(current_seq) >= 2:
+                expected = list(range(1, len(current_seq) + 1))
+                results.append((current_heading, expected, list(current_seq)))
+
+        for line in lines:
+            stripped = line.lstrip()
+            # Code-fence toggle (any ``` opens or closes a fence).
+            if stripped.startswith("```"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+
+            heading = self.HEADING_RE.match(line)
+            if heading:
+                # New heading — flush any prior list, start a fresh group.
+                flush()
+                current_heading = f"{heading.group(1)} {heading.group(2)}"
+                current_seq = []
+                continue
+
+            # Sub-numbered "labels" (e.g., `3.1. **Active version guard:**`) are
+            # neutral — skip without touching state.
+            if self.SUB_NUM_RE.match(line):
+                continue
+
+            # Top-level (zero-indent) ordered-list item.
+            ol = self.OL_ITEM_RE.match(line)
+            if ol:
+                value = int(ol.group(1))
+                # If we encounter `1.` while a list is already in progress, that
+                # is the start of a NEW list — flush the prior one first. (Some
+                # Step/Phase sections legitimately contain multiple distinct
+                # numbered lists separated by prose.)
+                if value == 1 and current_seq:
+                    flush()
+                    current_seq = []
+                current_seq.append(value)
+                continue
+
+            # Everything else (prose, tables, indented continuations, blank lines)
+            # is ignored — we tolerate intervening content within a single
+            # heading's instruction list.
+
+        flush()
+        return results
+
+    def test_step_numbering_within_phase_is_sequential(self):
+        """For each numbered list directly under a Step/Phase heading, the leading
+        integer prefixes must be `range(1, K+1)` — no gaps, no duplicates, no
+        non-1 starts.
+        """
+        violations = []
+        scanned_count = 0
+        for path in sorted(REPO_ROOT.glob("*/skills/*/SKILL.md")):
+            for heading, expected, actual in self._scan_skill(path):
+                scanned_count += 1
+                if actual != expected:
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}: under '{heading}', "
+                        f"numbered list is {actual} (expected sequential {expected})"
+                    )
+        assert violations == [], (
+            "Numbering gaps found in numbered lists under Step/Phase headings:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+        # Sanity: the scanner must find a non-trivial number of lists, otherwise
+        # the test silently passes on any future SKILL.md edit that changes the
+        # heading style.
+        assert scanned_count >= 5, (
+            f"Phase-numbering scanner only found {scanned_count} numbered lists "
+            f"under Step/Phase headings — expected at least 5. The scanner "
+            f"regex may have drifted from the actual SKILL.md heading format."
+        )
+
+
+class TestAllDepsCancelledMessage:
+    """AGENTS.md Protocol: All-Dependencies-Cancelled Resolution must be referenced
+    by each stage agent that performs dependency checks."""
+
+    REQUIRED_SKILLS = ["plan", "build", "review", "done", "batch"]
+    REQUIRED_REF = "AGENTS.md Protocol: All-Dependencies-Cancelled Resolution"
+
+    def test_stage_skills_reference_all_deps_cancelled_protocol(self):
+        violations = []
+        for skill in self.REQUIRED_SKILLS:
+            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
+            content = path.read_text()
+            # Strip inlined block
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            if self.REQUIRED_REF not in body:
+                violations.append(f"{path.relative_to(REPO_ROOT)}: missing reference")
+        assert violations == [], "\n".join(violations)
+
+
+class TestResolveFullValidation:
+    """resolve Step 4.2 must reference the full Protocol: optimus-tasks.md Validation
+    rather than enumerating a subset of checks inline."""
+
+    def test_resolve_uses_full_format_validation_protocol(self):
+        """Resolve Step 4.2 must reference Protocol: optimus-tasks.md Validation
+        (full 15-item check), not enumerate a subset of checks inline."""
+        path = REPO_ROOT / "resolve" / "skills" / "optimus-resolve" / "SKILL.md"
+        content = path.read_text()
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        assert "AGENTS.md Protocol: optimus-tasks.md Validation" in body, (
+            "Resolve must reference the full validation protocol, not an inline subset."
+        )
+
+
+class TestStructuredAskUserScope:
+    """The structured AskUser template ([topic]/[option]) is required ONLY for
+    finding-decision AskUsers in cycle review skills. Documenting and enforcing
+    this scope prevents two failure modes:
+    1. Cycle review skills slipping a prose AskUser inside a finding loop.
+    2. Admin/stage skills being incorrectly flagged for using prose AskUser
+       in legitimate non-finding contexts.
+    """
+
+    # Only skills that present findings/decisions are required to use the
+    # structured template. `done` is a stage skill but presents prose
+    # confirmations (close confirmation, divergence warnings, PR-state prompts)
+    # — it is NOT a finding-loop skill, so the structured template is not
+    # required there. AGENTS.md's "Common Patterns" section formally lists
+    # plan, review, pr-check, coderabbit-review as cycle review skills, with
+    # deep-review and deep-doc-review as variants that follow the same finding
+    # presentation principles. build is included because it presents finding
+    # decisions during pre-dev artifact validation.
+    CYCLE_REVIEW_SKILLS = [
+        "plan", "build", "review",
+        "pr-check", "deep-review", "deep-doc-review", "coderabbit-review",
+    ]
+
+    def test_cycle_review_skills_use_structured_template_in_findings(self):
+        """Within Phase 5 / finding-decision sections of cycle review skills,
+        AskUser calls must include `[topic]` and `[option]` markers."""
+        # Scan each cycle review SKILL.md body, find AskUser calls (look for
+        # `AskUser` or `AskUserQuestion` mentions), and check that within
+        # finding-decision contexts (sections containing keywords like
+        # "Phase 5", "Phase 4", "for each finding", "AskUser per-finding"),
+        # the structured markers are present.
+        violations = []
+        for skill in self.CYCLE_REVIEW_SKILLS:
+            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
+            content = path.read_text()
+            # Look for the canonical [topic]/[option] template presence anywhere
+            # in the body — every cycle review skill should have at least one.
+            if "[topic]" not in content or "[option]" not in content:
+                violations.append(
+                    f"{path.relative_to(REPO_ROOT)}: cycle review skill missing "
+                    f"structured AskUser template"
+                )
+        assert violations == [], "\n".join(violations)
+
+    def test_scope_clarification_documented_in_agents_md(self):
+        """AGENTS.md must document the structured AskUser scope explicitly."""
+        content = (REPO_ROOT / "AGENTS.md").read_text()
+        assert "Scope of the structured AskUser template" in content, (
+            "AGENTS.md must document the scope of the AskUser structured template."
         )

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -518,14 +518,14 @@ Show the new table order.
 
 1. Update the status to `Cancelado` in state.json — see AGENTS.md Protocol: State Management.
 2. Remove the `branch` field from the task's entry in state.json (if branch was deleted in Step 6.1).
-4. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
+3. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
      "$HOOKS_FILE" task-cancelled "$(_optimus_sanitize "T-XXX")" "$(_optimus_sanitize "<old status>")" "$(_optimus_sanitize "Cancelado")" 2>/dev/null &
    fi
    ```
-5. **Fire `task-blocked` hook for affected dependents:** For each non-cancelled task that
+4. **Fire `task-blocked` hook for affected dependents:** For each non-cancelled task that
    depends on T-XXX (identified in Step 6.1, item 3), fire the `task-blocked` hook:
    ```bash
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
@@ -670,8 +670,8 @@ code manually without using stage-2).
    - If target status is `Cancelado` → **STOP**: "Cannot advance to Cancelado. Use the cancel operation (`cancel T-XXX`) which handles cleanup."
 2. **Current status validation:**
    - If status is `DONE` or `Cancelado` → **STOP**: "Task T-XXX is in terminal status '<status>'. Use 'reopen' for DONE tasks."
-2. **Check dependencies (HARD BLOCK):** same rules as stage agents — all dependencies must be `DONE`.
-3. **Workspace check (warning):** If the target status is `Validando Spec` or later, verify
+3. **Check dependencies (HARD BLOCK):** same rules as stage agents — all dependencies must be `DONE`.
+4. **Workspace check (warning):** If the target status is `Validando Spec` or later, verify
    that a workspace exists for this task (stage-1 normally creates the workspace when
    setting `Validando Spec` — advancing manually bypasses this):
    - Read the `branch` field from state.json for the task (or search by task ID pattern)
@@ -684,7 +684,7 @@ code manually without using stage-2).
      - Advance anyway (I'll create the workspace manually)
      - Cancel (run /optimus-plan first to create the workspace)
      ```
-4. Warn via `AskUser`:
+5. Warn via `AskUser`:
    ```
    You are manually advancing task T-XXX status.
 
@@ -758,7 +758,7 @@ that significant rework is needed and the task should go back to implementation)
 ### Step 9.2: Apply Demotion
 
 1. Update the status in state.json to the target status — see AGENTS.md Protocol: State Management.
-3. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
+2. **Invoke notification hooks (if present)** — see AGENTS.md Protocol: Notification Hooks:
    ```bash
    HOOKS_FILE=$(test -f ./tasks-hooks.sh && echo ./tasks-hooks.sh || (test -f ./docs/tasks-hooks.sh && echo ./docs/tasks-hooks.sh))
    if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then


### PR DESCRIPTION
## Summary

Third batch from deep-review session. Lands two HIGH-severity groups:
- **F6** — Phase/numbering inconsistencies + semantic anchors
- **F7** — Cross-skill contract violations

Builds on PR #35 (F1+F2+F3) and PR #36 (F4+F5).

## What's in this PR

### F6 — Phase/numbering + semantic anchors (HIGH)

**Renumbering** (4 fixes — including a bonus catch):

| File | Step/Phase | Old | New | Source |
|------|-----------|-----|-----|--------|
| resolve/SKILL.md | Phase 2 | 2.2, 2.3 | 2.1, 2.2 | deep-review |
| tasks/SKILL.md | Step 6.2 list | 1, 2, 4, 5 | 1, 2, 3, 4 | deep-review |
| tasks/SKILL.md | Step 9.2 list | 1, 3 | 1, 2 | deep-review |
| tasks/SKILL.md | **Step 8.1 list** | **1, 2, 2, 3, 4** | **1, 2, 3, 4, 5** | **bonus catch (new scanner)** |

The pr-check Step 1.3.4→1.8 "gap" the deep-review flagged was a misread — Step 13.0 lives in Phase 13, not Phase 1. Phase 1 is sequential.

**Semantic anchors** replace verbatim numeric step references in tests. 5 anchors added across 3 SKILL.md files; 4 tests refactored:

| Test | Old reference | New anchor |
|------|--------------|------------|
| test_pr_check_has_outdated_thread_cleanup | `"Step 13.0:"` | `step-cleanup-outdated-threads` |
| test_workspace_auto_navigation_documents_done_override | `"Step 1.0.2"` | `step-resolve-current-workspace` |
| test_resume_dry_run_forbids_reset | `"Step 3.3 Case 3"` | `step-dry-run-short-circuit` + `step-reset-to-pendente-recovery` |
| test_resume_step_2_3_has_explicit_extraction | `"Step 2.3"` | `step-read-task-metadata` |

**New meta-tests:**
- `TestSemanticAnchorConvention` — kebab-lowercase format + no duplicates within a SKILL
- `TestPhaseNumberingNoGaps` — scans 125 distinct numbered lists across all SKILL.md (found Step 8.1 bonus bug)

### F7 — Cross-skill contracts (HIGH)

**F7a — All-deps-cancelled resolution.** AGENTS.md mandated a multi-option message ("(a) remove all (b) replace (c) cancel T-XXX") when all of a task's deps are `Cancelado`. Zero stage skills implemented it. Fixed by:
- New `Protocol: All-Dependencies-Cancelled Resolution` in AGENTS.md with bash recipe
- 5 skills (plan, build, review, done, batch) reference the protocol via the canonical phrasing — single source of truth, propagates via inliner
- `TestAllDepsCancelledMessage` regression test

Note: dep-check loops in stage skills are prose pseudocode (no live bash). Protocol documents the `DEP_STATUSES` array contract for future migration to real bash.

**F7b — Resolve full Format Validation.** `resolve/SKILL.md` Step 4.2 enforced 7 of 15 validation rules (missing exactly-one-Ativa, Version reference resolution, etc.) — letting a malformed file slip through and HARD-BLOCK every subsequent stage agent. Replaced inline 7-item list with reference to `AGENTS.md Protocol: optimus-tasks.md Validation` (full 15-rule check). `test_resolve_uses_full_format_validation_protocol` regression.

**F7c — AskUser structured-template scope.** AGENTS.md "Finding Presentation" item 8 mandated `[topic]/[option]` template — but the wording was ambiguous: 7 cycle review skills used it, 8 admin/stage skills used prose. Clarified the rule explicitly:
- **In scope:** finding-decision AskUsers in plan, review, pr-check, coderabbit-review, deep-review, deep-doc-review, build
- **Out of scope:** status confirmations, scope choosers, admin AskUsers in done/tasks/import/resume/batch/resolve/quick-report/help

`TestStructuredAskUserScope` enforces both directions (cycle review skills MUST have markers; clarification documented).

## Test plan

- [x] `python3 -m pytest scripts/ -v` — 278 passed, 1 pre-existing failure
- [x] `make lint` — passes (ruff + py_compile + shellcheck)
- [x] `make check-inline` — clean (0 unmatched refs)
- [ ] CI on this PR

## New tests (+5 classes / ~9 tests)

| Class | Coverage |
|-------|----------|
| `TestSemanticAnchorConvention` | kebab format + no duplicates |
| `TestPhaseNumberingNoGaps` | 125 numbered lists scanned for sequential ordering |
| `TestAllDepsCancelledMessage` | 5 stage skills reference the new protocol |
| `test_resolve_uses_full_format_validation_protocol` | resolve uses canonical validation |
| `TestStructuredAskUserScope` | cycle review skills have `[topic]/[option]`, scope documented |

## Files modified
- `AGENTS.md` (new protocol + scope clarification)
- `resolve/SKILL.md` (Phase 2 renumber, Step 4.2 full validation reference)
- `tasks/SKILL.md` (Step 6.2/8.1/9.2 renumber)
- `pr-check/SKILL.md` (anchor)
- `done/SKILL.md` (anchor + dep-check protocol ref)
- `resume/SKILL.md` (3 anchors + Step 3.4 prose update)
- `plan/SKILL.md`, `build/SKILL.md`, `review/SKILL.md`, `batch/SKILL.md` (dep-check protocol ref)
- `commands/{batch,build,done,plan,pr-check,resolve,resume,review,tasks}.md` (auto-synced)
- `scripts/test_skill_consistency.py` (5 new test classes)

24 files, +1114 / -95.

## Punch list — remaining

After this PR:
- [ ] F9 (test infrastructure residual)
- [ ] F10 (metadata drift)
- [ ] F11 + F12 (done robustness + stage-agent prompt quality)
- [ ] F13 (operational hygiene)
- [ ] F14 (cosmetic/perf bucket — Option B = full sweep)
- [ ] F8 architectural decision tracked at #34