### PR TITLE
fix(deep-review): done robustness + stage-agent prompt quality (F11+F12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1587,11 +1587,30 @@ fi
        T-002 — Login page (Em Andamento) → /projeto-t-002-.../
      Which task should I continue?
      ```
-   - After task is identified, locate the worktree by task ID:
+   - After task is identified, locate the worktree. Prefer the source-of-truth
+     (state.json `branch` field) and match the porcelain output by exact
+     branch ref. Fall back to a kebab-anchored path match — never an
+     unanchored substring grep on the bare task ID, which produces false
+     positives for short IDs (e.g., `T-1` matching `T-10`, `T-100`):
      ```bash
-     git worktree list | grep -iF "<task-id>"
+     # Source-of-truth: branch from state.json (set by stage 1).
+     TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+       "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+     WORKTREE_PATH=""
+     if [ -n "$TASK_BRANCH" ]; then
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+         /^worktree / { path=$2 }
+         /^branch /   { if ($2 == br) { print path; exit } }
+       ')
+     fi
+     if [ -z "$WORKTREE_PATH" ]; then
+       # Fallback: anchored kebab-cased path-segment match (avoids T-1 vs T-10 substring collision).
+       TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+         | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+     fi
      ```
-   - **If worktree found** → change working directory to the worktree path.
+   - **If `WORKTREE_PATH` is non-empty** → change working directory to it.
    - **If worktree NOT found** → derive the branch name (Protocol: Branch Name Derivation)
      and verify it exists:
      ```bash
@@ -1659,6 +1678,63 @@ status transition.
 
 Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
 
+### Protocol: Default Branch Resolution
+
+**Referenced by:** done (cleanup), Workspace Auto-Navigation, Default Branch Refusal,
+Resolve Tasks Git Scope, Push Commits.
+
+**Why:** Several skills need to resolve the project repo's default branch (the
+branch to checkout before deleting a feature branch, the branch the workspace
+auto-navigation refuses to mutate, etc.). Non-deterministic resolutions like
+`git branch --list main master | head -1` return whichever entry git happens to
+list first — which depends on collation and on whether both branches exist
+locally. The recipe below is fully deterministic.
+
+**Recipe:**
+
+```bash
+# Deterministic default-branch resolution: prefer remote symbolic-ref
+# (origin/HEAD), then verify against `main` first, then `master`, then bail.
+DEFAULT_BRANCH=""
+if symref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+  DEFAULT_BRANCH="${symref#origin/}"
+elif git show-ref --verify --quiet refs/heads/main; then
+  DEFAULT_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master; then
+  DEFAULT_BRANCH="master"
+fi
+
+if [ -z "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: Could not determine default branch (no origin/HEAD, no main, no master)" >&2
+  exit 1
+fi
+```
+
+**Resolution order (deterministic):**
+
+1. `origin/HEAD` symbolic-ref — the canonical answer when `gh repo clone`/
+   `git clone` has set it. Fastest and works even when neither `main` nor
+   `master` exists locally.
+2. Local `refs/heads/main` — second-best signal: if the user has `main`
+   checked out at all, it is overwhelmingly the default.
+3. Local `refs/heads/master` — fall-back for legacy repos.
+4. None of the above → hard error. The user must run
+   `git remote set-head origin <branch>` (or fetch from origin) before any
+   skill that needs the default branch can proceed.
+
+**Why prefer `main` before `master` in the fallback chain:** when
+`origin/HEAD` is absent (e.g., shallow clone, fresh repo, broken remote),
+both `main` and `master` may exist locally as orphans. Probing `main` first
+biases toward the modern default rather than the historical one.
+
+**`git branch --list main master | head -1` is forbidden:** it returns
+whichever name sorts first alphabetically (`main` always wins), which only
+*happens* to look correct — but it also returns `main` when only `master`
+actually exists locally (because `head -1` on empty stdout is empty). Any
+skill that needs the default branch MUST use the recipe above.
+
+Skills reference this as: "Resolve default branch — see AGENTS.md Protocol: Default Branch Resolution."
+
 ### Protocol: Discover Review Droids
 
 **Referenced by:** deep-review, pr-check
@@ -1716,10 +1792,29 @@ Droids whose purpose is implementation, design, operations, or non-code domains:
 | **Domain specialist** | Description mentions a specific technology — include only if the project uses it | `lib-commons-reviewer` (if `go.mod` imports `lib-commons`), `multi-tenant-reviewer` (if project uses multi-tenancy), `performance-reviewer` (always relevant) |
 | **Non-reviewer (EXCLUDE)** | Description indicates implementation, design, ops, finance, planning, or infrastructure — NOT code review | See exclusion list above |
 
+**Deny-list filter (applied AFTER inclusion regex, BEFORE final selection):**
+
+If the description matches `architecture|design|planning|process|workflow|strategy`,
+EXCLUDE the agent regardless of inclusion-regex match. These words indicate the
+agent is meta-level (not code review) and should not be dispatched to review code.
+This guards against future agents whose descriptions accidentally match the
+inclusion regex's broader words (e.g., `architecture-reviewer`,
+`design-reviewer`, `process-reviewer`) — they would otherwise be dispatched
+against actual code, which is not their job.
+
+The combined logic: `(matches inclusion regex) AND NOT (matches deny regex) → include`.
+
+**Positive allow-list** (overrides deny-list for known good agents that may have
+"design" or another deny term in their descriptions accidentally): listed in the
+protocol's roster JSON (empty by default; add specific droid IDs as needed).
+Allow-list entries are matched by full droid ID (not regex) so a single
+accidental wording match cannot reopen the deny-list for an entire family of
+droids.
+
 For non-ring entries (only present when `INCLUDE_NON_RING=true`), apply the same
-description filter. Non-ring agents that pass the filter are returned in the `Non-Ring`
-group regardless of stack/domain category — the caller decides whether to default-select
-them in its UX.
+description filter AND the deny-list. Non-ring agents that pass both filters are
+returned in the `Non-Ring` group regardless of stack/domain category — the caller
+decides whether to default-select them in its UX.
 
 **Output format:**
 
@@ -1758,6 +1853,139 @@ instead of a roster. The caller is responsible for STOP semantics — typically 
 message instructing the user to install the missing droids and re-run.
 
 Skills reference this as: "Execute Protocol: Discover Review Droids — see AGENTS.md Protocol: Discover Review Droids."
+
+### Protocol: Parse CodeRabbit Review Body
+
+**Referenced by:** pr-check, coderabbit-review
+
+Deterministic algorithm for extracting actionable findings from a CodeRabbit
+review-body GraphQL response. Both pr-check and coderabbit-review consume the
+same source format; this protocol is the single source of truth so the two
+skills cannot drift in their parsing rules. Drift is exactly how CodeRabbit
+findings get silently dropped — see the historical "duplicate comments missed"
+incident that motivated the count-parity guard below.
+
+**Source data — GraphQL fields fetched:**
+
+The CodeRabbit review body is obtained via the GitHub GraphQL API:
+
+```graphql
+pullRequest(number: $pr) {
+  reviews(first: 100) {
+    nodes {
+      author { login }      # filter to coderabbitai[bot]
+      body                  # markdown body containing the <details> blocks below
+      submittedAt
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+Take the **latest** review whose author is `coderabbitai[bot]`. Pagination via
+`pageInfo` is mandatory when `hasNextPage` is true.
+
+**Parsing algorithm — top-level sections:**
+
+The latest CodeRabbit review body contains zero or more of these top-level
+`<details>` blocks (each parsed via the per-section algorithm below):
+
+| Top-level summary regex | Origin tag | Description |
+|------------------------|------------|-------------|
+| `♻️ Duplicate comments \((\d+)\)` | `duplicate` | Findings repeated from previous reviews, still unresolved |
+| `⚠️ Outside diff range comments \((\d+)\)` | `outside-diff` | Findings about code outside the PR diff |
+| `🤖 Prompt for all review comments with AI agents` | `aggregate` (cross-validation only, NOT a per-finding source) | Aggregate flat-list block used to cross-check the per-finding parse |
+
+Inline (in-diff) findings come from the per-thread GraphQL fetch (review
+threads), not from the review body — they are tagged `origin: inline` by the
+caller. The review body parser handles only the duplicate/outside-diff
+sections plus the aggregate cross-validation block.
+
+**Per-section algorithm (applied to each top-level `<details>` block):**
+
+1. **Locate the outer `<details>`** by matching the summary regex (case-sensitive).
+   Capture `N_TOTAL`. If no match: section absent (N=0) — skip.
+
+2. **Extract the outer blockquote body**, tracking nesting: every inner
+   `<details>` opens a level; every matching `</details>` closes one. Stop
+   when the outer level closes.
+
+3. **Iterate inner per-file `<details>` blocks**:
+   `<summary>(.+?) \((\d+)\)</summary>` — capture `FILE_PATH` and `K_COUNT`.
+
+4. **Within each per-file blockquote, split by `---` separators at the top
+   level** (depth == 0). Walk line-by-line, increment depth on `<details>`,
+   decrement on `</details>`; a line `^\s*---\s*$` is a separator only when
+   depth == 0.
+
+5. **Each slice = ONE finding.** Parse:
+   - First non-empty line: `` `(\d+(?:-\d+)?)`: _(⚠️ Potential issue|🛠️ Refactor suggestion|🧹 Nitpick|...)_ \| _(🔴|🟠|🟡|🔵) (Critical|Major|Minor|Trivial)_ `` — capture `LINE_RANGE`, `TYPE_LABEL`, `SEVERITY_EMOJI`, `SEVERITY_LABEL`.
+   - Next bold line `**...**` is the `TITLE`.
+   - Body until first nested `<details>` or end-of-slice is the `DESCRIPTION`.
+
+6. **Per-finding fix-block extraction.** Within each finding's slice:
+   - `FIX_LABEL` + `FIX_DIFF` — match `<details><summary>(🐛 Minimal fix|🐛 Suggested refactor)</summary>` (the two labels are mutually exclusive within one finding; if neither is present, leave both empty). **Critical:** match BOTH labels — matching only `🐛 Minimal fix` silently drops findings labeled `Suggested refactor` even when the diff is supplied.
+   - `AI_PROMPT` — match `<details><summary>🤖 Prompt for AI Agents</summary>` and capture body. **Disambiguation:** this is the per-finding prompt block, NOT the aggregate `🤖 Prompt for all review comments with AI agents` block. Both can coexist; extract independently.
+
+7. **Severity mapping:**
+
+   | Emoji | Label | Severity |
+   |-------|-------|----------|
+   | 🔴 | Critical | CRITICAL |
+   | 🟠 | Major | HIGH |
+   | 🟡 | Minor | MEDIUM |
+   | 🔵 | Trivial | LOW |
+
+**Count parity validation (HARD BLOCK on mismatch):**
+
+After parsing each section:
+- Sum per-file extracted findings → must equal `N_TOTAL`.
+- Per-file extracted count → must equal `K_COUNT` for every file.
+
+**On mismatch: STOP immediately.** Print: parsed N, expected M, file
+breakdown, missing/extra IDs. **Do NOT offer an opt-out** — a silent
+partial-set continuation is exactly the failure mode this gate prevents. The
+user must investigate the parser or CodeRabbit output before the skill can
+proceed.
+
+**Cross-validation via aggregate prompt block:**
+
+CodeRabbit emits a `<details><summary>🤖 Prompt for all review comments with AI agents</summary>` block listing findings as a flat bullet list grouped by section. Parse it independently and take the **UNION** with the per-section parse, matched by `(file, line_range)`:
+- In both → merge (per-section block is primary; aggregate description is fallback).
+- Only in one → keep, log which source surfaced it.
+- **Never take the intersection** — single-source absence is a parsing bug, not ground truth.
+
+**Outdated-thread partitioning:**
+
+Inline review threads with `isOutdated: true` are partitioned out of the
+active findings set. The original finding text is preserved in the duplicate
+comments section of the review body (CodeRabbit re-emits unresolved findings
+across reviews), so the duplicate-section parse remains the source of record
+for content. Outdated threads are typically auto-resolved by the consuming
+skill's hygiene step — see pr-check Step 13.0.
+
+**Origin tagging rules** (when presenting findings to the user, ALWAYS include
+the origin tag in the finding header):
+
+| Source | Tag |
+|--------|-----|
+| Per-thread inline review comment (in-diff) | `[CodeRabbit]` |
+| Duplicate-comments section | `[CodeRabbit — DUPLICATE]` |
+| Outside-diff-range section | `[CodeRabbit — OUTSIDE PR DIFF]` |
+| Non-CodeRabbit (Codacy/DeepSource/CI/human) | their own origin tag — NOT this protocol |
+
+**Distinguishing CodeRabbit from CI bot, duplicate, human:**
+
+This protocol handles CodeRabbit only. The caller separately identifies:
+- **CI bots** (`github-actions[bot]`, `codacy-production[bot]`, `deepsource-io[bot]`, etc.) — handled by their own per-bot parsers.
+- **Duplicate findings** (CodeRabbit's own duplicate section) — origin-tagged here, not de-duplicated against earlier reviews.
+- **Human reviewers** — every author whose login is not in the known-bot list.
+
+**Caller-specific application** (NOT part of this protocol):
+- pr-check applies CodeRabbit-as-is (`[Minimal fix]` / `[Suggested refactor]` direct application path) for nitpick-level findings — see pr-check Step 1.3.3 surrounding prose.
+- coderabbit-review always applies findings via TDD — see coderabbit-review Phase 4. The relationship between the two skills is documented in coderabbit-review/SKILL.md ("Relationship to pr-check").
+
+Skills reference this as: "Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body."
 
 ### Protocol: Divergence Warning
 
@@ -2141,6 +2369,20 @@ whether to suggest advancement or offer a re-run. This protocol replaces the sta
    - After the re-run completes, apply this protocol again (evaluate findings count)
    - There is no limit on re-runs — the user controls when to stop
 
+   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
+   context", the orchestrator MUST:
+
+   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
+      or another terminal state at the previous run's end).
+   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
+      that performs work, NOT the load-only phases).
+   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
+   4. Preserve `task_id`, `task_branch`, and any other identity fields.
+   5. After reset, normal `Protocol: Session State` updates resume.
+
+   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
+   short-circuit the re-run's loop, producing a phantom "no findings" result.
+
 5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
 
 **NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
@@ -2406,9 +2648,16 @@ Where:
 - T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
 
 **Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest)
-2. Search by task ID: `git branch --list "*<task-id>*"` or `git worktree list | grep -iF "<task-id>"`
-3. Derive from Tipo + ID + Title (always works)
+1. Read `branch` from state.json (fastest, source-of-truth).
+2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
+   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
+   ```bash
+   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
+   git worktree list --porcelain 2>/dev/null \
+     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
+   ```
+3. Derive from Tipo + ID + Title (always works).
 
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -105,44 +105,36 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
 ### Step 1.2.2: Set Terminal Title
 
-**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance. Execute this command NOW:
+**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance.
+
+**First, parse `TASK_TITLE` from optimus-tasks.md** — the title is interpolated
+into the terminal title below, and parsing it lazily (after the title is set)
+results in `optimus: BUILD T-XXX — ` with an empty trailing dash:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
+# optimus-tasks.md columns by pipe index:
+# | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# Use the same parser pattern as resume/SKILL.md Step 2.3 (Read Task Metadata).
+TASK_TITLE=$(awk -F'|' -v id="$TASK_ID" '
+  { gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2) }
+  $2 == id {
+    title=$3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+    print title
+    exit
+  }
+' "$TASKS_FILE")
+
+if [ -z "$TASK_TITLE" ]; then
+  # Non-fatal: the terminal title is informational. Fall back to a stub so the
+  # later interpolation does not produce a trailing-dash artifact.
+  TASK_TITLE="(title unavailable)"
+fi
+```
+
+Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `BUILD`:
+
+```bash
 _optimus_set_title "optimus: BUILD $TASK_ID — $TASK_TITLE"
 ```
 
@@ -328,6 +320,36 @@ results — never to write production code.
 
 For EACH subtask (sequentially, unless PARALLEL-PLAN.md allows parallel):
 
+**0. Gather prior-subtask summaries (F12a — required before dispatch):**
+
+Before dispatching `subtask_NNN`, collect short summaries of subtasks
+`001..NNN-1` so the droid has full continuity context. Without this, the droid
+for `subtask_002` does not know what `subtask_001` produced (file paths,
+exported symbols, contract decisions) and can re-derive or contradict prior
+work. Two complementary sources:
+
+- **Session/state file:** if a post-subtask state file exists in
+  `.optimus/sessions/` with a `completed_subtasks[]` array (filename + 1-line
+  summary + key files/symbols), read it.
+- **Git history (always available):** since the task started (find the
+  branch's first commit on `$TASK_BRANCH`), enumerate subtask commits:
+  ```bash
+  git log --oneline --grep='subtask_' "$(git merge-base HEAD origin/main)"..HEAD
+  ```
+  For each commit, derive the subtask number from the message and a 1-line
+  summary of files touched (`git show --stat --format= <sha>`).
+
+Compose a list of entries shaped like:
+
+```
+- subtask_001.md — Added `internal/auth/jwt.go` (SignToken, VerifyToken); updated config schema with `jwt.secret`.
+- subtask_002.md — Added `internal/auth/middleware.go` (RequireAuth); updated router to apply it on /api/*.
+```
+
+Pass this list as the **Previously completed subtasks** context block in the
+dispatch prompt below. For `subtask_001` the list is empty (and the prompt
+section says "(none — this is the first subtask)").
+
 **1. Dispatch the stack-appropriate ring droid** via `Task` tool:
 
 | Stack | Ring Droid |
@@ -344,6 +366,12 @@ For EACH subtask (sequentially, unless PARALLEL-PLAN.md allows parallel):
 - Codebase patterns discovered in Step 1.8
 - File paths for the droid to navigate (Read/Grep/Glob enabled)
 - Answers to questions from Step 1.9
+- **Previously completed subtasks:** populated by the orchestrator from prior
+  subtask state (Step 0 above). For each completed subtask: `subtask_NNN.md`
+  filename + 1-line summary of files created/modified + relevant exported
+  symbols/contracts. For `subtask_001`, this section reads `(none — this is
+  the first subtask)`. The droid uses this to avoid re-creating files,
+  re-exporting symbols, or contradicting earlier contract decisions.
 - Instruction: "Implement this subtask following TDD (RED-GREEN-REFACTOR).
   Write failing test first, then minimal implementation, then refactor."
 
@@ -2143,6 +2171,101 @@ Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
+### Protocol: Terminal Identification
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Set title (after task ID is known):**
+
+```bash
+_optimus_set_title() {
+  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
+  # tasks always run in "divorced" iTerm2 sessions where the profile's
+  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
+  # SetUserVar are both ineffective in that state, so AppleScript's
+  # `set name of s` is the only channel that actually mutates session.name.
+  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
+  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
+  # up to 4 ancestors in case of nested shells. First run triggers a macOS
+  # TCC prompt ("droid wants to control iTerm"); approving enables this
+  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
+  # unavailable — non-iTerm2 / non-macOS users get no title update.
+  local title="$1"
+  local pid="$PPID" tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+      *) break ;;
+    esac
+  done
+  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
+     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
+     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
+    osascript \
+      -e 'on run argv' \
+      -e '  set targetTty to "/dev/" & item 1 of argv' \
+      -e '  set newName to item 2 of argv' \
+      -e '  tell application "iTerm2"' \
+      -e '    repeat with w in windows' \
+      -e '      repeat with t in tabs of w' \
+      -e '        repeat with s in sessions of t' \
+      -e '          if (tty of s as string) is targetTty then' \
+      -e '            try' \
+      -e '              set name of s to newName' \
+      -e '            end try' \
+      -e '          end if' \
+      -e '        end repeat' \
+      -e '      end repeat' \
+      -e '    end repeat' \
+      -e '  end tell' \
+      -e 'end run' \
+      -- "$tty" "$title" >/dev/null 2>&1 || true
+  fi
+}
+_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+```
+
+Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+
+**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
+terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
+asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
+session list via AppleScript — that device is connected to the user's real iTerm2
+session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
+function silently no-ops.
+
+**Restore title (at stage completion or exit):**
+
+```bash
+_optimus_set_title ""
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
+"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
+channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
+will not see a title update.
+
+**Troubleshooting iTerm2 (if the title still doesn't update):**
+
+1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
+   sticky on the tab label and overrides the session name visually, even
+   when `session.name` is updated correctly underneath.
+2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
+   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
+   silent no-op.
+3. The helper requires the parent process to have a controlling TTY. Inside
+   Docker/CI without a TTY, no ancestor will resolve and the helper will
+   silently no-op.
+
+Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+
+
 ### Protocol: Workspace Auto-Navigation (HARD BLOCK)
 
 **Referenced by:** stages 2-4
@@ -2196,11 +2319,30 @@ fi
        T-002 — Login page (Em Andamento) → /projeto-t-002-.../
      Which task should I continue?
      ```
-   - After task is identified, locate the worktree by task ID:
+   - After task is identified, locate the worktree. Prefer the source-of-truth
+     (state.json `branch` field) and match the porcelain output by exact
+     branch ref. Fall back to a kebab-anchored path match — never an
+     unanchored substring grep on the bare task ID, which produces false
+     positives for short IDs (e.g., `T-1` matching `T-10`, `T-100`):
      ```bash
-     git worktree list | grep -iF "<task-id>"
+     # Source-of-truth: branch from state.json (set by stage 1).
+     TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+       "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+     WORKTREE_PATH=""
+     if [ -n "$TASK_BRANCH" ]; then
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+         /^worktree / { path=$2 }
+         /^branch /   { if ($2 == br) { print path; exit } }
+       ')
+     fi
+     if [ -z "$WORKTREE_PATH" ]; then
+       # Fallback: anchored kebab-cased path-segment match (avoids T-1 vs T-10 substring collision).
+       TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+         | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+     fi
      ```
-   - **If worktree found** → change working directory to the worktree path.
+   - **If `WORKTREE_PATH` is non-empty** → change working directory to it.
    - **If worktree NOT found** → derive the branch name (Protocol: Branch Name Derivation)
      and verify it exists:
      ```bash

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -120,11 +120,20 @@ the same interactive resolution flow from Phase 3 onward.
 
 ### Step 2.1: Parse Findings
 
-Parse the CodeRabbit output. The output may contain three types of findings:
+**Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body.**
 
-1. **Regular findings** — inline suggestions about code within the diff. Tag as `origin: inline`.
-2. **Duplicate comments** — findings CodeRabbit already reported in previous reviews that remain unresolved. Look for a `<details>` block titled "Duplicate comments" in the output. Parse each entry and tag as `origin: duplicate`.
-3. **Outside diff range comments** — suggestions about code OUTSIDE the reviewed diff. Look for a `<details>` block titled `⚠️ Outside diff range comments` in the output. Parse each entry (file path, line, suggestion) and tag as `origin: outside-diff`.
+The shared protocol is the single source of truth for the deterministic
+parsing algorithm consumed by both `coderabbit-review` and `pr-check`. It
+covers: per-section parse (regular inline / duplicate / outside-diff),
+per-finding fix-block extraction (`Minimal fix` / `Suggested refactor`), AI
+prompt capture, severity mapping, count-parity HARD BLOCK, aggregate
+cross-validation, and origin tagging.
+
+The three origin tags surfaced by the protocol:
+
+1. **Regular findings** — inline suggestions about code within the diff. `origin: inline`.
+2. **Duplicate comments** — findings CodeRabbit already reported in previous reviews that remain unresolved. `origin: duplicate`.
+3. **Outside diff range comments** — suggestions about code OUTSIDE the reviewed diff. `origin: outside-diff`.
 
 Categorize ALL findings (regardless of origin) by severity:
 
@@ -276,6 +285,16 @@ Record the decision internally. Do NOT apply any fix yet — all fixes are appli
 ## Phase 4: Apply All Approved Fixes with TDD + Agent Validation
 
 **IMPORTANT:** This phase runs ONCE, after ALL findings have been presented and ALL decisions collected in Phase 3. No fix is applied during Phase 3.
+
+**Relationship to pr-check:** `pr-check` allows direct application of CodeRabbit's
+`[Minimal fix]` or `[Suggested refactor]` blocks (path: `CodeRabbit-as-is`) for
+nitpick-level findings without requiring TDD. `coderabbit-review` always uses TDD
+for ALL findings — by design, this skill is for the case where the user wants to
+deeply understand and re-implement each suggestion, not just merge cosmetic patches.
+
+If you want as-is application of CodeRabbit's exact suggestions, use `pr-check`
+instead. If you want TDD-driven re-implementation with full author understanding,
+use `coderabbit-review`.
 
 Apply ALL approved fixes in a single pass (skipped for ignored findings). Group fixes by file
 to minimize I/O. The steps below apply to each fix within the batch — NOT sequentially
@@ -916,6 +935,140 @@ separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir
 for Ring specs) — see the File Location section above.
 
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
+
+
+### Protocol: Parse CodeRabbit Review Body
+
+**Referenced by:** pr-check, coderabbit-review
+
+Deterministic algorithm for extracting actionable findings from a CodeRabbit
+review-body GraphQL response. Both pr-check and coderabbit-review consume the
+same source format; this protocol is the single source of truth so the two
+skills cannot drift in their parsing rules. Drift is exactly how CodeRabbit
+findings get silently dropped — see the historical "duplicate comments missed"
+incident that motivated the count-parity guard below.
+
+**Source data — GraphQL fields fetched:**
+
+The CodeRabbit review body is obtained via the GitHub GraphQL API:
+
+```graphql
+pullRequest(number: $pr) {
+  reviews(first: 100) {
+    nodes {
+      author { login }      # filter to coderabbitai[bot]
+      body                  # markdown body containing the <details> blocks below
+      submittedAt
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+Take the **latest** review whose author is `coderabbitai[bot]`. Pagination via
+`pageInfo` is mandatory when `hasNextPage` is true.
+
+**Parsing algorithm — top-level sections:**
+
+The latest CodeRabbit review body contains zero or more of these top-level
+`<details>` blocks (each parsed via the per-section algorithm below):
+
+| Top-level summary regex | Origin tag | Description |
+|------------------------|------------|-------------|
+| `♻️ Duplicate comments \((\d+)\)` | `duplicate` | Findings repeated from previous reviews, still unresolved |
+| `⚠️ Outside diff range comments \((\d+)\)` | `outside-diff` | Findings about code outside the PR diff |
+| `🤖 Prompt for all review comments with AI agents` | `aggregate` (cross-validation only, NOT a per-finding source) | Aggregate flat-list block used to cross-check the per-finding parse |
+
+Inline (in-diff) findings come from the per-thread GraphQL fetch (review
+threads), not from the review body — they are tagged `origin: inline` by the
+caller. The review body parser handles only the duplicate/outside-diff
+sections plus the aggregate cross-validation block.
+
+**Per-section algorithm (applied to each top-level `<details>` block):**
+
+1. **Locate the outer `<details>`** by matching the summary regex (case-sensitive).
+   Capture `N_TOTAL`. If no match: section absent (N=0) — skip.
+
+2. **Extract the outer blockquote body**, tracking nesting: every inner
+   `<details>` opens a level; every matching `</details>` closes one. Stop
+   when the outer level closes.
+
+3. **Iterate inner per-file `<details>` blocks**:
+   `<summary>(.+?) \((\d+)\)</summary>` — capture `FILE_PATH` and `K_COUNT`.
+
+4. **Within each per-file blockquote, split by `---` separators at the top
+   level** (depth == 0). Walk line-by-line, increment depth on `<details>`,
+   decrement on `</details>`; a line `^\s*---\s*$` is a separator only when
+   depth == 0.
+
+5. **Each slice = ONE finding.** Parse:
+   - First non-empty line: `` `(\d+(?:-\d+)?)`: _(⚠️ Potential issue|🛠️ Refactor suggestion|🧹 Nitpick|...)_ \| _(🔴|🟠|🟡|🔵) (Critical|Major|Minor|Trivial)_ `` — capture `LINE_RANGE`, `TYPE_LABEL`, `SEVERITY_EMOJI`, `SEVERITY_LABEL`.
+   - Next bold line `**...**` is the `TITLE`.
+   - Body until first nested `<details>` or end-of-slice is the `DESCRIPTION`.
+
+6. **Per-finding fix-block extraction.** Within each finding's slice:
+   - `FIX_LABEL` + `FIX_DIFF` — match `<details><summary>(🐛 Minimal fix|🐛 Suggested refactor)</summary>` (the two labels are mutually exclusive within one finding; if neither is present, leave both empty). **Critical:** match BOTH labels — matching only `🐛 Minimal fix` silently drops findings labeled `Suggested refactor` even when the diff is supplied.
+   - `AI_PROMPT` — match `<details><summary>🤖 Prompt for AI Agents</summary>` and capture body. **Disambiguation:** this is the per-finding prompt block, NOT the aggregate `🤖 Prompt for all review comments with AI agents` block. Both can coexist; extract independently.
+
+7. **Severity mapping:**
+
+   | Emoji | Label | Severity |
+   |-------|-------|----------|
+   | 🔴 | Critical | CRITICAL |
+   | 🟠 | Major | HIGH |
+   | 🟡 | Minor | MEDIUM |
+   | 🔵 | Trivial | LOW |
+
+**Count parity validation (HARD BLOCK on mismatch):**
+
+After parsing each section:
+- Sum per-file extracted findings → must equal `N_TOTAL`.
+- Per-file extracted count → must equal `K_COUNT` for every file.
+
+**On mismatch: STOP immediately.** Print: parsed N, expected M, file
+breakdown, missing/extra IDs. **Do NOT offer an opt-out** — a silent
+partial-set continuation is exactly the failure mode this gate prevents. The
+user must investigate the parser or CodeRabbit output before the skill can
+proceed.
+
+**Cross-validation via aggregate prompt block:**
+
+CodeRabbit emits a `<details><summary>🤖 Prompt for all review comments with AI agents</summary>` block listing findings as a flat bullet list grouped by section. Parse it independently and take the **UNION** with the per-section parse, matched by `(file, line_range)`:
+- In both → merge (per-section block is primary; aggregate description is fallback).
+- Only in one → keep, log which source surfaced it.
+- **Never take the intersection** — single-source absence is a parsing bug, not ground truth.
+
+**Outdated-thread partitioning:**
+
+Inline review threads with `isOutdated: true` are partitioned out of the
+active findings set. The original finding text is preserved in the duplicate
+comments section of the review body (CodeRabbit re-emits unresolved findings
+across reviews), so the duplicate-section parse remains the source of record
+for content. Outdated threads are typically auto-resolved by the consuming
+skill's hygiene step — see pr-check Step 13.0.
+
+**Origin tagging rules** (when presenting findings to the user, ALWAYS include
+the origin tag in the finding header):
+
+| Source | Tag |
+|--------|-----|
+| Per-thread inline review comment (in-diff) | `[CodeRabbit]` |
+| Duplicate-comments section | `[CodeRabbit — DUPLICATE]` |
+| Outside-diff-range section | `[CodeRabbit — OUTSIDE PR DIFF]` |
+| Non-CodeRabbit (Codacy/DeepSource/CI/human) | their own origin tag — NOT this protocol |
+
+**Distinguishing CodeRabbit from CI bot, duplicate, human:**
+
+This protocol handles CodeRabbit only. The caller separately identifies:
+- **CI bots** (`github-actions[bot]`, `codacy-production[bot]`, `deepsource-io[bot]`, etc.) — handled by their own per-bot parsers.
+- **Duplicate findings** (CodeRabbit's own duplicate section) — origin-tagged here, not de-duplicated against earlier reviews.
+- **Human reviewers** — every author whose login is not in the known-bot list.
+
+**Caller-specific application** (NOT part of this protocol):
+- pr-check applies CodeRabbit-as-is (`[Minimal fix]` / `[Suggested refactor]` direct application path) for nitpick-level findings — see pr-check Step 1.3.3 surrounding prose.
+- coderabbit-review always applies findings via TDD — see coderabbit-review Phase 4. The relationship between the two skills is documented in coderabbit-review/SKILL.md ("Relationship to pr-check").
+
+Skills reference this as: "Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body."
 
 
 ### Protocol: Per-Droid Quality Checklists

--- a/commands/build.md
+++ b/commands/build.md
@@ -43,44 +43,36 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
 ### Step 1.2.2: Set Terminal Title
 
-**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance. Execute this command NOW:
+**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance.
+
+**First, parse `TASK_TITLE` from optimus-tasks.md** — the title is interpolated
+into the terminal title below, and parsing it lazily (after the title is set)
+results in `optimus: BUILD T-XXX — ` with an empty trailing dash:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
+# optimus-tasks.md columns by pipe index:
+# | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# Use the same parser pattern as resume/SKILL.md Step 2.3 (Read Task Metadata).
+TASK_TITLE=$(awk -F'|' -v id="$TASK_ID" '
+  { gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2) }
+  $2 == id {
+    title=$3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+    print title
+    exit
+  }
+' "$TASKS_FILE")
+
+if [ -z "$TASK_TITLE" ]; then
+  # Non-fatal: the terminal title is informational. Fall back to a stub so the
+  # later interpolation does not produce a trailing-dash artifact.
+  TASK_TITLE="(title unavailable)"
+fi
+```
+
+Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `BUILD`:
+
+```bash
 _optimus_set_title "optimus: BUILD $TASK_ID — $TASK_TITLE"
 ```
 
@@ -266,6 +258,36 @@ results — never to write production code.
 
 For EACH subtask (sequentially, unless PARALLEL-PLAN.md allows parallel):
 
+**0. Gather prior-subtask summaries (F12a — required before dispatch):**
+
+Before dispatching `subtask_NNN`, collect short summaries of subtasks
+`001..NNN-1` so the droid has full continuity context. Without this, the droid
+for `subtask_002` does not know what `subtask_001` produced (file paths,
+exported symbols, contract decisions) and can re-derive or contradict prior
+work. Two complementary sources:
+
+- **Session/state file:** if a post-subtask state file exists in
+  `.optimus/sessions/` with a `completed_subtasks[]` array (filename + 1-line
+  summary + key files/symbols), read it.
+- **Git history (always available):** since the task started (find the
+  branch's first commit on `$TASK_BRANCH`), enumerate subtask commits:
+  ```bash
+  git log --oneline --grep='subtask_' "$(git merge-base HEAD origin/main)"..HEAD
+  ```
+  For each commit, derive the subtask number from the message and a 1-line
+  summary of files touched (`git show --stat --format= <sha>`).
+
+Compose a list of entries shaped like:
+
+```
+- subtask_001.md — Added `internal/auth/jwt.go` (SignToken, VerifyToken); updated config schema with `jwt.secret`.
+- subtask_002.md — Added `internal/auth/middleware.go` (RequireAuth); updated router to apply it on /api/*.
+```
+
+Pass this list as the **Previously completed subtasks** context block in the
+dispatch prompt below. For `subtask_001` the list is empty (and the prompt
+section says "(none — this is the first subtask)").
+
 **1. Dispatch the stack-appropriate ring droid** via `Task` tool:
 
 | Stack | Ring Droid |
@@ -282,6 +304,12 @@ For EACH subtask (sequentially, unless PARALLEL-PLAN.md allows parallel):
 - Codebase patterns discovered in Step 1.8
 - File paths for the droid to navigate (Read/Grep/Glob enabled)
 - Answers to questions from Step 1.9
+- **Previously completed subtasks:** populated by the orchestrator from prior
+  subtask state (Step 0 above). For each completed subtask: `subtask_NNN.md`
+  filename + 1-line summary of files created/modified + relevant exported
+  symbols/contracts. For `subtask_001`, this section reads `(none — this is
+  the first subtask)`. The droid uses this to avoid re-creating files,
+  re-exporting symbols, or contradicting earlier contract decisions.
 - Instruction: "Implement this subtask following TDD (RED-GREEN-REFACTOR).
   Write failing test first, then minimal implementation, then refactor."
 
@@ -2081,6 +2109,101 @@ Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
+### Protocol: Terminal Identification
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Set title (after task ID is known):**
+
+```bash
+_optimus_set_title() {
+  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
+  # tasks always run in "divorced" iTerm2 sessions where the profile's
+  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
+  # SetUserVar are both ineffective in that state, so AppleScript's
+  # `set name of s` is the only channel that actually mutates session.name.
+  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
+  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
+  # up to 4 ancestors in case of nested shells. First run triggers a macOS
+  # TCC prompt ("droid wants to control iTerm"); approving enables this
+  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
+  # unavailable — non-iTerm2 / non-macOS users get no title update.
+  local title="$1"
+  local pid="$PPID" tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+      *) break ;;
+    esac
+  done
+  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
+     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
+     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
+    osascript \
+      -e 'on run argv' \
+      -e '  set targetTty to "/dev/" & item 1 of argv' \
+      -e '  set newName to item 2 of argv' \
+      -e '  tell application "iTerm2"' \
+      -e '    repeat with w in windows' \
+      -e '      repeat with t in tabs of w' \
+      -e '        repeat with s in sessions of t' \
+      -e '          if (tty of s as string) is targetTty then' \
+      -e '            try' \
+      -e '              set name of s to newName' \
+      -e '            end try' \
+      -e '          end if' \
+      -e '        end repeat' \
+      -e '      end repeat' \
+      -e '    end repeat' \
+      -e '  end tell' \
+      -e 'end run' \
+      -- "$tty" "$title" >/dev/null 2>&1 || true
+  fi
+}
+_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+```
+
+Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+
+**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
+terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
+asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
+session list via AppleScript — that device is connected to the user's real iTerm2
+session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
+function silently no-ops.
+
+**Restore title (at stage completion or exit):**
+
+```bash
+_optimus_set_title ""
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
+"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
+channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
+will not see a title update.
+
+**Troubleshooting iTerm2 (if the title still doesn't update):**
+
+1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
+   sticky on the tab label and overrides the session name visually, even
+   when `session.name` is updated correctly underneath.
+2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
+   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
+   silent no-op.
+3. The helper requires the parent process to have a controlling TTY. Inside
+   Docker/CI without a TTY, no ancestor will resolve and the helper will
+   silently no-op.
+
+Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+
+
 ### Protocol: Workspace Auto-Navigation (HARD BLOCK)
 
 **Referenced by:** stages 2-4
@@ -2134,11 +2257,30 @@ fi
        T-002 — Login page (Em Andamento) → /projeto-t-002-.../
      Which task should I continue?
      ```
-   - After task is identified, locate the worktree by task ID:
+   - After task is identified, locate the worktree. Prefer the source-of-truth
+     (state.json `branch` field) and match the porcelain output by exact
+     branch ref. Fall back to a kebab-anchored path match — never an
+     unanchored substring grep on the bare task ID, which produces false
+     positives for short IDs (e.g., `T-1` matching `T-10`, `T-100`):
      ```bash
-     git worktree list | grep -iF "<task-id>"
+     # Source-of-truth: branch from state.json (set by stage 1).
+     TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+       "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+     WORKTREE_PATH=""
+     if [ -n "$TASK_BRANCH" ]; then
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+         /^worktree / { path=$2 }
+         /^branch /   { if ($2 == br) { print path; exit } }
+       ')
+     fi
+     if [ -z "$WORKTREE_PATH" ]; then
+       # Fallback: anchored kebab-cased path-segment match (avoids T-1 vs T-10 substring collision).
+       TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+         | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+     fi
      ```
-   - **If worktree found** → change working directory to the worktree path.
+   - **If `WORKTREE_PATH` is non-empty** → change working directory to it.
    - **If worktree NOT found** → derive the branch name (Protocol: Branch Name Derivation)
      and verify it exists:
      ```bash

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -63,11 +63,20 @@ the same interactive resolution flow from Phase 3 onward.
 
 ### Step 2.1: Parse Findings
 
-Parse the CodeRabbit output. The output may contain three types of findings:
+**Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body.**
 
-1. **Regular findings** — inline suggestions about code within the diff. Tag as `origin: inline`.
-2. **Duplicate comments** — findings CodeRabbit already reported in previous reviews that remain unresolved. Look for a `<details>` block titled "Duplicate comments" in the output. Parse each entry and tag as `origin: duplicate`.
-3. **Outside diff range comments** — suggestions about code OUTSIDE the reviewed diff. Look for a `<details>` block titled `⚠️ Outside diff range comments` in the output. Parse each entry (file path, line, suggestion) and tag as `origin: outside-diff`.
+The shared protocol is the single source of truth for the deterministic
+parsing algorithm consumed by both `coderabbit-review` and `pr-check`. It
+covers: per-section parse (regular inline / duplicate / outside-diff),
+per-finding fix-block extraction (`Minimal fix` / `Suggested refactor`), AI
+prompt capture, severity mapping, count-parity HARD BLOCK, aggregate
+cross-validation, and origin tagging.
+
+The three origin tags surfaced by the protocol:
+
+1. **Regular findings** — inline suggestions about code within the diff. `origin: inline`.
+2. **Duplicate comments** — findings CodeRabbit already reported in previous reviews that remain unresolved. `origin: duplicate`.
+3. **Outside diff range comments** — suggestions about code OUTSIDE the reviewed diff. `origin: outside-diff`.
 
 Categorize ALL findings (regardless of origin) by severity:
 
@@ -219,6 +228,16 @@ Record the decision internally. Do NOT apply any fix yet — all fixes are appli
 ## Phase 4: Apply All Approved Fixes with TDD + Agent Validation
 
 **IMPORTANT:** This phase runs ONCE, after ALL findings have been presented and ALL decisions collected in Phase 3. No fix is applied during Phase 3.
+
+**Relationship to pr-check:** `pr-check` allows direct application of CodeRabbit's
+`[Minimal fix]` or `[Suggested refactor]` blocks (path: `CodeRabbit-as-is`) for
+nitpick-level findings without requiring TDD. `coderabbit-review` always uses TDD
+for ALL findings — by design, this skill is for the case where the user wants to
+deeply understand and re-implement each suggestion, not just merge cosmetic patches.
+
+If you want as-is application of CodeRabbit's exact suggestions, use `pr-check`
+instead. If you want TDD-driven re-implementation with full author understanding,
+use `coderabbit-review`.
 
 Apply ALL approved fixes in a single pass (skipped for ignored findings). Group fixes by file
 to minimize I/O. The steps below apply to each fix within the batch — NOT sequentially
@@ -859,6 +878,140 @@ separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir
 for Ring specs) — see the File Location section above.
 
 Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
+
+
+### Protocol: Parse CodeRabbit Review Body
+
+**Referenced by:** pr-check, coderabbit-review
+
+Deterministic algorithm for extracting actionable findings from a CodeRabbit
+review-body GraphQL response. Both pr-check and coderabbit-review consume the
+same source format; this protocol is the single source of truth so the two
+skills cannot drift in their parsing rules. Drift is exactly how CodeRabbit
+findings get silently dropped — see the historical "duplicate comments missed"
+incident that motivated the count-parity guard below.
+
+**Source data — GraphQL fields fetched:**
+
+The CodeRabbit review body is obtained via the GitHub GraphQL API:
+
+```graphql
+pullRequest(number: $pr) {
+  reviews(first: 100) {
+    nodes {
+      author { login }      # filter to coderabbitai[bot]
+      body                  # markdown body containing the <details> blocks below
+      submittedAt
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+Take the **latest** review whose author is `coderabbitai[bot]`. Pagination via
+`pageInfo` is mandatory when `hasNextPage` is true.
+
+**Parsing algorithm — top-level sections:**
+
+The latest CodeRabbit review body contains zero or more of these top-level
+`<details>` blocks (each parsed via the per-section algorithm below):
+
+| Top-level summary regex | Origin tag | Description |
+|------------------------|------------|-------------|
+| `♻️ Duplicate comments \((\d+)\)` | `duplicate` | Findings repeated from previous reviews, still unresolved |
+| `⚠️ Outside diff range comments \((\d+)\)` | `outside-diff` | Findings about code outside the PR diff |
+| `🤖 Prompt for all review comments with AI agents` | `aggregate` (cross-validation only, NOT a per-finding source) | Aggregate flat-list block used to cross-check the per-finding parse |
+
+Inline (in-diff) findings come from the per-thread GraphQL fetch (review
+threads), not from the review body — they are tagged `origin: inline` by the
+caller. The review body parser handles only the duplicate/outside-diff
+sections plus the aggregate cross-validation block.
+
+**Per-section algorithm (applied to each top-level `<details>` block):**
+
+1. **Locate the outer `<details>`** by matching the summary regex (case-sensitive).
+   Capture `N_TOTAL`. If no match: section absent (N=0) — skip.
+
+2. **Extract the outer blockquote body**, tracking nesting: every inner
+   `<details>` opens a level; every matching `</details>` closes one. Stop
+   when the outer level closes.
+
+3. **Iterate inner per-file `<details>` blocks**:
+   `<summary>(.+?) \((\d+)\)</summary>` — capture `FILE_PATH` and `K_COUNT`.
+
+4. **Within each per-file blockquote, split by `---` separators at the top
+   level** (depth == 0). Walk line-by-line, increment depth on `<details>`,
+   decrement on `</details>`; a line `^\s*---\s*$` is a separator only when
+   depth == 0.
+
+5. **Each slice = ONE finding.** Parse:
+   - First non-empty line: `` `(\d+(?:-\d+)?)`: _(⚠️ Potential issue|🛠️ Refactor suggestion|🧹 Nitpick|...)_ \| _(🔴|🟠|🟡|🔵) (Critical|Major|Minor|Trivial)_ `` — capture `LINE_RANGE`, `TYPE_LABEL`, `SEVERITY_EMOJI`, `SEVERITY_LABEL`.
+   - Next bold line `**...**` is the `TITLE`.
+   - Body until first nested `<details>` or end-of-slice is the `DESCRIPTION`.
+
+6. **Per-finding fix-block extraction.** Within each finding's slice:
+   - `FIX_LABEL` + `FIX_DIFF` — match `<details><summary>(🐛 Minimal fix|🐛 Suggested refactor)</summary>` (the two labels are mutually exclusive within one finding; if neither is present, leave both empty). **Critical:** match BOTH labels — matching only `🐛 Minimal fix` silently drops findings labeled `Suggested refactor` even when the diff is supplied.
+   - `AI_PROMPT` — match `<details><summary>🤖 Prompt for AI Agents</summary>` and capture body. **Disambiguation:** this is the per-finding prompt block, NOT the aggregate `🤖 Prompt for all review comments with AI agents` block. Both can coexist; extract independently.
+
+7. **Severity mapping:**
+
+   | Emoji | Label | Severity |
+   |-------|-------|----------|
+   | 🔴 | Critical | CRITICAL |
+   | 🟠 | Major | HIGH |
+   | 🟡 | Minor | MEDIUM |
+   | 🔵 | Trivial | LOW |
+
+**Count parity validation (HARD BLOCK on mismatch):**
+
+After parsing each section:
+- Sum per-file extracted findings → must equal `N_TOTAL`.
+- Per-file extracted count → must equal `K_COUNT` for every file.
+
+**On mismatch: STOP immediately.** Print: parsed N, expected M, file
+breakdown, missing/extra IDs. **Do NOT offer an opt-out** — a silent
+partial-set continuation is exactly the failure mode this gate prevents. The
+user must investigate the parser or CodeRabbit output before the skill can
+proceed.
+
+**Cross-validation via aggregate prompt block:**
+
+CodeRabbit emits a `<details><summary>🤖 Prompt for all review comments with AI agents</summary>` block listing findings as a flat bullet list grouped by section. Parse it independently and take the **UNION** with the per-section parse, matched by `(file, line_range)`:
+- In both → merge (per-section block is primary; aggregate description is fallback).
+- Only in one → keep, log which source surfaced it.
+- **Never take the intersection** — single-source absence is a parsing bug, not ground truth.
+
+**Outdated-thread partitioning:**
+
+Inline review threads with `isOutdated: true` are partitioned out of the
+active findings set. The original finding text is preserved in the duplicate
+comments section of the review body (CodeRabbit re-emits unresolved findings
+across reviews), so the duplicate-section parse remains the source of record
+for content. Outdated threads are typically auto-resolved by the consuming
+skill's hygiene step — see pr-check Step 13.0.
+
+**Origin tagging rules** (when presenting findings to the user, ALWAYS include
+the origin tag in the finding header):
+
+| Source | Tag |
+|--------|-----|
+| Per-thread inline review comment (in-diff) | `[CodeRabbit]` |
+| Duplicate-comments section | `[CodeRabbit — DUPLICATE]` |
+| Outside-diff-range section | `[CodeRabbit — OUTSIDE PR DIFF]` |
+| Non-CodeRabbit (Codacy/DeepSource/CI/human) | their own origin tag — NOT this protocol |
+
+**Distinguishing CodeRabbit from CI bot, duplicate, human:**
+
+This protocol handles CodeRabbit only. The caller separately identifies:
+- **CI bots** (`github-actions[bot]`, `codacy-production[bot]`, `deepsource-io[bot]`, etc.) — handled by their own per-bot parsers.
+- **Duplicate findings** (CodeRabbit's own duplicate section) — origin-tagged here, not de-duplicated against earlier reviews.
+- **Human reviewers** — every author whose login is not in the known-bot list.
+
+**Caller-specific application** (NOT part of this protocol):
+- pr-check applies CodeRabbit-as-is (`[Minimal fix]` / `[Suggested refactor]` direct application path) for nitpick-level findings — see pr-check Step 1.3.3 surrounding prose.
+- coderabbit-review always applies findings via TDD — see coderabbit-review Phase 4. The relationship between the two skills is documented in coderabbit-review/SKILL.md ("Relationship to pr-check").
+
+Skills reference this as: "Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body."
 
 
 ### Protocol: Per-Droid Quality Checklists

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -832,10 +832,29 @@ Droids whose purpose is implementation, design, operations, or non-code domains:
 | **Domain specialist** | Description mentions a specific technology — include only if the project uses it | `lib-commons-reviewer` (if `go.mod` imports `lib-commons`), `multi-tenant-reviewer` (if project uses multi-tenancy), `performance-reviewer` (always relevant) |
 | **Non-reviewer (EXCLUDE)** | Description indicates implementation, design, ops, finance, planning, or infrastructure — NOT code review | See exclusion list above |
 
+**Deny-list filter (applied AFTER inclusion regex, BEFORE final selection):**
+
+If the description matches `architecture|design|planning|process|workflow|strategy`,
+EXCLUDE the agent regardless of inclusion-regex match. These words indicate the
+agent is meta-level (not code review) and should not be dispatched to review code.
+This guards against future agents whose descriptions accidentally match the
+inclusion regex's broader words (e.g., `architecture-reviewer`,
+`design-reviewer`, `process-reviewer`) — they would otherwise be dispatched
+against actual code, which is not their job.
+
+The combined logic: `(matches inclusion regex) AND NOT (matches deny regex) → include`.
+
+**Positive allow-list** (overrides deny-list for known good agents that may have
+"design" or another deny term in their descriptions accidentally): listed in the
+protocol's roster JSON (empty by default; add specific droid IDs as needed).
+Allow-list entries are matched by full droid ID (not regex) so a single
+accidental wording match cannot reopen the deny-list for an entire family of
+droids.
+
 For non-ring entries (only present when `INCLUDE_NON_RING=true`), apply the same
-description filter. Non-ring agents that pass the filter are returned in the `Non-Ring`
-group regardless of stack/domain category — the caller decides whether to default-select
-them in its UX.
+description filter AND the deny-list. Non-ring agents that pass both filters are
+returned in the `Non-Ring` group regardless of stack/domain category — the caller
+decides whether to default-select them in its UX.
 
 **Output format:**
 

--- a/commands/done.md
+++ b/commands/done.md
@@ -78,44 +78,36 @@ message. It never offers to redo `plan`, `build`, or `review`.
 
 ### Step 1.0.3.2: Set Terminal Title
 
-**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance. Execute this command NOW:
+**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance.
+
+**First, parse `TASK_TITLE` from optimus-tasks.md** — the title is interpolated
+into the terminal title below, and parsing it lazily (after the title is set)
+results in `optimus: DONE T-XXX — ` with an empty trailing dash:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
+# optimus-tasks.md columns by pipe index:
+# | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# Use the same parser pattern as resume/SKILL.md Step 2.3 (Read Task Metadata).
+TASK_TITLE=$(awk -F'|' -v id="$TASK_ID" '
+  { gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2) }
+  $2 == id {
+    title=$3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+    print title
+    exit
+  }
+' "$TASKS_FILE")
+
+if [ -z "$TASK_TITLE" ]; then
+  # Non-fatal: the terminal title is informational. Fall back to a stub so the
+  # later interpolation does not produce a trailing-dash artifact.
+  TASK_TITLE="(title unavailable)"
+fi
+```
+
+Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `DONE`:
+
+```bash
 _optimus_set_title "optimus: DONE $TASK_ID — $TASK_TITLE"
 ```
 
@@ -314,11 +306,37 @@ This phase runs ONLY after the task has been marked as `DONE` (or `Cancelado`).
 
 **IMPORTANT:** Worktree must be removed BEFORE attempting branch deletion.
 
+Resolve the worktree from the source-of-truth: read the task's branch from
+state.json (set by Workspace Auto-Navigation in earlier stages), then match it
+against `git worktree list --porcelain`. This avoids substring false positives
+on short task IDs (e.g., `T-1` matching `T-10`, `T-100`).
+
 ```bash
-git worktree list | grep -iF "T-XXX"
+# Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="${MAIN_WORKTREE:-$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')}"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+
+WORKTREE_PATH=""
+if [ -n "$TASK_BRANCH" ]; then
+  # Match by branch (exact, deterministic) — porcelain output has one
+  # `worktree <path>` line followed by `branch refs/heads/<name>` per entry.
+  WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+    /^worktree / { path=$2 }
+    /^branch /   { if ($2 == br) { print path; exit } }
+  ')
+fi
+
+if [ -z "$WORKTREE_PATH" ]; then
+  # Fallback: anchored kebab-cased path-segment match — never `grep -iF "$TASK_ID"`,
+  # which would match T-1 against T-10/T-100.
+  TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+  WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+    | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+fi
 ```
 
-If a worktree is found, ask via `AskUser`:
+If a worktree is found (`WORKTREE_PATH` non-empty), ask via `AskUser`:
 ```
 Task T-XXX is done. A worktree still exists at '<path>'. What should I do?
 ```
@@ -360,22 +378,87 @@ Options:
 or "Delete local only", present a final confirmation via `AskUser`:
 "This will permanently delete branch `<branch>`. Are you sure?" Options: Yes, delete / Cancel.
 
-**Before deleting:** switch to the default branch first:
+**Before deleting:** switch to the default branch first. Use the canonical
+deterministic recipe — see AGENTS.md Protocol: Default Branch Resolution.
+
 ```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-if [ -z "$DEFAULT_BRANCH" ]; then
-  DEFAULT_BRANCH=$(git branch --list main master 2>/dev/null | head -1 | tr -d ' *')
+# Resolve DEFAULT_BRANCH deterministically — see AGENTS.md Protocol: Default Branch Resolution.
+DEFAULT_BRANCH=""
+if symref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+  DEFAULT_BRANCH="${symref#origin/}"
+elif git show-ref --verify --quiet refs/heads/main; then
+  DEFAULT_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master; then
+  DEFAULT_BRANCH="master"
 fi
 if [ -z "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: Cannot determine default branch. Set it with: git remote set-head origin <branch>"
+  echo "ERROR: Could not determine default branch (no origin/HEAD, no main, no master)." >&2
+  echo "       Set it with: git remote set-head origin <branch>" >&2
   # STOP — do not proceed with branch deletion
 fi
 git checkout "$DEFAULT_BRANCH"
 git pull
-git branch -d "$TASK_BRANCH" 2>/dev/null || git branch -D "$TASK_BRANCH"
-# If also deleting remote:
-git push origin --delete "$TASK_BRANCH"
+
+# Local delete first; -d (safe) preferred over -D
+if ! git branch -d "$TASK_BRANCH" 2>/dev/null; then
+  if ! LOCAL_DELETE_OUTPUT=$(git branch -D "$TASK_BRANCH" 2>&1); then
+    echo "ERROR: Could not delete local branch $TASK_BRANCH: $LOCAL_DELETE_OUTPUT" >&2
+    # AskUser:
+    #   "Local branch delete failed. How should I proceed?"
+    #   - **Continue cleanup anyway** — proceed (e.g., the user will clean up manually)
+    #   - **Abort cleanup** — STOP without attempting remote deletion
+  fi
+fi
+
+# Remote delete with explicit failure-cause classification.
+# `DELETE_REMOTE` is "yes" only when the user picked "Delete local and remote".
+if [ "$DELETE_REMOTE" = "yes" ]; then
+  if ! PUSH_OUTPUT=$(git push origin --delete "$TASK_BRANCH" 2>&1); then
+    PUSH_RC=$?
+    # Classify the failure so the user gets actionable diagnostics.
+    case "$PUSH_OUTPUT" in
+      *"remote ref does not exist"*|*"deleted reference"*)
+        echo "ℹ Remote branch already deleted upstream (rc=$PUSH_RC) — local cleanup complete." >&2
+        REMOTE_DELETE_RESULT="already-deleted"
+        ;;
+      *"protected branch"*|*"protection"*)
+        echo "✗ Remote branch is protected — cannot delete (rc=$PUSH_RC)." >&2
+        echo "  Local branch deleted; remote branch will need manual cleanup or branch-protection adjustment." >&2
+        REMOTE_DELETE_RESULT="protected"
+        ;;
+      *"could not read"*|*"unable to access"*|*"connection"*|*"timed out"*|*"timeout"*|*"Network"*)
+        echo "✗ Network error pushing branch deletion (rc=$PUSH_RC):" >&2
+        echo "  $PUSH_OUTPUT" >&2
+        echo "  Local branch deleted; retry or run \`git push origin --delete $TASK_BRANCH\` manually after restoring connectivity." >&2
+        REMOTE_DELETE_RESULT="network-error"
+        ;;
+      *)
+        echo "✗ Remote branch delete failed (rc=$PUSH_RC): $PUSH_OUTPUT" >&2
+        REMOTE_DELETE_RESULT="other-error"
+        ;;
+    esac
+
+    # AskUser (integrate the classification message above into the body):
+    #   "Remote branch deletion failed (<classification>). What should I do?"
+    #   - **Ignore and continue** — leave the remote branch as is (logged with `pending-remote-delete`)
+    #   - **Retry now** — re-run `git push origin --delete "$TASK_BRANCH"` once
+    #   - **Abort cleanup** — STOP; user will resolve manually
+    #
+    # Notify the user via Hooks if available (event=`pending-remote-delete`).
+    # Tag the task in state.json with `pending_remote_delete: true` so a future
+    # operation (e.g., a follow-up `done`, or a maintenance script) can retry.
+  else
+    REMOTE_DELETE_RESULT="ok"
+  fi
+fi
 ```
+
+**Partial-state contract on failure:** if remote deletion fails after local
+deletion succeeds, the task is `DONE` and the local branch is gone, but the
+remote branch may persist. The task is flagged with `pending_remote_delete`
+in state.json so it can be retried later. The Cleanup Summary (Step 4.3) MUST
+reflect this partial state — do NOT report "Deleted" for the remote when the
+push failed.
 
 ### Step 4.3: Cleanup Summary
 
@@ -838,6 +921,64 @@ status transition.
 Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
 
 
+### Protocol: Default Branch Resolution
+
+**Referenced by:** done (cleanup), Workspace Auto-Navigation, Default Branch Refusal,
+Resolve Tasks Git Scope, Push Commits.
+
+**Why:** Several skills need to resolve the project repo's default branch (the
+branch to checkout before deleting a feature branch, the branch the workspace
+auto-navigation refuses to mutate, etc.). Non-deterministic resolutions like
+`git branch --list main master | head -1` return whichever entry git happens to
+list first — which depends on collation and on whether both branches exist
+locally. The recipe below is fully deterministic.
+
+**Recipe:**
+
+```bash
+# Deterministic default-branch resolution: prefer remote symbolic-ref
+# (origin/HEAD), then verify against `main` first, then `master`, then bail.
+DEFAULT_BRANCH=""
+if symref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+  DEFAULT_BRANCH="${symref#origin/}"
+elif git show-ref --verify --quiet refs/heads/main; then
+  DEFAULT_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master; then
+  DEFAULT_BRANCH="master"
+fi
+
+if [ -z "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: Could not determine default branch (no origin/HEAD, no main, no master)" >&2
+  exit 1
+fi
+```
+
+**Resolution order (deterministic):**
+
+1. `origin/HEAD` symbolic-ref — the canonical answer when `gh repo clone`/
+   `git clone` has set it. Fastest and works even when neither `main` nor
+   `master` exists locally.
+2. Local `refs/heads/main` — second-best signal: if the user has `main`
+   checked out at all, it is overwhelmingly the default.
+3. Local `refs/heads/master` — fall-back for legacy repos.
+4. None of the above → hard error. The user must run
+   `git remote set-head origin <branch>` (or fetch from origin) before any
+   skill that needs the default branch can proceed.
+
+**Why prefer `main` before `master` in the fallback chain:** when
+`origin/HEAD` is absent (e.g., shallow clone, fresh repo, broken remote),
+both `main` and `master` may exist locally as orphans. Probing `main` first
+biases toward the modern default rather than the historical one.
+
+**`git branch --list main master | head -1` is forbidden:** it returns
+whichever name sorts first alphabetically (`main` always wins), which only
+*happens* to look correct — but it also returns `main` when only `master`
+actually exists locally (because `head -1` on empty stdout is empty). Any
+skill that needs the default branch MUST use the recipe above.
+
+Skills reference this as: "Resolve default branch — see AGENTS.md Protocol: Default Branch Resolution."
+
+
 ### Protocol: Divergence Warning
 
 **Referenced by:** all stage agents (1-4)
@@ -1169,6 +1310,101 @@ and offer to run reconciliation before proceeding. This prevents tasks from sile
 appearing as `Pendente` when they actually have active worktrees.
 
 Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: State Management."
+
+
+### Protocol: Terminal Identification
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Set title (after task ID is known):**
+
+```bash
+_optimus_set_title() {
+  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
+  # tasks always run in "divorced" iTerm2 sessions where the profile's
+  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
+  # SetUserVar are both ineffective in that state, so AppleScript's
+  # `set name of s` is the only channel that actually mutates session.name.
+  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
+  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
+  # up to 4 ancestors in case of nested shells. First run triggers a macOS
+  # TCC prompt ("droid wants to control iTerm"); approving enables this
+  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
+  # unavailable — non-iTerm2 / non-macOS users get no title update.
+  local title="$1"
+  local pid="$PPID" tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+      *) break ;;
+    esac
+  done
+  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
+     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
+     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
+    osascript \
+      -e 'on run argv' \
+      -e '  set targetTty to "/dev/" & item 1 of argv' \
+      -e '  set newName to item 2 of argv' \
+      -e '  tell application "iTerm2"' \
+      -e '    repeat with w in windows' \
+      -e '      repeat with t in tabs of w' \
+      -e '        repeat with s in sessions of t' \
+      -e '          if (tty of s as string) is targetTty then' \
+      -e '            try' \
+      -e '              set name of s to newName' \
+      -e '            end try' \
+      -e '          end if' \
+      -e '        end repeat' \
+      -e '      end repeat' \
+      -e '    end repeat' \
+      -e '  end tell' \
+      -e 'end run' \
+      -- "$tty" "$title" >/dev/null 2>&1 || true
+  fi
+}
+_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+```
+
+Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+
+**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
+terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
+asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
+session list via AppleScript — that device is connected to the user's real iTerm2
+session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
+function silently no-ops.
+
+**Restore title (at stage completion or exit):**
+
+```bash
+_optimus_set_title ""
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
+"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
+channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
+will not see a title update.
+
+**Troubleshooting iTerm2 (if the title still doesn't update):**
+
+1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
+   sticky on the tab label and overrides the session name visually, even
+   when `session.name` is updated correctly underneath.
+2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
+   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
+   silent no-op.
+3. The helper requires the parent process to have a controlling TTY. Inside
+   Docker/CI without a TTY, no ancestor will resolve and the helper will
+   silently no-op.
+
+Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -48,44 +48,36 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
 ### Step 1.0.2.2: Set Terminal Title
 
-**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance. Execute this command NOW:
+**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance.
+
+**First, parse `TASK_TITLE` from optimus-tasks.md** — the title is interpolated
+into the terminal title below, and parsing it lazily (after the title is set)
+results in `optimus: PLAN T-XXX — ` with an empty trailing dash:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
+# optimus-tasks.md columns by pipe index:
+# | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# Use the same parser pattern as resume/SKILL.md Step 2.3 (Read Task Metadata).
+TASK_TITLE=$(awk -F'|' -v id="$TASK_ID" '
+  { gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2) }
+  $2 == id {
+    title=$3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+    print title
+    exit
+  }
+' "$TASKS_FILE")
+
+if [ -z "$TASK_TITLE" ]; then
+  # Non-fatal: the terminal title is informational. Fall back to a stub so the
+  # later interpolation does not produce a trailing-dash artifact.
+  TASK_TITLE="(title unavailable)"
+fi
+```
+
+Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `PLAN`:
+
+```bash
 _optimus_set_title "optimus: PLAN $TASK_ID — $TASK_TITLE"
 ```
 
@@ -140,14 +132,33 @@ _optimus_set_title ""
 **ALWAYS run this step** — regardless of task status. This detects orphaned workspaces
 from a previous run that was interrupted (crash, user closed terminal, etc.).
 
-1. Check if any branch or worktree already exists for this task:
+1. Check if any branch or worktree already exists for this task. Use anchored
+   matches to avoid substring false positives (`T-1` against `T-10`/`T-100`).
+   Prefer state.json's `branch` field when present:
    ```bash
-   # Check for any branch matching the task ID
-   git branch --list "*<task-id>*" 2>/dev/null
-   # Check for any worktree matching the task ID
-   git worktree list | grep -iF "<task-id>"
+   # Source-of-truth: branch from state.json (fastest, set by previous plan run).
+   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+     "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+
+   # Fallback: anchored kebab-cased search (avoids T-1 vs T-10 collision).
+   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+   if [ -z "$TASK_BRANCH" ]; then
+     TASK_BRANCH=$(git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null | head -1 | tr -d ' *')
+   fi
+   WORKTREE_PATH=""
+   if [ -n "$TASK_BRANCH" ]; then
+     WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+       /^worktree / { path=$2 }
+       /^branch /   { if ($2 == br) { print path; exit } }
+     ')
+   fi
+   if [ -z "$WORKTREE_PATH" ]; then
+     WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+       | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+   fi
    ```
-2. Also read the `branch` field from state.json if available.
+2. The state.json read above already covers the "Also read the `branch` field
+   from state.json if available" step.
 3. **If a branch or worktree exists:**
    - Ask via `AskUser`:
      ```
@@ -627,7 +638,7 @@ Execute re-run guard — see AGENTS.md Protocol: Re-run Guard.
 - If the user chooses **Re-run with clean context**: go back to Step 1.1 (Discover Project
   Structure). Skip all prior setup steps (GitHub CLI check, optimus-tasks.md validation, task
   identification, session state, status validation, workspace creation, divergence check).
-  Increment stage stats before re-starting analysis.
+  Increment stage stats before re-starting analysis. Apply the **Re-run reset semantics**: reset `convergence_status` to `null`; reset `phase` to the first re-executed phase; overwrite `started_at`; preserve `task_id`, `task_branch`, `created_at`. See AGENTS.md Protocol: Re-run Guard.
 - If the user chooses **Advance** (or 0 findings): proceed to Phase 8 (Push).
 
 ## Phase 8: Push Commits
@@ -1309,9 +1320,16 @@ Where:
 - T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
 
 **Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest)
-2. Search by task ID: `git branch --list "*<task-id>*"` or `git worktree list | grep -iF "<task-id>"`
-3. Derive from Tipo + ID + Title (always works)
+1. Read `branch` from state.json (fastest, source-of-truth).
+2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
+   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
+   ```bash
+   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
+   git worktree list --porcelain 2>/dev/null \
+     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
+   ```
+3. Derive from Tipo + ID + Title (always works).
 
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 
@@ -1831,6 +1849,20 @@ whether to suggest advancement or offer a re-run. This protocol replaces the sta
    - After the re-run completes, apply this protocol again (evaluate findings count)
    - There is no limit on re-runs — the user controls when to stop
 
+   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
+   context", the orchestrator MUST:
+
+   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
+      or another terminal state at the previous run's end).
+   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
+      that performs work, NOT the load-only phases).
+   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
+   4. Preserve `task_id`, `task_branch`, and any other identity fields.
+   5. After reset, normal `Protocol: Session State` updates resume.
+
+   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
+   short-circuit the re-run's loop, producing a phantom "no findings" result.
+
 5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
 
 **NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
@@ -2270,6 +2302,101 @@ Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 7. If subtasks directory exists, read all `.md` files inside it
 
 Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
+
+
+### Protocol: Terminal Identification
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Set title (after task ID is known):**
+
+```bash
+_optimus_set_title() {
+  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
+  # tasks always run in "divorced" iTerm2 sessions where the profile's
+  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
+  # SetUserVar are both ineffective in that state, so AppleScript's
+  # `set name of s` is the only channel that actually mutates session.name.
+  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
+  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
+  # up to 4 ancestors in case of nested shells. First run triggers a macOS
+  # TCC prompt ("droid wants to control iTerm"); approving enables this
+  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
+  # unavailable — non-iTerm2 / non-macOS users get no title update.
+  local title="$1"
+  local pid="$PPID" tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+      *) break ;;
+    esac
+  done
+  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
+     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
+     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
+    osascript \
+      -e 'on run argv' \
+      -e '  set targetTty to "/dev/" & item 1 of argv' \
+      -e '  set newName to item 2 of argv' \
+      -e '  tell application "iTerm2"' \
+      -e '    repeat with w in windows' \
+      -e '      repeat with t in tabs of w' \
+      -e '        repeat with s in sessions of t' \
+      -e '          if (tty of s as string) is targetTty then' \
+      -e '            try' \
+      -e '              set name of s to newName' \
+      -e '            end try' \
+      -e '          end if' \
+      -e '        end repeat' \
+      -e '      end repeat' \
+      -e '    end repeat' \
+      -e '  end tell' \
+      -e 'end run' \
+      -- "$tty" "$title" >/dev/null 2>&1 || true
+  fi
+}
+_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+```
+
+Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+
+**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
+terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
+asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
+session list via AppleScript — that device is connected to the user's real iTerm2
+session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
+function silently no-ops.
+
+**Restore title (at stage completion or exit):**
+
+```bash
+_optimus_set_title ""
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
+"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
+channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
+will not see a title update.
+
+**Troubleshooting iTerm2 (if the title still doesn't update):**
+
+1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
+   sticky on the tab label and overrides the session name visually, even
+   when `session.name` is updated correctly underneath.
+2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
+   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
+   silent no-op.
+3. The helper requires the parent process to have a controlling TTY. Inside
+   Docker/CI without a TTY, no ancestor will resolve and the helper will
+   silently no-op.
+
+Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -313,125 +313,22 @@ Extract: severity (HIGH/MEDIUM/LOW), annotation_level, message, file, line.
 Extract: shortcode, severity, category, analyzer, title, explanation, file, line.
 
 **CodeRabbit comments** (author: `coderabbitai[bot]`):
-- Inline review comments with suggestions (from thread fetch, Step 1.3.1)
-- **Duplicated Comments section** (from review body fetch, Step 1.3.1.5): `<details>` block titled `♻️ Duplicate comments (N)` in the review body listing findings already reported in previous reviews but still unresolved. These are the findings whose inline threads typically became `isOutdated: true` (now collected into `outdated_threads` and auto-resolved hygienically by Step 13.0; the original finding text is not re-evaluated, so the Duplicate Comments review body remains the source of record for this finding's content). Parse per algorithm below and tag with `origin: duplicate`.
-- **Outside diff range section** (from review body fetch, Step 1.3.1.5): `<details>` block titled `⚠️ Outside diff range comments (N)` with suggestions about code OUTSIDE the PR diff. Parse per same algorithm and tag with `origin: outside-diff`.
 
-**Deterministic parsing algorithm (MANDATORY for both sections):**
+**Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body.**
 
-The `<details>` block for a CodeRabbit special section has this exact nested structure:
+The shared protocol covers: GraphQL fetch, per-section deterministic algorithm
+(duplicate / outside-diff sections), per-finding fix-block extraction (Minimal
+fix / Suggested refactor), AI prompt capture, severity mapping, count parity
+HARD BLOCK, aggregate cross-validation, outdated-thread partitioning, and
+origin tagging rules (`[CodeRabbit]` / `[CodeRabbit — DUPLICATE]` /
+`[CodeRabbit — OUTSIDE PR DIFF]`).
 
-```
-<details>
-<summary>♻️ Duplicate comments (N)</summary><blockquote>
-<details>
-<summary>path/to/fileA.py (K1)</summary><blockquote>
-
-`LINE_RANGE`: _⚠️ Potential issue_ | _<EMOJI> <LABEL>_
-
-**<Finding title.>**
-
-<body paragraph(s)>
-
-<details><summary>🐛 Minimal fix</summary>...diff...</details>
-<details><summary>🤖 Prompt for AI Agents</summary>...prompt...</details>
-
----
-
-`LINE_RANGE`: _⚠️ Potential issue_ | _<EMOJI> <LABEL>_
-
-**<Second finding title.>**
-
-... (same structure) ...
-
-</blockquote></details>
-
-<details>
-<summary>path/to/fileB.go (K2)</summary><blockquote>
-... (K2 findings) ...
-</blockquote></details>
-
-</blockquote></details>
-```
-
-**Steps (apply to the latest CodeRabbit review body from Step 1.3.1.5):**
-
-1. **Locate the outer `<details>` block.** Match the opening summary line with case-sensitive regex:
-   - For duplicates: `<summary>♻️ Duplicate comments \((\d+)\)</summary>` → capture `N_TOTAL`.
-   - For outside-diff: `<summary>⚠️ Outside diff range comments \((\d+)\)</summary>` → capture `N_TOTAL`.
-   - If no match → no findings in this section (N=0); skip parsing.
-
-2. **Extract the outer blockquote body** — everything between the `<blockquote>` right after the summary and its matching `</blockquote></details>`. Track nesting: every inner `<details>` opens a level; every matching `</details>` closes one. Stop when the outer level closes.
-
-3. **Iterate inner per-file `<details>` blocks.** Match: `<summary>(.+?) \((\d+)\)</summary>` where the filename pattern allows `/`, `.`, `_`, `-`. Capture `FILE_PATH` and `K_COUNT` per block.
-
-4. **Within each per-file blockquote, split by `---` separator at the top level.** A `---` counts as a finding separator only if it is at the same nesting level as the finding headers — NOT inside any nested `<details>`. Implementation: walk line-by-line, maintain an integer `depth` (increment on `<details>`, decrement on `</details>`); a line matching `^\s*---\s*$` is a separator **only when `depth == 0`**.
-
-5. **Each resulting slice is ONE finding.** Parse its header:
-   - First non-empty line: `` `(\d+(?:-\d+)?)`: _(⚠️ Potential issue|🛠️ Refactor suggestion|🧹 Nitpick|...)_ \| _(🔴|🟠|🟡|🔵) (Critical|Major|Minor|Trivial)_ ``
-   - Capture `LINE_RANGE`, `TYPE_LABEL`, `SEVERITY_EMOJI`, `SEVERITY_LABEL`.
-   - Next bold line (`**...**`) is the `TITLE`.
-   - Everything until the first nested `<details>` or end-of-slice is the `DESCRIPTION`.
-   - **Fix suggestion (`FIX_LABEL` + `FIX_DIFF`):** if a `<details>` block exists whose summary matches one of CodeRabbit's known fix-suggestion labels, capture its body as `FIX_DIFF` and the label text as `FIX_LABEL`. Match summary against either:
-     - `🐛 Minimal fix`
-     - `🐛 Suggested refactor`
-
-     Implementation: regex `<details><summary>(🐛 Minimal fix|🐛 Suggested refactor)</summary>`. Body capture is non-greedy until the matching `</details>` at the same nesting depth — reuse the depth-walking approach from Step 4. The two labels are mutually exclusive within a finding (CodeRabbit picks one); if neither is present, leave both fields empty. **Do NOT match `🐛 Minimal fix` alone** — the legacy single-label match silently dropped findings labeled `Suggested refactor`, even though CodeRabbit had supplied a usable diff.
-   - **AI agent prompt (`AI_PROMPT`):** if a `<details><summary>🤖 Prompt for AI Agents</summary>` exists within the finding slice, capture its content as `AI_PROMPT`. **Important disambiguation:** this is the per-finding prompt block. Do NOT confuse it with the aggregate `🤖 Prompt for all review comments with AI agents` block at the end of the review body, which lives outside any per-finding slice and is consumed separately for cross-validation (see "Cross-validation fallback" below). Both blocks may coexist in the same review body — they are extracted independently. Leave `AI_PROMPT` empty if absent.
-
-6. **Severity mapping:**
-   | Emoji | Label | Severity |
-   |-------|-------|----------|
-   | 🔴 | Critical | CRITICAL |
-   | 🟠 | Major | HIGH |
-   | 🟡 | Minor | MEDIUM |
-   | 🔵 | Trivial | LOW |
-
-7. **Count validation (HARD BLOCK):** After parsing:
-   - Sum per-file extracted findings → must equal `N_TOTAL` from the outer summary.
-   - Per-file extracted count → must equal `K_COUNT` from that file's summary.
-   - **On mismatch: STOP.** Print: `"Parser extracted X of N duplicate comments from review <id>. Aborting to prevent silent loss. Expected N=<N>, got X=<X>. File breakdown: {path: expected_K vs got_K}. Investigate the review body format."` Then ask the user via `AskUser` whether to proceed with the partial set or abort the entire skill run.
-   - This validation is the PRIMARY guardrail against the historical bug where one of two duplicate comments was silently missed.
-   - **Scope of validation:** count parity guards against silent loss of FINDINGS, not of fix-suggestion sub-fields. A finding with empty `FIX_LABEL`/`FIX_DIFF`/`AI_PROMPT` is still a counted finding (CodeRabbit does not always supply those blocks).
-
-**Cross-validation fallback via "Prompt for all review comments" section:**
-
-CodeRabbit additionally emits a `<details>` block titled `🤖 Prompt for all review comments with AI agents` near the end of the review body. Inside its code fence, findings appear as a flat bullet list grouped by section and file:
-
-```
-Inline comments:
-In `@path/to/file.py`:
-- Around line 361-376: <description>
-- Around line 257-266: <description>
-
-Duplicate comments:
-In `@path/to/file.py`:
-- Around line 146-169: <description>
-- Around line 11-12: <description>
-
-Outside diff range comments:
-In `@path/to/other.go`:
-- Around line 42: <description>
-```
-
-**Parse this block IN ADDITION TO the `<details>` parsing:**
-1. Match: `<details>\s*<summary>🤖 Prompt for all review comments with AI agents</summary>`.
-2. Extract the code fence content.
-3. For each section header (`Inline comments:`, `Duplicate comments:`, `Outside diff range comments:`), extract bullets matching: `^- Around line ([\d\-]+):\s+(.+)$` under each `In \`@(.+?)\`:` header.
-4. Map section → origin tag (`inline`, `duplicate`, `outside-diff`).
-
-**Reconciliation (MANDATORY):** Take the **UNION** of findings from both sources (the `<details>` parse AND the "Prompt for all" parse). Match by `(file, line_range)` tuple.
-- Findings present in both → merge (use `<details>` block's richer metadata as primary, use "Prompt for all" description as fallback if `<details>` description was empty).
-- Findings only in one source → keep as-is, log which source surfaced it (for debugging).
-- **Never take the intersection** — one source missing a finding is a parsing bug, not ground truth.
-
-**CodeRabbit origin tagging rules:**
-When presenting findings from CodeRabbit, ALWAYS include the origin tag in the finding header:
-- `[CodeRabbit — DUPLICATE]` for findings from the "Duplicate comments" section. These are repeat findings from previous reviews that remain unaddressed.
-- `[CodeRabbit — OUTSIDE PR DIFF]` for findings from the "Outside diff range" section. These affect code not changed in this PR.
-- `[CodeRabbit]` for regular inline findings (no special tag needed).
-
-This tagging helps the user understand whether the finding is about code they changed in this PR, code outside their changes, or a recurring issue from a previous review.
+**pr-check-specific application:** the parsed findings feed into Step 1.3.4
+(by-source summary) and downstream the CodeRabbit-as-is path that allows
+direct application of `[Minimal fix]` / `[Suggested refactor]` blocks for
+nitpick-level findings without TDD. This as-is path is intentional for
+pr-check — coderabbit-review takes the TDD path for the same sources. See
+the relationship note in coderabbit-review/SKILL.md Phase 4.
 
 **Human reviewer comments:** All threads where the first comment author is not a known bot.
 
@@ -1160,6 +1057,16 @@ For each approved fix, classify its complexity and apply accordingly — see AGE
 1. Apply `FIX_DIFF` verbatim using Edit/MultiEdit. Treat the diff as authoritative — do NOT re-derive from agent recommendation.
 2. Run unit tests to verify no regression.
 3. If tests fail → revert the diff and escalate to ring droid dispatch (Complex flow), informing the user that CodeRabbit's diff did not pass tests as-applied. Record the failure in the per-finding audit trail.
+
+**Relationship to coderabbit-review (intentional divergence):** This as-is path
+is unique to `pr-check` and intentionally absent from `coderabbit-review`.
+`coderabbit-review` always applies CodeRabbit findings via TDD (RED-GREEN-REFACTOR)
+because that skill is for the case where the user wants to deeply understand
+and re-implement each suggestion. `pr-check` accepts the trade-off of merging
+CodeRabbit's exact patches (even nitpicks) because the goal here is unblocking
+PR review, not author understanding. If you want as-is application, stay on
+`pr-check`; if you want TDD-driven re-implementation, switch to
+`coderabbit-review`. See coderabbit-review/SKILL.md Phase 4 for the mirror note.
 
 **Simple fix flow:**
 1. Apply the fix directly using Edit/MultiEdit tools
@@ -2277,10 +2184,29 @@ Droids whose purpose is implementation, design, operations, or non-code domains:
 | **Domain specialist** | Description mentions a specific technology — include only if the project uses it | `lib-commons-reviewer` (if `go.mod` imports `lib-commons`), `multi-tenant-reviewer` (if project uses multi-tenancy), `performance-reviewer` (always relevant) |
 | **Non-reviewer (EXCLUDE)** | Description indicates implementation, design, ops, finance, planning, or infrastructure — NOT code review | See exclusion list above |
 
+**Deny-list filter (applied AFTER inclusion regex, BEFORE final selection):**
+
+If the description matches `architecture|design|planning|process|workflow|strategy`,
+EXCLUDE the agent regardless of inclusion-regex match. These words indicate the
+agent is meta-level (not code review) and should not be dispatched to review code.
+This guards against future agents whose descriptions accidentally match the
+inclusion regex's broader words (e.g., `architecture-reviewer`,
+`design-reviewer`, `process-reviewer`) — they would otherwise be dispatched
+against actual code, which is not their job.
+
+The combined logic: `(matches inclusion regex) AND NOT (matches deny regex) → include`.
+
+**Positive allow-list** (overrides deny-list for known good agents that may have
+"design" or another deny term in their descriptions accidentally): listed in the
+protocol's roster JSON (empty by default; add specific droid IDs as needed).
+Allow-list entries are matched by full droid ID (not regex) so a single
+accidental wording match cannot reopen the deny-list for an entire family of
+droids.
+
 For non-ring entries (only present when `INCLUDE_NON_RING=true`), apply the same
-description filter. Non-ring agents that pass the filter are returned in the `Non-Ring`
-group regardless of stack/domain category — the caller decides whether to default-select
-them in its UX.
+description filter AND the deny-list. Non-ring agents that pass both filters are
+returned in the `Non-Ring` group regardless of stack/domain category — the caller
+decides whether to default-select them in its UX.
 
 **Output format:**
 
@@ -2397,6 +2323,140 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 - If no PR exists, skip.
 
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
+
+
+### Protocol: Parse CodeRabbit Review Body
+
+**Referenced by:** pr-check, coderabbit-review
+
+Deterministic algorithm for extracting actionable findings from a CodeRabbit
+review-body GraphQL response. Both pr-check and coderabbit-review consume the
+same source format; this protocol is the single source of truth so the two
+skills cannot drift in their parsing rules. Drift is exactly how CodeRabbit
+findings get silently dropped — see the historical "duplicate comments missed"
+incident that motivated the count-parity guard below.
+
+**Source data — GraphQL fields fetched:**
+
+The CodeRabbit review body is obtained via the GitHub GraphQL API:
+
+```graphql
+pullRequest(number: $pr) {
+  reviews(first: 100) {
+    nodes {
+      author { login }      # filter to coderabbitai[bot]
+      body                  # markdown body containing the <details> blocks below
+      submittedAt
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+Take the **latest** review whose author is `coderabbitai[bot]`. Pagination via
+`pageInfo` is mandatory when `hasNextPage` is true.
+
+**Parsing algorithm — top-level sections:**
+
+The latest CodeRabbit review body contains zero or more of these top-level
+`<details>` blocks (each parsed via the per-section algorithm below):
+
+| Top-level summary regex | Origin tag | Description |
+|------------------------|------------|-------------|
+| `♻️ Duplicate comments \((\d+)\)` | `duplicate` | Findings repeated from previous reviews, still unresolved |
+| `⚠️ Outside diff range comments \((\d+)\)` | `outside-diff` | Findings about code outside the PR diff |
+| `🤖 Prompt for all review comments with AI agents` | `aggregate` (cross-validation only, NOT a per-finding source) | Aggregate flat-list block used to cross-check the per-finding parse |
+
+Inline (in-diff) findings come from the per-thread GraphQL fetch (review
+threads), not from the review body — they are tagged `origin: inline` by the
+caller. The review body parser handles only the duplicate/outside-diff
+sections plus the aggregate cross-validation block.
+
+**Per-section algorithm (applied to each top-level `<details>` block):**
+
+1. **Locate the outer `<details>`** by matching the summary regex (case-sensitive).
+   Capture `N_TOTAL`. If no match: section absent (N=0) — skip.
+
+2. **Extract the outer blockquote body**, tracking nesting: every inner
+   `<details>` opens a level; every matching `</details>` closes one. Stop
+   when the outer level closes.
+
+3. **Iterate inner per-file `<details>` blocks**:
+   `<summary>(.+?) \((\d+)\)</summary>` — capture `FILE_PATH` and `K_COUNT`.
+
+4. **Within each per-file blockquote, split by `---` separators at the top
+   level** (depth == 0). Walk line-by-line, increment depth on `<details>`,
+   decrement on `</details>`; a line `^\s*---\s*$` is a separator only when
+   depth == 0.
+
+5. **Each slice = ONE finding.** Parse:
+   - First non-empty line: `` `(\d+(?:-\d+)?)`: _(⚠️ Potential issue|🛠️ Refactor suggestion|🧹 Nitpick|...)_ \| _(🔴|🟠|🟡|🔵) (Critical|Major|Minor|Trivial)_ `` — capture `LINE_RANGE`, `TYPE_LABEL`, `SEVERITY_EMOJI`, `SEVERITY_LABEL`.
+   - Next bold line `**...**` is the `TITLE`.
+   - Body until first nested `<details>` or end-of-slice is the `DESCRIPTION`.
+
+6. **Per-finding fix-block extraction.** Within each finding's slice:
+   - `FIX_LABEL` + `FIX_DIFF` — match `<details><summary>(🐛 Minimal fix|🐛 Suggested refactor)</summary>` (the two labels are mutually exclusive within one finding; if neither is present, leave both empty). **Critical:** match BOTH labels — matching only `🐛 Minimal fix` silently drops findings labeled `Suggested refactor` even when the diff is supplied.
+   - `AI_PROMPT` — match `<details><summary>🤖 Prompt for AI Agents</summary>` and capture body. **Disambiguation:** this is the per-finding prompt block, NOT the aggregate `🤖 Prompt for all review comments with AI agents` block. Both can coexist; extract independently.
+
+7. **Severity mapping:**
+
+   | Emoji | Label | Severity |
+   |-------|-------|----------|
+   | 🔴 | Critical | CRITICAL |
+   | 🟠 | Major | HIGH |
+   | 🟡 | Minor | MEDIUM |
+   | 🔵 | Trivial | LOW |
+
+**Count parity validation (HARD BLOCK on mismatch):**
+
+After parsing each section:
+- Sum per-file extracted findings → must equal `N_TOTAL`.
+- Per-file extracted count → must equal `K_COUNT` for every file.
+
+**On mismatch: STOP immediately.** Print: parsed N, expected M, file
+breakdown, missing/extra IDs. **Do NOT offer an opt-out** — a silent
+partial-set continuation is exactly the failure mode this gate prevents. The
+user must investigate the parser or CodeRabbit output before the skill can
+proceed.
+
+**Cross-validation via aggregate prompt block:**
+
+CodeRabbit emits a `<details><summary>🤖 Prompt for all review comments with AI agents</summary>` block listing findings as a flat bullet list grouped by section. Parse it independently and take the **UNION** with the per-section parse, matched by `(file, line_range)`:
+- In both → merge (per-section block is primary; aggregate description is fallback).
+- Only in one → keep, log which source surfaced it.
+- **Never take the intersection** — single-source absence is a parsing bug, not ground truth.
+
+**Outdated-thread partitioning:**
+
+Inline review threads with `isOutdated: true` are partitioned out of the
+active findings set. The original finding text is preserved in the duplicate
+comments section of the review body (CodeRabbit re-emits unresolved findings
+across reviews), so the duplicate-section parse remains the source of record
+for content. Outdated threads are typically auto-resolved by the consuming
+skill's hygiene step — see pr-check Step 13.0.
+
+**Origin tagging rules** (when presenting findings to the user, ALWAYS include
+the origin tag in the finding header):
+
+| Source | Tag |
+|--------|-----|
+| Per-thread inline review comment (in-diff) | `[CodeRabbit]` |
+| Duplicate-comments section | `[CodeRabbit — DUPLICATE]` |
+| Outside-diff-range section | `[CodeRabbit — OUTSIDE PR DIFF]` |
+| Non-CodeRabbit (Codacy/DeepSource/CI/human) | their own origin tag — NOT this protocol |
+
+**Distinguishing CodeRabbit from CI bot, duplicate, human:**
+
+This protocol handles CodeRabbit only. The caller separately identifies:
+- **CI bots** (`github-actions[bot]`, `codacy-production[bot]`, `deepsource-io[bot]`, etc.) — handled by their own per-bot parsers.
+- **Duplicate findings** (CodeRabbit's own duplicate section) — origin-tagged here, not de-duplicated against earlier reviews.
+- **Human reviewers** — every author whose login is not in the known-bot list.
+
+**Caller-specific application** (NOT part of this protocol):
+- pr-check applies CodeRabbit-as-is (`[Minimal fix]` / `[Suggested refactor]` direct application path) for nitpick-level findings — see pr-check Step 1.3.3 surrounding prose.
+- coderabbit-review always applies findings via TDD — see coderabbit-review Phase 4. The relationship between the two skills is documented in coderabbit-review/SKILL.md ("Relationship to pr-check").
+
+Skills reference this as: "Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body."
 
 
 ### Protocol: Per-Droid Quality Checklists

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -298,19 +298,24 @@ if [ -z "$TASK_ID" ] || ! [[ "$TASK_ID" =~ ^T-[0-9]+$ ]]; then
   # STOP
 fi
 
-# Use awk's literal index() (not regex ~) so a future relaxation of the TASK_ID format
-# (e.g., alphanumeric suffix) does not suddenly change semantics through regex metachars.
+# Anchor the match on the kebab-cased task ID (e.g., `-t-1-`) so substrings like
+# `t-1` cannot match `t-10`/`t-100`. Worktree paths follow the convention
+# `<parent>/<repo>-<id>-<keywords>`, and feature branches follow
+# `<tipo>/<id>-<keywords>` — both surround the lowercased ID with hyphens.
+TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
 WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
-  | awk -v id="$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')" '
-      BEGIN { if (id == "") exit 1 }
+  | awk -v anchor="$TASK_KEBAB" '
+      BEGIN { if (anchor == "--") exit 1 }
       /^worktree / { wt=$2 }
-      /^branch /   { if (index(tolower(wt), id) > 0 || index(tolower($2), id) > 0) print wt }
-    ' | head -1)
+      /^branch /   { if (index(tolower(wt), anchor) > 0 || index(tolower($2), anchor) > 0) { print wt; exit } }
+    ')
 
 if [ -z "$WORKTREE_PATH" ]; then
-  # Fallback: literal task-ID search. The Step 3.2 hard guard above already refused empty
-  # TASK_ID, so grep -F has a non-empty pattern here.
-  WORKTREE_PATH=$(git worktree list | grep -iF "$TASK_ID" | awk '{print $1}' | head -1)
+  # Fallback: anchored kebab match against the path field only. NEVER use a bare
+  # `grep -iF "$TASK_ID"` — that produces false positives for short IDs
+  # (e.g., `T-1` matching `T-10`, `T-100`).
+  WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+    | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
 fi
 ```
 
@@ -457,41 +462,6 @@ If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
 Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `RESUME`:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
 _optimus_set_title "optimus: RESUME $TASK_ID — $TASK_TITLE"
 ```
 
@@ -938,9 +908,16 @@ Where:
 - T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
 
 **Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest)
-2. Search by task ID: `git branch --list "*<task-id>*"` or `git worktree list | grep -iF "<task-id>"`
-3. Derive from Tipo + ID + Title (always works)
+1. Read `branch` from state.json (fastest, source-of-truth).
+2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
+   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
+   ```bash
+   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
+   git worktree list --porcelain 2>/dev/null \
+     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
+   ```
+3. Derive from Tipo + ID + Title (always works).
 
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -61,44 +61,36 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
 ### Step 1.0.7.1: Set Terminal Title
 
-**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance. Execute this command NOW:
+**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance.
+
+**First, parse `TASK_TITLE` from optimus-tasks.md** — the title is interpolated
+into the terminal title below, and parsing it lazily (after the title is set)
+results in `optimus: REVIEW T-XXX — ` with an empty trailing dash:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
+# optimus-tasks.md columns by pipe index:
+# | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# Use the same parser pattern as resume/SKILL.md Step 2.3 (Read Task Metadata).
+TASK_TITLE=$(awk -F'|' -v id="$TASK_ID" '
+  { gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2) }
+  $2 == id {
+    title=$3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+    print title
+    exit
+  }
+' "$TASKS_FILE")
+
+if [ -z "$TASK_TITLE" ]; then
+  # Non-fatal: the terminal title is informational. Fall back to a stub so the
+  # later interpolation does not produce a trailing-dash artifact.
+  TASK_TITLE="(title unavailable)"
+fi
+```
+
+Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `REVIEW`:
+
+```bash
 _optimus_set_title "optimus: REVIEW $TASK_ID — $TASK_TITLE"
 ```
 
@@ -700,7 +692,7 @@ Execute re-run guard — see AGENTS.md Protocol: Re-run Guard.
 - If the user chooses **Re-run with clean context**: go back to Step 1.1 (Discover Project
   Structure). Skip all prior setup steps (GitHub CLI check, optimus-tasks.md validation, workspace
   resolution, task identification, session state, status validation, divergence check).
-  Increment stage stats before re-starting analysis.
+  Increment stage stats before re-starting analysis. Apply the **Re-run reset semantics**: reset `convergence_status` to `null`; reset `phase` to the first re-executed phase; overwrite `started_at`; preserve `task_id`, `task_branch`, `created_at`. See AGENTS.md Protocol: Re-run Guard.
 - If the user chooses **Advance** (or 0 findings): proceed to Phase 10 (integration tests).
 
 ---
@@ -2342,6 +2334,20 @@ whether to suggest advancement or offer a re-run. This protocol replaces the sta
    - After the re-run completes, apply this protocol again (evaluate findings count)
    - There is no limit on re-runs — the user controls when to stop
 
+   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
+   context", the orchestrator MUST:
+
+   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
+      or another terminal state at the previous run's end).
+   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
+      that performs work, NOT the load-only phases).
+   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
+   4. Preserve `task_id`, `task_branch`, and any other identity fields.
+   5. After reset, normal `Protocol: Session State` updates resume.
+
+   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
+   short-circuit the re-run's loop, producing a phantom "no findings" result.
+
 5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
 
 **NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
@@ -2740,6 +2746,101 @@ Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
+### Protocol: Terminal Identification
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Set title (after task ID is known):**
+
+```bash
+_optimus_set_title() {
+  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
+  # tasks always run in "divorced" iTerm2 sessions where the profile's
+  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
+  # SetUserVar are both ineffective in that state, so AppleScript's
+  # `set name of s` is the only channel that actually mutates session.name.
+  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
+  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
+  # up to 4 ancestors in case of nested shells. First run triggers a macOS
+  # TCC prompt ("droid wants to control iTerm"); approving enables this
+  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
+  # unavailable — non-iTerm2 / non-macOS users get no title update.
+  local title="$1"
+  local pid="$PPID" tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+      *) break ;;
+    esac
+  done
+  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
+     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
+     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
+    osascript \
+      -e 'on run argv' \
+      -e '  set targetTty to "/dev/" & item 1 of argv' \
+      -e '  set newName to item 2 of argv' \
+      -e '  tell application "iTerm2"' \
+      -e '    repeat with w in windows' \
+      -e '      repeat with t in tabs of w' \
+      -e '        repeat with s in sessions of t' \
+      -e '          if (tty of s as string) is targetTty then' \
+      -e '            try' \
+      -e '              set name of s to newName' \
+      -e '            end try' \
+      -e '          end if' \
+      -e '        end repeat' \
+      -e '      end repeat' \
+      -e '    end repeat' \
+      -e '  end tell' \
+      -e 'end run' \
+      -- "$tty" "$title" >/dev/null 2>&1 || true
+  fi
+}
+_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+```
+
+Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+
+**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
+terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
+asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
+session list via AppleScript — that device is connected to the user's real iTerm2
+session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
+function silently no-ops.
+
+**Restore title (at stage completion or exit):**
+
+```bash
+_optimus_set_title ""
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
+"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
+channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
+will not see a title update.
+
+**Troubleshooting iTerm2 (if the title still doesn't update):**
+
+1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
+   sticky on the tab label and overrides the session name visually, even
+   when `session.name` is updated correctly underneath.
+2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
+   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
+   silent no-op.
+3. The helper requires the parent process to have a controlling TTY. Inside
+   Docker/CI without a TTY, no ancestor will resolve and the helper will
+   silently no-op.
+
+Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+
+
 ### Protocol: Workspace Auto-Navigation (HARD BLOCK)
 
 **Referenced by:** stages 2-4
@@ -2793,11 +2894,30 @@ fi
        T-002 — Login page (Em Andamento) → /projeto-t-002-.../
      Which task should I continue?
      ```
-   - After task is identified, locate the worktree by task ID:
+   - After task is identified, locate the worktree. Prefer the source-of-truth
+     (state.json `branch` field) and match the porcelain output by exact
+     branch ref. Fall back to a kebab-anchored path match — never an
+     unanchored substring grep on the bare task ID, which produces false
+     positives for short IDs (e.g., `T-1` matching `T-10`, `T-100`):
      ```bash
-     git worktree list | grep -iF "<task-id>"
+     # Source-of-truth: branch from state.json (set by stage 1).
+     TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+       "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+     WORKTREE_PATH=""
+     if [ -n "$TASK_BRANCH" ]; then
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+         /^worktree / { path=$2 }
+         /^branch /   { if ($2 == br) { print path; exit } }
+       ')
+     fi
+     if [ -z "$WORKTREE_PATH" ]; then
+       # Fallback: anchored kebab-cased path-segment match (avoids T-1 vs T-10 substring collision).
+       TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+         | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+     fi
      ```
-   - **If worktree found** → change working directory to the worktree path.
+   - **If `WORKTREE_PATH` is non-empty** → change working directory to it.
    - **If worktree NOT found** → derive the branch name (Protocol: Branch Name Derivation)
      and verify it exists:
      ```bash

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -423,11 +423,29 @@ Show the new table order.
    **IMPORTANT:** Worktree must be removed BEFORE attempting branch deletion (step 5b).
    Git refuses to delete a branch that is checked out in a worktree.
 
+   Resolve the worktree by branch (source-of-truth from state.json) with a
+   kebab-anchored fallback. Never `grep -iF "T-XXX"` directly — that would
+   match `T-1` against `T-10`/`T-100`:
+
    ```bash
-   git worktree list | grep -iF "T-XXX"
+   # Source-of-truth: branch from state.json.
+   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+     "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+   WORKTREE_PATH=""
+   if [ -n "$TASK_BRANCH" ]; then
+     WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+       /^worktree / { path=$2 }
+       /^branch /   { if ($2 == br) { print path; exit } }
+     ')
+   fi
+   if [ -z "$WORKTREE_PATH" ]; then
+     TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+     WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+       | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+   fi
    ```
 
-   If a worktree is found, ask via `AskUser`:
+   If a worktree is found (`WORKTREE_PATH` non-empty), ask via `AskUser`:
    ```
    Task T-XXX has a worktree at '<path>'. What should I do with it?
    ```

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -883,10 +883,29 @@ Droids whose purpose is implementation, design, operations, or non-code domains:
 | **Domain specialist** | Description mentions a specific technology — include only if the project uses it | `lib-commons-reviewer` (if `go.mod` imports `lib-commons`), `multi-tenant-reviewer` (if project uses multi-tenancy), `performance-reviewer` (always relevant) |
 | **Non-reviewer (EXCLUDE)** | Description indicates implementation, design, ops, finance, planning, or infrastructure — NOT code review | See exclusion list above |
 
+**Deny-list filter (applied AFTER inclusion regex, BEFORE final selection):**
+
+If the description matches `architecture|design|planning|process|workflow|strategy`,
+EXCLUDE the agent regardless of inclusion-regex match. These words indicate the
+agent is meta-level (not code review) and should not be dispatched to review code.
+This guards against future agents whose descriptions accidentally match the
+inclusion regex's broader words (e.g., `architecture-reviewer`,
+`design-reviewer`, `process-reviewer`) — they would otherwise be dispatched
+against actual code, which is not their job.
+
+The combined logic: `(matches inclusion regex) AND NOT (matches deny regex) → include`.
+
+**Positive allow-list** (overrides deny-list for known good agents that may have
+"design" or another deny term in their descriptions accidentally): listed in the
+protocol's roster JSON (empty by default; add specific droid IDs as needed).
+Allow-list entries are matched by full droid ID (not regex) so a single
+accidental wording match cannot reopen the deny-list for an entire family of
+droids.
+
 For non-ring entries (only present when `INCLUDE_NON_RING=true`), apply the same
-description filter. Non-ring agents that pass the filter are returned in the `Non-Ring`
-group regardless of stack/domain category — the caller decides whether to default-select
-them in its UX.
+description filter AND the deny-list. Non-ring agents that pass both filters are
+returned in the `Non-Ring` group regardless of stack/domain category — the caller
+decides whether to default-select them in its UX.
 
 **Output format:**
 

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -121,44 +121,36 @@ message. It never offers to redo `plan`, `build`, or `review`.
 
 ### Step 1.0.3.2: Set Terminal Title
 
-**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance. Execute this command NOW:
+**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance.
+
+**First, parse `TASK_TITLE` from optimus-tasks.md** — the title is interpolated
+into the terminal title below, and parsing it lazily (after the title is set)
+results in `optimus: DONE T-XXX — ` with an empty trailing dash:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
+# optimus-tasks.md columns by pipe index:
+# | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# Use the same parser pattern as resume/SKILL.md Step 2.3 (Read Task Metadata).
+TASK_TITLE=$(awk -F'|' -v id="$TASK_ID" '
+  { gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2) }
+  $2 == id {
+    title=$3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+    print title
+    exit
+  }
+' "$TASKS_FILE")
+
+if [ -z "$TASK_TITLE" ]; then
+  # Non-fatal: the terminal title is informational. Fall back to a stub so the
+  # later interpolation does not produce a trailing-dash artifact.
+  TASK_TITLE="(title unavailable)"
+fi
+```
+
+Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `DONE`:
+
+```bash
 _optimus_set_title "optimus: DONE $TASK_ID — $TASK_TITLE"
 ```
 
@@ -357,11 +349,37 @@ This phase runs ONLY after the task has been marked as `DONE` (or `Cancelado`).
 
 **IMPORTANT:** Worktree must be removed BEFORE attempting branch deletion.
 
+Resolve the worktree from the source-of-truth: read the task's branch from
+state.json (set by Workspace Auto-Navigation in earlier stages), then match it
+against `git worktree list --porcelain`. This avoids substring false positives
+on short task IDs (e.g., `T-1` matching `T-10`, `T-100`).
+
 ```bash
-git worktree list | grep -iF "T-XXX"
+# Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path.
+MAIN_WORKTREE="${MAIN_WORKTREE:-$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')}"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+
+WORKTREE_PATH=""
+if [ -n "$TASK_BRANCH" ]; then
+  # Match by branch (exact, deterministic) — porcelain output has one
+  # `worktree <path>` line followed by `branch refs/heads/<name>` per entry.
+  WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+    /^worktree / { path=$2 }
+    /^branch /   { if ($2 == br) { print path; exit } }
+  ')
+fi
+
+if [ -z "$WORKTREE_PATH" ]; then
+  # Fallback: anchored kebab-cased path-segment match — never `grep -iF "$TASK_ID"`,
+  # which would match T-1 against T-10/T-100.
+  TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+  WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+    | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+fi
 ```
 
-If a worktree is found, ask via `AskUser`:
+If a worktree is found (`WORKTREE_PATH` non-empty), ask via `AskUser`:
 ```
 Task T-XXX is done. A worktree still exists at '<path>'. What should I do?
 ```
@@ -403,22 +421,87 @@ Options:
 or "Delete local only", present a final confirmation via `AskUser`:
 "This will permanently delete branch `<branch>`. Are you sure?" Options: Yes, delete / Cancel.
 
-**Before deleting:** switch to the default branch first:
+**Before deleting:** switch to the default branch first. Use the canonical
+deterministic recipe — see AGENTS.md Protocol: Default Branch Resolution.
+
 ```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-if [ -z "$DEFAULT_BRANCH" ]; then
-  DEFAULT_BRANCH=$(git branch --list main master 2>/dev/null | head -1 | tr -d ' *')
+# Resolve DEFAULT_BRANCH deterministically — see AGENTS.md Protocol: Default Branch Resolution.
+DEFAULT_BRANCH=""
+if symref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+  DEFAULT_BRANCH="${symref#origin/}"
+elif git show-ref --verify --quiet refs/heads/main; then
+  DEFAULT_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master; then
+  DEFAULT_BRANCH="master"
 fi
 if [ -z "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: Cannot determine default branch. Set it with: git remote set-head origin <branch>"
+  echo "ERROR: Could not determine default branch (no origin/HEAD, no main, no master)." >&2
+  echo "       Set it with: git remote set-head origin <branch>" >&2
   # STOP — do not proceed with branch deletion
 fi
 git checkout "$DEFAULT_BRANCH"
 git pull
-git branch -d "$TASK_BRANCH" 2>/dev/null || git branch -D "$TASK_BRANCH"
-# If also deleting remote:
-git push origin --delete "$TASK_BRANCH"
+
+# Local delete first; -d (safe) preferred over -D
+if ! git branch -d "$TASK_BRANCH" 2>/dev/null; then
+  if ! LOCAL_DELETE_OUTPUT=$(git branch -D "$TASK_BRANCH" 2>&1); then
+    echo "ERROR: Could not delete local branch $TASK_BRANCH: $LOCAL_DELETE_OUTPUT" >&2
+    # AskUser:
+    #   "Local branch delete failed. How should I proceed?"
+    #   - **Continue cleanup anyway** — proceed (e.g., the user will clean up manually)
+    #   - **Abort cleanup** — STOP without attempting remote deletion
+  fi
+fi
+
+# Remote delete with explicit failure-cause classification.
+# `DELETE_REMOTE` is "yes" only when the user picked "Delete local and remote".
+if [ "$DELETE_REMOTE" = "yes" ]; then
+  if ! PUSH_OUTPUT=$(git push origin --delete "$TASK_BRANCH" 2>&1); then
+    PUSH_RC=$?
+    # Classify the failure so the user gets actionable diagnostics.
+    case "$PUSH_OUTPUT" in
+      *"remote ref does not exist"*|*"deleted reference"*)
+        echo "ℹ Remote branch already deleted upstream (rc=$PUSH_RC) — local cleanup complete." >&2
+        REMOTE_DELETE_RESULT="already-deleted"
+        ;;
+      *"protected branch"*|*"protection"*)
+        echo "✗ Remote branch is protected — cannot delete (rc=$PUSH_RC)." >&2
+        echo "  Local branch deleted; remote branch will need manual cleanup or branch-protection adjustment." >&2
+        REMOTE_DELETE_RESULT="protected"
+        ;;
+      *"could not read"*|*"unable to access"*|*"connection"*|*"timed out"*|*"timeout"*|*"Network"*)
+        echo "✗ Network error pushing branch deletion (rc=$PUSH_RC):" >&2
+        echo "  $PUSH_OUTPUT" >&2
+        echo "  Local branch deleted; retry or run \`git push origin --delete $TASK_BRANCH\` manually after restoring connectivity." >&2
+        REMOTE_DELETE_RESULT="network-error"
+        ;;
+      *)
+        echo "✗ Remote branch delete failed (rc=$PUSH_RC): $PUSH_OUTPUT" >&2
+        REMOTE_DELETE_RESULT="other-error"
+        ;;
+    esac
+
+    # AskUser (integrate the classification message above into the body):
+    #   "Remote branch deletion failed (<classification>). What should I do?"
+    #   - **Ignore and continue** — leave the remote branch as is (logged with `pending-remote-delete`)
+    #   - **Retry now** — re-run `git push origin --delete "$TASK_BRANCH"` once
+    #   - **Abort cleanup** — STOP; user will resolve manually
+    #
+    # Notify the user via Hooks if available (event=`pending-remote-delete`).
+    # Tag the task in state.json with `pending_remote_delete: true` so a future
+    # operation (e.g., a follow-up `done`, or a maintenance script) can retry.
+  else
+    REMOTE_DELETE_RESULT="ok"
+  fi
+fi
 ```
+
+**Partial-state contract on failure:** if remote deletion fails after local
+deletion succeeds, the task is `DONE` and the local branch is gone, but the
+remote branch may persist. The task is flagged with `pending_remote_delete`
+in state.json so it can be retried later. The Cleanup Summary (Step 4.3) MUST
+reflect this partial state — do NOT report "Deleted" for the remote when the
+push failed.
 
 ### Step 4.3: Cleanup Summary
 
@@ -881,6 +964,64 @@ status transition.
 Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
 
 
+### Protocol: Default Branch Resolution
+
+**Referenced by:** done (cleanup), Workspace Auto-Navigation, Default Branch Refusal,
+Resolve Tasks Git Scope, Push Commits.
+
+**Why:** Several skills need to resolve the project repo's default branch (the
+branch to checkout before deleting a feature branch, the branch the workspace
+auto-navigation refuses to mutate, etc.). Non-deterministic resolutions like
+`git branch --list main master | head -1` return whichever entry git happens to
+list first — which depends on collation and on whether both branches exist
+locally. The recipe below is fully deterministic.
+
+**Recipe:**
+
+```bash
+# Deterministic default-branch resolution: prefer remote symbolic-ref
+# (origin/HEAD), then verify against `main` first, then `master`, then bail.
+DEFAULT_BRANCH=""
+if symref=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null); then
+  DEFAULT_BRANCH="${symref#origin/}"
+elif git show-ref --verify --quiet refs/heads/main; then
+  DEFAULT_BRANCH="main"
+elif git show-ref --verify --quiet refs/heads/master; then
+  DEFAULT_BRANCH="master"
+fi
+
+if [ -z "$DEFAULT_BRANCH" ]; then
+  echo "ERROR: Could not determine default branch (no origin/HEAD, no main, no master)" >&2
+  exit 1
+fi
+```
+
+**Resolution order (deterministic):**
+
+1. `origin/HEAD` symbolic-ref — the canonical answer when `gh repo clone`/
+   `git clone` has set it. Fastest and works even when neither `main` nor
+   `master` exists locally.
+2. Local `refs/heads/main` — second-best signal: if the user has `main`
+   checked out at all, it is overwhelmingly the default.
+3. Local `refs/heads/master` — fall-back for legacy repos.
+4. None of the above → hard error. The user must run
+   `git remote set-head origin <branch>` (or fetch from origin) before any
+   skill that needs the default branch can proceed.
+
+**Why prefer `main` before `master` in the fallback chain:** when
+`origin/HEAD` is absent (e.g., shallow clone, fresh repo, broken remote),
+both `main` and `master` may exist locally as orphans. Probing `main` first
+biases toward the modern default rather than the historical one.
+
+**`git branch --list main master | head -1` is forbidden:** it returns
+whichever name sorts first alphabetically (`main` always wins), which only
+*happens* to look correct — but it also returns `main` when only `master`
+actually exists locally (because `head -1` on empty stdout is empty). Any
+skill that needs the default branch MUST use the recipe above.
+
+Skills reference this as: "Resolve default branch — see AGENTS.md Protocol: Default Branch Resolution."
+
+
 ### Protocol: Divergence Warning
 
 **Referenced by:** all stage agents (1-4)
@@ -1212,6 +1353,101 @@ and offer to run reconciliation before proceeding. This prevents tasks from sile
 appearing as `Pendente` when they actually have active worktrees.
 
 Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: State Management."
+
+
+### Protocol: Terminal Identification
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Set title (after task ID is known):**
+
+```bash
+_optimus_set_title() {
+  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
+  # tasks always run in "divorced" iTerm2 sessions where the profile's
+  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
+  # SetUserVar are both ineffective in that state, so AppleScript's
+  # `set name of s` is the only channel that actually mutates session.name.
+  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
+  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
+  # up to 4 ancestors in case of nested shells. First run triggers a macOS
+  # TCC prompt ("droid wants to control iTerm"); approving enables this
+  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
+  # unavailable — non-iTerm2 / non-macOS users get no title update.
+  local title="$1"
+  local pid="$PPID" tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+      *) break ;;
+    esac
+  done
+  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
+     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
+     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
+    osascript \
+      -e 'on run argv' \
+      -e '  set targetTty to "/dev/" & item 1 of argv' \
+      -e '  set newName to item 2 of argv' \
+      -e '  tell application "iTerm2"' \
+      -e '    repeat with w in windows' \
+      -e '      repeat with t in tabs of w' \
+      -e '        repeat with s in sessions of t' \
+      -e '          if (tty of s as string) is targetTty then' \
+      -e '            try' \
+      -e '              set name of s to newName' \
+      -e '            end try' \
+      -e '          end if' \
+      -e '        end repeat' \
+      -e '      end repeat' \
+      -e '    end repeat' \
+      -e '  end tell' \
+      -e 'end run' \
+      -- "$tty" "$title" >/dev/null 2>&1 || true
+  fi
+}
+_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+```
+
+Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+
+**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
+terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
+asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
+session list via AppleScript — that device is connected to the user's real iTerm2
+session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
+function silently no-ops.
+
+**Restore title (at stage completion or exit):**
+
+```bash
+_optimus_set_title ""
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
+"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
+channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
+will not see a title update.
+
+**Troubleshooting iTerm2 (if the title still doesn't update):**
+
+1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
+   sticky on the tab label and overrides the session name visually, even
+   when `session.name` is updated correctly underneath.
+2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
+   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
+   silent no-op.
+3. The helper requires the parent process to have a controlling TTY. Inside
+   Docker/CI without a TTY, no ancestor will resolve and the helper will
+   silently no-op.
+
+Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -110,44 +110,36 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
 ### Step 1.0.2.2: Set Terminal Title
 
-**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance. Execute this command NOW:
+**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance.
+
+**First, parse `TASK_TITLE` from optimus-tasks.md** — the title is interpolated
+into the terminal title below, and parsing it lazily (after the title is set)
+results in `optimus: PLAN T-XXX — ` with an empty trailing dash:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
+# optimus-tasks.md columns by pipe index:
+# | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# Use the same parser pattern as resume/SKILL.md Step 2.3 (Read Task Metadata).
+TASK_TITLE=$(awk -F'|' -v id="$TASK_ID" '
+  { gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2) }
+  $2 == id {
+    title=$3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+    print title
+    exit
+  }
+' "$TASKS_FILE")
+
+if [ -z "$TASK_TITLE" ]; then
+  # Non-fatal: the terminal title is informational. Fall back to a stub so the
+  # later interpolation does not produce a trailing-dash artifact.
+  TASK_TITLE="(title unavailable)"
+fi
+```
+
+Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `PLAN`:
+
+```bash
 _optimus_set_title "optimus: PLAN $TASK_ID — $TASK_TITLE"
 ```
 
@@ -202,14 +194,33 @@ _optimus_set_title ""
 **ALWAYS run this step** — regardless of task status. This detects orphaned workspaces
 from a previous run that was interrupted (crash, user closed terminal, etc.).
 
-1. Check if any branch or worktree already exists for this task:
+1. Check if any branch or worktree already exists for this task. Use anchored
+   matches to avoid substring false positives (`T-1` against `T-10`/`T-100`).
+   Prefer state.json's `branch` field when present:
    ```bash
-   # Check for any branch matching the task ID
-   git branch --list "*<task-id>*" 2>/dev/null
-   # Check for any worktree matching the task ID
-   git worktree list | grep -iF "<task-id>"
+   # Source-of-truth: branch from state.json (fastest, set by previous plan run).
+   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+     "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+
+   # Fallback: anchored kebab-cased search (avoids T-1 vs T-10 collision).
+   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+   if [ -z "$TASK_BRANCH" ]; then
+     TASK_BRANCH=$(git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null | head -1 | tr -d ' *')
+   fi
+   WORKTREE_PATH=""
+   if [ -n "$TASK_BRANCH" ]; then
+     WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+       /^worktree / { path=$2 }
+       /^branch /   { if ($2 == br) { print path; exit } }
+     ')
+   fi
+   if [ -z "$WORKTREE_PATH" ]; then
+     WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+       | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+   fi
    ```
-2. Also read the `branch` field from state.json if available.
+2. The state.json read above already covers the "Also read the `branch` field
+   from state.json if available" step.
 3. **If a branch or worktree exists:**
    - Ask via `AskUser`:
      ```
@@ -689,7 +700,7 @@ Execute re-run guard — see AGENTS.md Protocol: Re-run Guard.
 - If the user chooses **Re-run with clean context**: go back to Step 1.1 (Discover Project
   Structure). Skip all prior setup steps (GitHub CLI check, optimus-tasks.md validation, task
   identification, session state, status validation, workspace creation, divergence check).
-  Increment stage stats before re-starting analysis.
+  Increment stage stats before re-starting analysis. Apply the **Re-run reset semantics**: reset `convergence_status` to `null`; reset `phase` to the first re-executed phase; overwrite `started_at`; preserve `task_id`, `task_branch`, `created_at`. See AGENTS.md Protocol: Re-run Guard.
 - If the user chooses **Advance** (or 0 findings): proceed to Phase 8 (Push).
 
 ## Phase 8: Push Commits
@@ -1371,9 +1382,16 @@ Where:
 - T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
 
 **Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest)
-2. Search by task ID: `git branch --list "*<task-id>*"` or `git worktree list | grep -iF "<task-id>"`
-3. Derive from Tipo + ID + Title (always works)
+1. Read `branch` from state.json (fastest, source-of-truth).
+2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
+   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
+   ```bash
+   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
+   git worktree list --porcelain 2>/dev/null \
+     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
+   ```
+3. Derive from Tipo + ID + Title (always works).
 
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 
@@ -1893,6 +1911,20 @@ whether to suggest advancement or offer a re-run. This protocol replaces the sta
    - After the re-run completes, apply this protocol again (evaluate findings count)
    - There is no limit on re-runs — the user controls when to stop
 
+   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
+   context", the orchestrator MUST:
+
+   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
+      or another terminal state at the previous run's end).
+   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
+      that performs work, NOT the load-only phases).
+   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
+   4. Preserve `task_id`, `task_branch`, and any other identity fields.
+   5. After reset, normal `Protocol: Session State` updates resume.
+
+   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
+   short-circuit the re-run's loop, producing a phantom "no findings" result.
+
 5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
 
 **NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
@@ -2332,6 +2364,101 @@ Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 7. If subtasks directory exists, read all `.md` files inside it
 
 Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
+
+
+### Protocol: Terminal Identification
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Set title (after task ID is known):**
+
+```bash
+_optimus_set_title() {
+  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
+  # tasks always run in "divorced" iTerm2 sessions where the profile's
+  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
+  # SetUserVar are both ineffective in that state, so AppleScript's
+  # `set name of s` is the only channel that actually mutates session.name.
+  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
+  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
+  # up to 4 ancestors in case of nested shells. First run triggers a macOS
+  # TCC prompt ("droid wants to control iTerm"); approving enables this
+  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
+  # unavailable — non-iTerm2 / non-macOS users get no title update.
+  local title="$1"
+  local pid="$PPID" tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+      *) break ;;
+    esac
+  done
+  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
+     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
+     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
+    osascript \
+      -e 'on run argv' \
+      -e '  set targetTty to "/dev/" & item 1 of argv' \
+      -e '  set newName to item 2 of argv' \
+      -e '  tell application "iTerm2"' \
+      -e '    repeat with w in windows' \
+      -e '      repeat with t in tabs of w' \
+      -e '        repeat with s in sessions of t' \
+      -e '          if (tty of s as string) is targetTty then' \
+      -e '            try' \
+      -e '              set name of s to newName' \
+      -e '            end try' \
+      -e '          end if' \
+      -e '        end repeat' \
+      -e '      end repeat' \
+      -e '    end repeat' \
+      -e '  end tell' \
+      -e 'end run' \
+      -- "$tty" "$title" >/dev/null 2>&1 || true
+  fi
+}
+_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+```
+
+Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+
+**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
+terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
+asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
+session list via AppleScript — that device is connected to the user's real iTerm2
+session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
+function silently no-ops.
+
+**Restore title (at stage completion or exit):**
+
+```bash
+_optimus_set_title ""
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
+"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
+channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
+will not see a title update.
+
+**Troubleshooting iTerm2 (if the title still doesn't update):**
+
+1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
+   sticky on the tab label and overrides the session name visually, even
+   when `session.name` is updated correctly underneath.
+2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
+   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
+   silent no-op.
+3. The helper requires the parent process to have a controlling TTY. Inside
+   Docker/CI without a TTY, no ancestor will resolve and the helper will
+   silently no-op.
+
+Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -385,125 +385,22 @@ Extract: severity (HIGH/MEDIUM/LOW), annotation_level, message, file, line.
 Extract: shortcode, severity, category, analyzer, title, explanation, file, line.
 
 **CodeRabbit comments** (author: `coderabbitai[bot]`):
-- Inline review comments with suggestions (from thread fetch, Step 1.3.1)
-- **Duplicated Comments section** (from review body fetch, Step 1.3.1.5): `<details>` block titled `♻️ Duplicate comments (N)` in the review body listing findings already reported in previous reviews but still unresolved. These are the findings whose inline threads typically became `isOutdated: true` (now collected into `outdated_threads` and auto-resolved hygienically by Step 13.0; the original finding text is not re-evaluated, so the Duplicate Comments review body remains the source of record for this finding's content). Parse per algorithm below and tag with `origin: duplicate`.
-- **Outside diff range section** (from review body fetch, Step 1.3.1.5): `<details>` block titled `⚠️ Outside diff range comments (N)` with suggestions about code OUTSIDE the PR diff. Parse per same algorithm and tag with `origin: outside-diff`.
 
-**Deterministic parsing algorithm (MANDATORY for both sections):**
+**Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body.**
 
-The `<details>` block for a CodeRabbit special section has this exact nested structure:
+The shared protocol covers: GraphQL fetch, per-section deterministic algorithm
+(duplicate / outside-diff sections), per-finding fix-block extraction (Minimal
+fix / Suggested refactor), AI prompt capture, severity mapping, count parity
+HARD BLOCK, aggregate cross-validation, outdated-thread partitioning, and
+origin tagging rules (`[CodeRabbit]` / `[CodeRabbit — DUPLICATE]` /
+`[CodeRabbit — OUTSIDE PR DIFF]`).
 
-```
-<details>
-<summary>♻️ Duplicate comments (N)</summary><blockquote>
-<details>
-<summary>path/to/fileA.py (K1)</summary><blockquote>
-
-`LINE_RANGE`: _⚠️ Potential issue_ | _<EMOJI> <LABEL>_
-
-**<Finding title.>**
-
-<body paragraph(s)>
-
-<details><summary>🐛 Minimal fix</summary>...diff...</details>
-<details><summary>🤖 Prompt for AI Agents</summary>...prompt...</details>
-
----
-
-`LINE_RANGE`: _⚠️ Potential issue_ | _<EMOJI> <LABEL>_
-
-**<Second finding title.>**
-
-... (same structure) ...
-
-</blockquote></details>
-
-<details>
-<summary>path/to/fileB.go (K2)</summary><blockquote>
-... (K2 findings) ...
-</blockquote></details>
-
-</blockquote></details>
-```
-
-**Steps (apply to the latest CodeRabbit review body from Step 1.3.1.5):**
-
-1. **Locate the outer `<details>` block.** Match the opening summary line with case-sensitive regex:
-   - For duplicates: `<summary>♻️ Duplicate comments \((\d+)\)</summary>` → capture `N_TOTAL`.
-   - For outside-diff: `<summary>⚠️ Outside diff range comments \((\d+)\)</summary>` → capture `N_TOTAL`.
-   - If no match → no findings in this section (N=0); skip parsing.
-
-2. **Extract the outer blockquote body** — everything between the `<blockquote>` right after the summary and its matching `</blockquote></details>`. Track nesting: every inner `<details>` opens a level; every matching `</details>` closes one. Stop when the outer level closes.
-
-3. **Iterate inner per-file `<details>` blocks.** Match: `<summary>(.+?) \((\d+)\)</summary>` where the filename pattern allows `/`, `.`, `_`, `-`. Capture `FILE_PATH` and `K_COUNT` per block.
-
-4. **Within each per-file blockquote, split by `---` separator at the top level.** A `---` counts as a finding separator only if it is at the same nesting level as the finding headers — NOT inside any nested `<details>`. Implementation: walk line-by-line, maintain an integer `depth` (increment on `<details>`, decrement on `</details>`); a line matching `^\s*---\s*$` is a separator **only when `depth == 0`**.
-
-5. **Each resulting slice is ONE finding.** Parse its header:
-   - First non-empty line: `` `(\d+(?:-\d+)?)`: _(⚠️ Potential issue|🛠️ Refactor suggestion|🧹 Nitpick|...)_ \| _(🔴|🟠|🟡|🔵) (Critical|Major|Minor|Trivial)_ ``
-   - Capture `LINE_RANGE`, `TYPE_LABEL`, `SEVERITY_EMOJI`, `SEVERITY_LABEL`.
-   - Next bold line (`**...**`) is the `TITLE`.
-   - Everything until the first nested `<details>` or end-of-slice is the `DESCRIPTION`.
-   - **Fix suggestion (`FIX_LABEL` + `FIX_DIFF`):** if a `<details>` block exists whose summary matches one of CodeRabbit's known fix-suggestion labels, capture its body as `FIX_DIFF` and the label text as `FIX_LABEL`. Match summary against either:
-     - `🐛 Minimal fix`
-     - `🐛 Suggested refactor`
-
-     Implementation: regex `<details><summary>(🐛 Minimal fix|🐛 Suggested refactor)</summary>`. Body capture is non-greedy until the matching `</details>` at the same nesting depth — reuse the depth-walking approach from Step 4. The two labels are mutually exclusive within a finding (CodeRabbit picks one); if neither is present, leave both fields empty. **Do NOT match `🐛 Minimal fix` alone** — the legacy single-label match silently dropped findings labeled `Suggested refactor`, even though CodeRabbit had supplied a usable diff.
-   - **AI agent prompt (`AI_PROMPT`):** if a `<details><summary>🤖 Prompt for AI Agents</summary>` exists within the finding slice, capture its content as `AI_PROMPT`. **Important disambiguation:** this is the per-finding prompt block. Do NOT confuse it with the aggregate `🤖 Prompt for all review comments with AI agents` block at the end of the review body, which lives outside any per-finding slice and is consumed separately for cross-validation (see "Cross-validation fallback" below). Both blocks may coexist in the same review body — they are extracted independently. Leave `AI_PROMPT` empty if absent.
-
-6. **Severity mapping:**
-   | Emoji | Label | Severity |
-   |-------|-------|----------|
-   | 🔴 | Critical | CRITICAL |
-   | 🟠 | Major | HIGH |
-   | 🟡 | Minor | MEDIUM |
-   | 🔵 | Trivial | LOW |
-
-7. **Count validation (HARD BLOCK):** After parsing:
-   - Sum per-file extracted findings → must equal `N_TOTAL` from the outer summary.
-   - Per-file extracted count → must equal `K_COUNT` from that file's summary.
-   - **On mismatch: STOP.** Print: `"Parser extracted X of N duplicate comments from review <id>. Aborting to prevent silent loss. Expected N=<N>, got X=<X>. File breakdown: {path: expected_K vs got_K}. Investigate the review body format."` Then ask the user via `AskUser` whether to proceed with the partial set or abort the entire skill run.
-   - This validation is the PRIMARY guardrail against the historical bug where one of two duplicate comments was silently missed.
-   - **Scope of validation:** count parity guards against silent loss of FINDINGS, not of fix-suggestion sub-fields. A finding with empty `FIX_LABEL`/`FIX_DIFF`/`AI_PROMPT` is still a counted finding (CodeRabbit does not always supply those blocks).
-
-**Cross-validation fallback via "Prompt for all review comments" section:**
-
-CodeRabbit additionally emits a `<details>` block titled `🤖 Prompt for all review comments with AI agents` near the end of the review body. Inside its code fence, findings appear as a flat bullet list grouped by section and file:
-
-```
-Inline comments:
-In `@path/to/file.py`:
-- Around line 361-376: <description>
-- Around line 257-266: <description>
-
-Duplicate comments:
-In `@path/to/file.py`:
-- Around line 146-169: <description>
-- Around line 11-12: <description>
-
-Outside diff range comments:
-In `@path/to/other.go`:
-- Around line 42: <description>
-```
-
-**Parse this block IN ADDITION TO the `<details>` parsing:**
-1. Match: `<details>\s*<summary>🤖 Prompt for all review comments with AI agents</summary>`.
-2. Extract the code fence content.
-3. For each section header (`Inline comments:`, `Duplicate comments:`, `Outside diff range comments:`), extract bullets matching: `^- Around line ([\d\-]+):\s+(.+)$` under each `In \`@(.+?)\`:` header.
-4. Map section → origin tag (`inline`, `duplicate`, `outside-diff`).
-
-**Reconciliation (MANDATORY):** Take the **UNION** of findings from both sources (the `<details>` parse AND the "Prompt for all" parse). Match by `(file, line_range)` tuple.
-- Findings present in both → merge (use `<details>` block's richer metadata as primary, use "Prompt for all" description as fallback if `<details>` description was empty).
-- Findings only in one source → keep as-is, log which source surfaced it (for debugging).
-- **Never take the intersection** — one source missing a finding is a parsing bug, not ground truth.
-
-**CodeRabbit origin tagging rules:**
-When presenting findings from CodeRabbit, ALWAYS include the origin tag in the finding header:
-- `[CodeRabbit — DUPLICATE]` for findings from the "Duplicate comments" section. These are repeat findings from previous reviews that remain unaddressed.
-- `[CodeRabbit — OUTSIDE PR DIFF]` for findings from the "Outside diff range" section. These affect code not changed in this PR.
-- `[CodeRabbit]` for regular inline findings (no special tag needed).
-
-This tagging helps the user understand whether the finding is about code they changed in this PR, code outside their changes, or a recurring issue from a previous review.
+**pr-check-specific application:** the parsed findings feed into Step 1.3.4
+(by-source summary) and downstream the CodeRabbit-as-is path that allows
+direct application of `[Minimal fix]` / `[Suggested refactor]` blocks for
+nitpick-level findings without TDD. This as-is path is intentional for
+pr-check — coderabbit-review takes the TDD path for the same sources. See
+the relationship note in coderabbit-review/SKILL.md Phase 4.
 
 **Human reviewer comments:** All threads where the first comment author is not a known bot.
 
@@ -1232,6 +1129,16 @@ For each approved fix, classify its complexity and apply accordingly — see AGE
 1. Apply `FIX_DIFF` verbatim using Edit/MultiEdit. Treat the diff as authoritative — do NOT re-derive from agent recommendation.
 2. Run unit tests to verify no regression.
 3. If tests fail → revert the diff and escalate to ring droid dispatch (Complex flow), informing the user that CodeRabbit's diff did not pass tests as-applied. Record the failure in the per-finding audit trail.
+
+**Relationship to coderabbit-review (intentional divergence):** This as-is path
+is unique to `pr-check` and intentionally absent from `coderabbit-review`.
+`coderabbit-review` always applies CodeRabbit findings via TDD (RED-GREEN-REFACTOR)
+because that skill is for the case where the user wants to deeply understand
+and re-implement each suggestion. `pr-check` accepts the trade-off of merging
+CodeRabbit's exact patches (even nitpicks) because the goal here is unblocking
+PR review, not author understanding. If you want as-is application, stay on
+`pr-check`; if you want TDD-driven re-implementation, switch to
+`coderabbit-review`. See coderabbit-review/SKILL.md Phase 4 for the mirror note.
 
 **Simple fix flow:**
 1. Apply the fix directly using Edit/MultiEdit tools
@@ -2349,10 +2256,29 @@ Droids whose purpose is implementation, design, operations, or non-code domains:
 | **Domain specialist** | Description mentions a specific technology — include only if the project uses it | `lib-commons-reviewer` (if `go.mod` imports `lib-commons`), `multi-tenant-reviewer` (if project uses multi-tenancy), `performance-reviewer` (always relevant) |
 | **Non-reviewer (EXCLUDE)** | Description indicates implementation, design, ops, finance, planning, or infrastructure — NOT code review | See exclusion list above |
 
+**Deny-list filter (applied AFTER inclusion regex, BEFORE final selection):**
+
+If the description matches `architecture|design|planning|process|workflow|strategy`,
+EXCLUDE the agent regardless of inclusion-regex match. These words indicate the
+agent is meta-level (not code review) and should not be dispatched to review code.
+This guards against future agents whose descriptions accidentally match the
+inclusion regex's broader words (e.g., `architecture-reviewer`,
+`design-reviewer`, `process-reviewer`) — they would otherwise be dispatched
+against actual code, which is not their job.
+
+The combined logic: `(matches inclusion regex) AND NOT (matches deny regex) → include`.
+
+**Positive allow-list** (overrides deny-list for known good agents that may have
+"design" or another deny term in their descriptions accidentally): listed in the
+protocol's roster JSON (empty by default; add specific droid IDs as needed).
+Allow-list entries are matched by full droid ID (not regex) so a single
+accidental wording match cannot reopen the deny-list for an entire family of
+droids.
+
 For non-ring entries (only present when `INCLUDE_NON_RING=true`), apply the same
-description filter. Non-ring agents that pass the filter are returned in the `Non-Ring`
-group regardless of stack/domain category — the caller decides whether to default-select
-them in its UX.
+description filter AND the deny-list. Non-ring agents that pass both filters are
+returned in the `Non-Ring` group regardless of stack/domain category — the caller
+decides whether to default-select them in its UX.
 
 **Output format:**
 
@@ -2469,6 +2395,140 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 - If no PR exists, skip.
 
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
+
+
+### Protocol: Parse CodeRabbit Review Body
+
+**Referenced by:** pr-check, coderabbit-review
+
+Deterministic algorithm for extracting actionable findings from a CodeRabbit
+review-body GraphQL response. Both pr-check and coderabbit-review consume the
+same source format; this protocol is the single source of truth so the two
+skills cannot drift in their parsing rules. Drift is exactly how CodeRabbit
+findings get silently dropped — see the historical "duplicate comments missed"
+incident that motivated the count-parity guard below.
+
+**Source data — GraphQL fields fetched:**
+
+The CodeRabbit review body is obtained via the GitHub GraphQL API:
+
+```graphql
+pullRequest(number: $pr) {
+  reviews(first: 100) {
+    nodes {
+      author { login }      # filter to coderabbitai[bot]
+      body                  # markdown body containing the <details> blocks below
+      submittedAt
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+Take the **latest** review whose author is `coderabbitai[bot]`. Pagination via
+`pageInfo` is mandatory when `hasNextPage` is true.
+
+**Parsing algorithm — top-level sections:**
+
+The latest CodeRabbit review body contains zero or more of these top-level
+`<details>` blocks (each parsed via the per-section algorithm below):
+
+| Top-level summary regex | Origin tag | Description |
+|------------------------|------------|-------------|
+| `♻️ Duplicate comments \((\d+)\)` | `duplicate` | Findings repeated from previous reviews, still unresolved |
+| `⚠️ Outside diff range comments \((\d+)\)` | `outside-diff` | Findings about code outside the PR diff |
+| `🤖 Prompt for all review comments with AI agents` | `aggregate` (cross-validation only, NOT a per-finding source) | Aggregate flat-list block used to cross-check the per-finding parse |
+
+Inline (in-diff) findings come from the per-thread GraphQL fetch (review
+threads), not from the review body — they are tagged `origin: inline` by the
+caller. The review body parser handles only the duplicate/outside-diff
+sections plus the aggregate cross-validation block.
+
+**Per-section algorithm (applied to each top-level `<details>` block):**
+
+1. **Locate the outer `<details>`** by matching the summary regex (case-sensitive).
+   Capture `N_TOTAL`. If no match: section absent (N=0) — skip.
+
+2. **Extract the outer blockquote body**, tracking nesting: every inner
+   `<details>` opens a level; every matching `</details>` closes one. Stop
+   when the outer level closes.
+
+3. **Iterate inner per-file `<details>` blocks**:
+   `<summary>(.+?) \((\d+)\)</summary>` — capture `FILE_PATH` and `K_COUNT`.
+
+4. **Within each per-file blockquote, split by `---` separators at the top
+   level** (depth == 0). Walk line-by-line, increment depth on `<details>`,
+   decrement on `</details>`; a line `^\s*---\s*$` is a separator only when
+   depth == 0.
+
+5. **Each slice = ONE finding.** Parse:
+   - First non-empty line: `` `(\d+(?:-\d+)?)`: _(⚠️ Potential issue|🛠️ Refactor suggestion|🧹 Nitpick|...)_ \| _(🔴|🟠|🟡|🔵) (Critical|Major|Minor|Trivial)_ `` — capture `LINE_RANGE`, `TYPE_LABEL`, `SEVERITY_EMOJI`, `SEVERITY_LABEL`.
+   - Next bold line `**...**` is the `TITLE`.
+   - Body until first nested `<details>` or end-of-slice is the `DESCRIPTION`.
+
+6. **Per-finding fix-block extraction.** Within each finding's slice:
+   - `FIX_LABEL` + `FIX_DIFF` — match `<details><summary>(🐛 Minimal fix|🐛 Suggested refactor)</summary>` (the two labels are mutually exclusive within one finding; if neither is present, leave both empty). **Critical:** match BOTH labels — matching only `🐛 Minimal fix` silently drops findings labeled `Suggested refactor` even when the diff is supplied.
+   - `AI_PROMPT` — match `<details><summary>🤖 Prompt for AI Agents</summary>` and capture body. **Disambiguation:** this is the per-finding prompt block, NOT the aggregate `🤖 Prompt for all review comments with AI agents` block. Both can coexist; extract independently.
+
+7. **Severity mapping:**
+
+   | Emoji | Label | Severity |
+   |-------|-------|----------|
+   | 🔴 | Critical | CRITICAL |
+   | 🟠 | Major | HIGH |
+   | 🟡 | Minor | MEDIUM |
+   | 🔵 | Trivial | LOW |
+
+**Count parity validation (HARD BLOCK on mismatch):**
+
+After parsing each section:
+- Sum per-file extracted findings → must equal `N_TOTAL`.
+- Per-file extracted count → must equal `K_COUNT` for every file.
+
+**On mismatch: STOP immediately.** Print: parsed N, expected M, file
+breakdown, missing/extra IDs. **Do NOT offer an opt-out** — a silent
+partial-set continuation is exactly the failure mode this gate prevents. The
+user must investigate the parser or CodeRabbit output before the skill can
+proceed.
+
+**Cross-validation via aggregate prompt block:**
+
+CodeRabbit emits a `<details><summary>🤖 Prompt for all review comments with AI agents</summary>` block listing findings as a flat bullet list grouped by section. Parse it independently and take the **UNION** with the per-section parse, matched by `(file, line_range)`:
+- In both → merge (per-section block is primary; aggregate description is fallback).
+- Only in one → keep, log which source surfaced it.
+- **Never take the intersection** — single-source absence is a parsing bug, not ground truth.
+
+**Outdated-thread partitioning:**
+
+Inline review threads with `isOutdated: true` are partitioned out of the
+active findings set. The original finding text is preserved in the duplicate
+comments section of the review body (CodeRabbit re-emits unresolved findings
+across reviews), so the duplicate-section parse remains the source of record
+for content. Outdated threads are typically auto-resolved by the consuming
+skill's hygiene step — see pr-check Step 13.0.
+
+**Origin tagging rules** (when presenting findings to the user, ALWAYS include
+the origin tag in the finding header):
+
+| Source | Tag |
+|--------|-----|
+| Per-thread inline review comment (in-diff) | `[CodeRabbit]` |
+| Duplicate-comments section | `[CodeRabbit — DUPLICATE]` |
+| Outside-diff-range section | `[CodeRabbit — OUTSIDE PR DIFF]` |
+| Non-CodeRabbit (Codacy/DeepSource/CI/human) | their own origin tag — NOT this protocol |
+
+**Distinguishing CodeRabbit from CI bot, duplicate, human:**
+
+This protocol handles CodeRabbit only. The caller separately identifies:
+- **CI bots** (`github-actions[bot]`, `codacy-production[bot]`, `deepsource-io[bot]`, etc.) — handled by their own per-bot parsers.
+- **Duplicate findings** (CodeRabbit's own duplicate section) — origin-tagged here, not de-duplicated against earlier reviews.
+- **Human reviewers** — every author whose login is not in the known-bot list.
+
+**Caller-specific application** (NOT part of this protocol):
+- pr-check applies CodeRabbit-as-is (`[Minimal fix]` / `[Suggested refactor]` direct application path) for nitpick-level findings — see pr-check Step 1.3.3 surrounding prose.
+- coderabbit-review always applies findings via TDD — see coderabbit-review Phase 4. The relationship between the two skills is documented in coderabbit-review/SKILL.md ("Relationship to pr-check").
+
+Skills reference this as: "Parse CodeRabbit review body — see AGENTS.md Protocol: Parse CodeRabbit Review Body."
 
 
 ### Protocol: Per-Droid Quality Checklists

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -357,19 +357,24 @@ if [ -z "$TASK_ID" ] || ! [[ "$TASK_ID" =~ ^T-[0-9]+$ ]]; then
   # STOP
 fi
 
-# Use awk's literal index() (not regex ~) so a future relaxation of the TASK_ID format
-# (e.g., alphanumeric suffix) does not suddenly change semantics through regex metachars.
+# Anchor the match on the kebab-cased task ID (e.g., `-t-1-`) so substrings like
+# `t-1` cannot match `t-10`/`t-100`. Worktree paths follow the convention
+# `<parent>/<repo>-<id>-<keywords>`, and feature branches follow
+# `<tipo>/<id>-<keywords>` — both surround the lowercased ID with hyphens.
+TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
 WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
-  | awk -v id="$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')" '
-      BEGIN { if (id == "") exit 1 }
+  | awk -v anchor="$TASK_KEBAB" '
+      BEGIN { if (anchor == "--") exit 1 }
       /^worktree / { wt=$2 }
-      /^branch /   { if (index(tolower(wt), id) > 0 || index(tolower($2), id) > 0) print wt }
-    ' | head -1)
+      /^branch /   { if (index(tolower(wt), anchor) > 0 || index(tolower($2), anchor) > 0) { print wt; exit } }
+    ')
 
 if [ -z "$WORKTREE_PATH" ]; then
-  # Fallback: literal task-ID search. The Step 3.2 hard guard above already refused empty
-  # TASK_ID, so grep -F has a non-empty pattern here.
-  WORKTREE_PATH=$(git worktree list | grep -iF "$TASK_ID" | awk '{print $1}' | head -1)
+  # Fallback: anchored kebab match against the path field only. NEVER use a bare
+  # `grep -iF "$TASK_ID"` — that produces false positives for short IDs
+  # (e.g., `T-1` matching `T-10`, `T-100`).
+  WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+    | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
 fi
 ```
 
@@ -516,41 +521,6 @@ If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
 Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `RESUME`:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
 _optimus_set_title "optimus: RESUME $TASK_ID — $TASK_TITLE"
 ```
 
@@ -997,9 +967,16 @@ Where:
 - T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
 
 **Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest)
-2. Search by task ID: `git branch --list "*<task-id>*"` or `git worktree list | grep -iF "<task-id>"`
-3. Derive from Tipo + ID + Title (always works)
+1. Read `branch` from state.json (fastest, source-of-truth).
+2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
+   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
+   ```bash
+   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
+   git worktree list --porcelain 2>/dev/null \
+     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
+   ```
+3. Derive from Tipo + ID + Title (always works).
 
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -126,44 +126,36 @@ Execute session state protocol — see AGENTS.md Protocol: Session State. Use st
 
 ### Step 1.0.7.1: Set Terminal Title
 
-**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance. Execute this command NOW:
+**CRITICAL:** Set the terminal title so the user can identify this terminal at a glance.
+
+**First, parse `TASK_TITLE` from optimus-tasks.md** — the title is interpolated
+into the terminal title below, and parsing it lazily (after the title is set)
+results in `optimus: REVIEW T-XXX — ` with an empty trailing dash:
 
 ```bash
-_optimus_set_title() {
-  local title="$1"
-  local pid="$PPID" tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
-      *) break ;;
-    esac
-  done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
-}
+# optimus-tasks.md columns by pipe index:
+# | 1=<blank> | 2=ID | 3=Title | 4=Tipo | 5=Depends | 6=Priority | 7=Version | 8=Estimate | 9=TaskSpec | 10=<blank> |
+# Use the same parser pattern as resume/SKILL.md Step 2.3 (Read Task Metadata).
+TASK_TITLE=$(awk -F'|' -v id="$TASK_ID" '
+  { gsub(/^[[:space:]]+|[[:space:]]+$/,"",$2) }
+  $2 == id {
+    title=$3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", title)
+    print title
+    exit
+  }
+' "$TASKS_FILE")
+
+if [ -z "$TASK_TITLE" ]; then
+  # Non-fatal: the terminal title is informational. Fall back to a stub so the
+  # later interpolation does not produce a trailing-dash artifact.
+  TASK_TITLE="(title unavailable)"
+fi
+```
+
+Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `REVIEW`:
+
+```bash
 _optimus_set_title "optimus: REVIEW $TASK_ID — $TASK_TITLE"
 ```
 
@@ -765,7 +757,7 @@ Execute re-run guard — see AGENTS.md Protocol: Re-run Guard.
 - If the user chooses **Re-run with clean context**: go back to Step 1.1 (Discover Project
   Structure). Skip all prior setup steps (GitHub CLI check, optimus-tasks.md validation, workspace
   resolution, task identification, session state, status validation, divergence check).
-  Increment stage stats before re-starting analysis.
+  Increment stage stats before re-starting analysis. Apply the **Re-run reset semantics**: reset `convergence_status` to `null`; reset `phase` to the first re-executed phase; overwrite `started_at`; preserve `task_id`, `task_branch`, `created_at`. See AGENTS.md Protocol: Re-run Guard.
 - If the user chooses **Advance** (or 0 findings): proceed to Phase 10 (integration tests).
 
 ---
@@ -2407,6 +2399,20 @@ whether to suggest advancement or offer a re-run. This protocol replaces the sta
    - After the re-run completes, apply this protocol again (evaluate findings count)
    - There is no limit on re-runs — the user controls when to stop
 
+   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
+   context", the orchestrator MUST:
+
+   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
+      or another terminal state at the previous run's end).
+   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
+      that performs work, NOT the load-only phases).
+   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
+   4. Preserve `task_id`, `task_branch`, and any other identity fields.
+   5. After reset, normal `Protocol: Session State` updates resume.
+
+   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
+   short-circuit the re-run's loop, producing a phantom "no findings" result.
+
 5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
 
 **NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
@@ -2805,6 +2811,101 @@ Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
+### Protocol: Terminal Identification
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Set title (after task ID is known):**
+
+```bash
+_optimus_set_title() {
+  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
+  # tasks always run in "divorced" iTerm2 sessions where the profile's
+  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
+  # SetUserVar are both ineffective in that state, so AppleScript's
+  # `set name of s` is the only channel that actually mutates session.name.
+  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
+  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
+  # up to 4 ancestors in case of nested shells. First run triggers a macOS
+  # TCC prompt ("droid wants to control iTerm"); approving enables this
+  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
+  # unavailable — non-iTerm2 / non-macOS users get no title update.
+  local title="$1"
+  local pid="$PPID" tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+      *) break ;;
+    esac
+  done
+  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
+     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
+     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
+    osascript \
+      -e 'on run argv' \
+      -e '  set targetTty to "/dev/" & item 1 of argv' \
+      -e '  set newName to item 2 of argv' \
+      -e '  tell application "iTerm2"' \
+      -e '    repeat with w in windows' \
+      -e '      repeat with t in tabs of w' \
+      -e '        repeat with s in sessions of t' \
+      -e '          if (tty of s as string) is targetTty then' \
+      -e '            try' \
+      -e '              set name of s to newName' \
+      -e '            end try' \
+      -e '          end if' \
+      -e '        end repeat' \
+      -e '      end repeat' \
+      -e '    end repeat' \
+      -e '  end tell' \
+      -e 'end run' \
+      -- "$tty" "$title" >/dev/null 2>&1 || true
+  fi
+}
+_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+```
+
+Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+
+**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
+terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
+asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
+session list via AppleScript — that device is connected to the user's real iTerm2
+session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
+function silently no-ops.
+
+**Restore title (at stage completion or exit):**
+
+```bash
+_optimus_set_title ""
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
+"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
+channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
+will not see a title update.
+
+**Troubleshooting iTerm2 (if the title still doesn't update):**
+
+1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
+   sticky on the tab label and overrides the session name visually, even
+   when `session.name` is updated correctly underneath.
+2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
+   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
+   silent no-op.
+3. The helper requires the parent process to have a controlling TTY. Inside
+   Docker/CI without a TTY, no ancestor will resolve and the helper will
+   silently no-op.
+
+Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+
+
 ### Protocol: Workspace Auto-Navigation (HARD BLOCK)
 
 **Referenced by:** stages 2-4
@@ -2858,11 +2959,30 @@ fi
        T-002 — Login page (Em Andamento) → /projeto-t-002-.../
      Which task should I continue?
      ```
-   - After task is identified, locate the worktree by task ID:
+   - After task is identified, locate the worktree. Prefer the source-of-truth
+     (state.json `branch` field) and match the porcelain output by exact
+     branch ref. Fall back to a kebab-anchored path match — never an
+     unanchored substring grep on the bare task ID, which produces false
+     positives for short IDs (e.g., `T-1` matching `T-10`, `T-100`):
      ```bash
-     git worktree list | grep -iF "<task-id>"
+     # Source-of-truth: branch from state.json (set by stage 1).
+     TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+       "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+     WORKTREE_PATH=""
+     if [ -n "$TASK_BRANCH" ]; then
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+         /^worktree / { path=$2 }
+         /^branch /   { if ($2 == br) { print path; exit } }
+       ')
+     fi
+     if [ -z "$WORKTREE_PATH" ]; then
+       # Fallback: anchored kebab-cased path-segment match (avoids T-1 vs T-10 substring collision).
+       TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+       WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+         | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+     fi
      ```
-   - **If worktree found** → change working directory to the worktree path.
+   - **If `WORKTREE_PATH` is non-empty** → change working directory to it.
    - **If worktree NOT found** → derive the branch name (Protocol: Branch Name Derivation)
      and verify it exists:
      ```bash

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -2451,3 +2451,237 @@ class TestStructuredAskUserScope:
         assert "Scope of the structured AskUser template" in content, (
             "AGENTS.md must document the scope of the AskUser structured template."
         )
+
+
+# --- F11: done skill robustness regression tests ---
+
+
+class TestDoneRobustness:
+    """F11 regression tests: done skill must handle push-failure modes
+    explicitly and use deterministic resolutions."""
+
+    def test_done_classifies_remote_delete_failures(self):
+        """done/SKILL.md must distinguish network/protection/already-deleted
+        on `git push origin --delete` failure."""
+        path = REPO_ROOT / "done" / "skills" / "optimus-done" / "SKILL.md"
+        content = path.read_text()
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        # At minimum the body must mention these failure-cause keywords
+        # near a `git push origin --delete` block.
+        assert "remote ref does not exist" in body or "already deleted" in body, (
+            "done must classify 'remote ref does not exist' as benign"
+        )
+        assert "protected" in body, "done must distinguish protected-branch failures"
+        assert "Network" in body or "connection" in body or "timeout" in body, (
+            "done must distinguish network/transient failures"
+        )
+
+    def test_done_uses_deterministic_default_branch(self):
+        """done/SKILL.md must use show-ref --verify (or symbolic-ref) for
+        default branch resolution — NOT 'git branch --list main master | head -1'."""
+        path = REPO_ROOT / "done" / "skills" / "optimus-done" / "SKILL.md"
+        content = path.read_text()
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        forbidden = "git branch --list main master | head"
+        assert forbidden not in body, (
+            f"done body contains non-deterministic default-branch resolution: {forbidden!r}"
+        )
+        assert "show-ref --verify" in body or "symbolic-ref" in body or (
+            "AGENTS.md Protocol: Default Branch Resolution" in body
+        ) or (
+            "AGENTS.md Protocol: Workspace Auto-Navigation" in body
+        ), "done must use deterministic resolution (or reference canonical protocol)"
+
+
+class TestStageSkillsParseTaskTitleEarly:
+    """F11d regression: stage skills must parse TASK_TITLE before
+    interpolating it into the terminal title."""
+
+    STAGE_SKILLS = ["plan", "build", "review", "done"]
+
+    def test_stage_skills_parse_task_title_from_tasks_file(self):
+        violations = []
+        for skill in self.STAGE_SKILLS:
+            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
+            content = path.read_text()
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            # The terminal title interpolates $TASK_TITLE; before that line,
+            # the skill must have an awk/grep against optimus-tasks.md or a
+            # documented metadata-extraction step.
+            if "TASK_TITLE" in body:
+                # Must parse it from somewhere
+                if not any(
+                    p in body
+                    for p in (
+                        "awk",
+                        "grep",
+                        "TASK_TITLE=$(",
+                        'TASK_TITLE="$(',
+                        "Read task metadata",
+                    )
+                ):
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}: TASK_TITLE used but never parsed"
+                    )
+        assert violations == [], "\n".join(violations)
+
+
+class TestTaskIdMatchUsesAnchoredPattern:
+    """F11c regression: searches for a worktree by TASK_ID must NOT use
+    `grep -iF` (substring) which produces false positives for short IDs."""
+
+    def test_no_unanchored_taskid_grep(self):
+        violations = []
+        targets = [REPO_ROOT / "AGENTS.md", *REPO_ROOT.glob("*/skills/*/SKILL.md")]
+        for path in targets:
+            content = path.read_text()
+            body = (
+                content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+                if "skills/" in str(path)
+                else content
+            )
+            for lineno, line in enumerate(body.splitlines(), start=1):
+                # Match `git worktree list ... | grep -iF "$TASK_ID"` patterns
+                if (
+                    "git worktree list" in line
+                    and "grep -iF" in line
+                    and "TASK_ID" in line
+                ):
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}:{lineno}: unanchored grep"
+                    )
+        assert violations == [], (
+            "Unanchored TASK_ID greps allow false positives (T-1 matches T-10):\n"
+            + "\n".join(violations)
+        )
+
+
+class TestReRunGuardResetSemantics:
+    """F12b: Re-run Guard must explicitly reset convergence_status and phase
+    to prevent phantom convergence on subsequent runs."""
+
+    def test_agents_md_documents_rerun_reset_semantics(self):
+        content = (REPO_ROOT / "AGENTS.md").read_text()
+        assert "Re-run reset semantics" in content
+        assert "convergence_status" in content
+        assert "MUST" in content  # mandatory marker
+
+
+class TestPrCheckHardBlocksAreUncompromising:
+    """F12c: pr-check HARD BLOCK markers must not be paired with an AskUser
+    that lets the user opt out of the block."""
+
+    def test_no_askuser_immediately_after_hard_block_in_pr_check(self):
+        path = REPO_ROOT / "pr-check" / "skills" / "optimus-pr-check" / "SKILL.md"
+        content = path.read_text()
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        # Find each "HARD BLOCK" mention and inspect the next ~40 lines for AskUser
+        violations = []
+        lines = body.splitlines()
+        for i, line in enumerate(lines):
+            if "HARD BLOCK" in line:
+                window = "\n".join(lines[i:i + 40])
+                if "Proceed with partial" in window or "proceed with the partial" in window:
+                    violations.append(
+                        f"line {i+1}: HARD BLOCK followed by partial-set AskUser"
+                    )
+        assert violations == [], "\n".join(violations)
+
+
+class TestSharedCodeRabbitParserProtocol:
+    """F12d: Both pr-check and coderabbit-review must reference the shared
+    AGENTS.md `Protocol: Parse CodeRabbit Review Body` instead of carrying
+    their own divergent copies of the algorithm."""
+
+    def test_agents_md_defines_shared_protocol(self):
+        content = (REPO_ROOT / "AGENTS.md").read_text()
+        assert "### Protocol: Parse CodeRabbit Review Body" in content, (
+            "AGENTS.md must define the shared CodeRabbit parser protocol"
+        )
+
+    def test_pr_check_references_shared_protocol(self):
+        path = REPO_ROOT / "pr-check" / "skills" / "optimus-pr-check" / "SKILL.md"
+        content = path.read_text()
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        assert "Protocol: Parse CodeRabbit Review Body" in body, (
+            "pr-check SKILL body must reference the shared protocol"
+        )
+
+    def test_coderabbit_review_references_shared_protocol(self):
+        path = (
+            REPO_ROOT
+            / "coderabbit-review"
+            / "skills"
+            / "optimus-coderabbit-review"
+            / "SKILL.md"
+        )
+        content = path.read_text()
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        assert "Protocol: Parse CodeRabbit Review Body" in body, (
+            "coderabbit-review SKILL body must reference the shared protocol"
+        )
+
+
+class TestDiscoverReviewDroidsDenyList:
+    """F12e: Protocol: Discover Review Droids must apply a deny-list filter
+    (architecture/design/planning/process/workflow/strategy) AFTER the
+    inclusion regex to prevent meta-level reviewers from being dispatched
+    against actual code."""
+
+    def test_agents_md_defines_deny_list(self):
+        content = (REPO_ROOT / "AGENTS.md").read_text()
+        # Locate the Discover Review Droids section
+        start = content.find("### Protocol: Discover Review Droids")
+        assert start != -1
+        # Find the next protocol section
+        end = content.find("\n### Protocol: ", start + 1)
+        section = content[start:end if end != -1 else len(content)]
+        assert "Deny-list filter" in section, (
+            "Discover Review Droids must define a Deny-list filter section"
+        )
+        # Required deny-regex words
+        for term in (
+            "architecture",
+            "design",
+            "planning",
+            "process",
+            "workflow",
+            "strategy",
+        ):
+            assert term in section, f"Deny-list must mention {term!r}"
+
+    def test_deny_list_does_not_block_known_good_droids(self):
+        """Sanity check: the deny-list applies AFTER the inclusion regex,
+        so genuine reviewers like `ring-default-code-reviewer` whose
+        descriptions do NOT contain deny terms remain dispatchable.
+
+        We assert this structurally by verifying the protocol documents the
+        explicit ordering: inclusion regex -> deny-list -> final selection.
+        """
+        content = (REPO_ROOT / "AGENTS.md").read_text()
+        start = content.find("### Protocol: Discover Review Droids")
+        end = content.find("\n### Protocol: ", start + 1)
+        section = content[start:end if end != -1 else len(content)]
+        # Order semantics MUST be made explicit
+        assert "AFTER inclusion regex" in section or "applied AFTER" in section
+        assert "BEFORE final selection" in section or "BEFORE final" in section
+
+
+class TestTerminalIdentificationNotPastedInBody:
+    """F12f: After consolidating `_optimus_set_title`, no SKILL body should
+    contain a manual definition. The function comes from the inlined block
+    via the `AGENTS.md Protocol: Terminal Identification` reference."""
+
+    def test_no_set_title_definition_in_skill_bodies(self):
+        violations = []
+        for skill_path in _all_skill_files():
+            content = skill_path.read_text()
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            if "_optimus_set_title() {" in body:
+                violations.append(str(skill_path.relative_to(REPO_ROOT)))
+        assert violations == [], (
+            "These SKILL.md files still contain a body-level "
+            "`_optimus_set_title()` definition; move it to the inlined "
+            "`Protocol: Terminal Identification` block:\n"
+            + "\n".join(violations)
+        )

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -475,11 +475,29 @@ Show the new table order.
    **IMPORTANT:** Worktree must be removed BEFORE attempting branch deletion (step 5b).
    Git refuses to delete a branch that is checked out in a worktree.
 
+   Resolve the worktree by branch (source-of-truth from state.json) with a
+   kebab-anchored fallback. Never `grep -iF "T-XXX"` directly — that would
+   match `T-1` against `T-10`/`T-100`:
+
    ```bash
-   git worktree list | grep -iF "T-XXX"
+   # Source-of-truth: branch from state.json.
+   TASK_BRANCH=$(jq -r --arg id "$TASK_ID" '.[$id].branch // ""' \
+     "${MAIN_WORKTREE}/.optimus/state.json" 2>/dev/null)
+   WORKTREE_PATH=""
+   if [ -n "$TASK_BRANCH" ]; then
+     WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null | awk -v br="refs/heads/$TASK_BRANCH" '
+       /^worktree / { path=$2 }
+       /^branch /   { if ($2 == br) { print path; exit } }
+     ')
+   fi
+   if [ -z "$WORKTREE_PATH" ]; then
+     TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
+     WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
+       | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) { print path; exit } }')
+   fi
    ```
 
-   If a worktree is found, ask via `AskUser`:
+   If a worktree is found (`WORKTREE_PATH` non-empty), ask via `AskUser`:
    ```
    Task T-XXX has a worktree at '<path>'. What should I do with it?
    ```


### PR DESCRIPTION
## Summary

Fourth batch from deep-review session. Lands two HIGH-severity groups:
- **F11** — Done skill robustness gaps (4 sub-fixes)
- **F12** — Stage-agent prompt quality (7 sub-fixes)

Builds on PR #35 (F1+F2+F3), PR #36 (F4+F5), PR #37 (F6+F7).

## What's in this PR

### F11 — Done skill robustness (HIGH)

**F11a — `git push origin --delete` recovery handler.** Failures (network, branch protection, ref-already-deleted) used to leave inconsistent state silently. Now classified explicitly:
- `remote ref does not exist` / `already deleted` → benign info message
- `protected branch` → manual-cleanup hint + AskUser
- `connection` / `timeout` / `unable to access` → retry guidance
- other → verbose error
- `pending_remote_delete` flag suggested for future retry surface

**F11b — Deterministic `DEFAULT_BRANCH`.** New AGENTS.md `Protocol: Default Branch Resolution`:
```
symbolic-ref refs/remotes/origin/HEAD → show-ref refs/heads/main → show-ref refs/heads/master → hard error
```
done/SKILL.md replaces `git branch --list main master | head -1` (non-deterministic) with reference to canonical protocol.

**F11c — Hybrid TASK_ID worktree-match.** `grep -iF "$TASK_ID"` matched substring (T-1 ⊂ T-10). New strategy: state.json `branch` as primary (post-F1 reliable from any worktree); kebab-anchored awk fallback (`-t-1-` not `t-1`). Sites updated: done, plan, build, review, resume, tasks, AGENTS.md Workspace Auto-Navigation + Branch Name Derivation.

Bonus catches:
- `tasks/SKILL.md` cancel-task flow had unanchored grep
- `resume/SKILL.md` Step 3.2 used bare lowercase task ID

**F11d — TASK_TITLE parsed early.** Stage skills now parse Title from `optimus-tasks.md` row (column 3 with `-F'|'`) BEFORE `_optimus_set_title` interpolation. Mirrors resume/SKILL.md Step 2.3. Non-fatal fallback `(title unavailable)`.

### F12 — Stage-agent prompt quality (HIGH)

**F12a — `build` subtask droid prior context.** Prompt template now includes `Previously completed subtasks` section populated from session state or `git log --oneline --grep='subtask_'`. Subtask 002's droid sees what subtask 001 did.

**F12b — Re-run reset semantics MANDATORY.** AGENTS.md Re-run Guard now explicit:
- Reset `convergence_status` → `null`
- Reset `phase` → entry
- Overwrite `started_at`
- Preserve `task_id` / `task_branch`

Prevents phantom CONVERGED short-circuit. Plan Phase 7 + review Phase 9 reference.

**F12c — pr-check HARD BLOCK uncompromising.** Step 1.3.3 count-mismatch path: removed AskUser fallback. "Do NOT offer an opt-out" explicit. Diagnostic prints parsed/expected/missing.

**F12d — Shared CodeRabbit parser.** New `Protocol: Parse CodeRabbit Review Body` in AGENTS.md (~120 lines: GraphQL fields, fix-block extraction `[Minimal fix]`/`[Suggested refactor]`, count parity HARD BLOCK, outdated-thread partitioning, origin tags). Both pr-check Step 1.3.3 and coderabbit-review Step 2.1 reference it.

**F12e — Discover Review Droids deny-list.** `architecture|design|planning|process|workflow|strategy` → exclude even if inclusion regex matched. Positive allow-list for known-good outliers documented. Logic: `(matches inclusion) AND NOT (matches deny) → include`.

**F12f — `_optimus_set_title` auto-inline.** Removed manual `_optimus_set_title()` body paste from build/plan/review/done SKILLs. Reference `AGENTS.md Protocol: Terminal Identification` via canonical phrasing rule (F3.3f). Inliner body-paste WARNING (F3.3e) now reports zero offenders.

**F12g — TDD-vs-as-is divergence documented.** coderabbit-review (TDD-always) and pr-check (CodeRabbit-as-is for nitpicks) carry mirror notes explaining the intentional divergence and when to pick which.

## Test plan

- [x] `python3 -m pytest scripts/ -v` — 290 passed, 1 pre-existing failure
- [x] `make lint` — passes (ruff + py_compile + shellcheck)
- [x] `make check-inline` — clean (0 unmatched refs, 0 body-paste WARNINGs, no `_optimus_set_title` regression)
- [ ] CI on this PR

## New tests (+9 classes / ~12 tests)

| Class | Coverage |
|-------|----------|
| `TestDoneRobustness` (×2) | classifies push failures + uses deterministic DEFAULT_BRANCH |
| `TestStageSkillsParseTaskTitleEarly` | TASK_TITLE parsed before terminal-title interpolation |
| `TestTaskIdMatchUsesAnchoredPattern` | no unanchored `grep -iF "$TASK_ID"` |
| `TestReRunGuardResetSemantics` | AGENTS.md documents reset MUST |
| `TestPrCheckHardBlocksAreUncompromising` | no AskUser within HARD BLOCK windows |
| `TestSharedCodeRabbitParserProtocol` | both pr-check and coderabbit-review reference shared protocol |
| `TestDiscoverReviewDroidsDenyList` | deny-list documented + applied AFTER inclusion |
| `TestTerminalIdentificationNotPastedInBody` | no `_optimus_set_title()` body definitions |

## Files modified

20 files, +2888 / −701. Highlights:
- `AGENTS.md` (3 new protocols / clarifications: Default Branch Resolution, Parse CodeRabbit Review Body, Discover Review Droids deny-list, Re-run Guard reset semantics; updated Workspace Auto-Navigation + Branch Name Derivation)
- `done/SKILL.md` (push-failure handler, deterministic default branch, anchored worktree match, TASK_TITLE parse)
- `build/plan/review/SKILL.md` (TASK_TITLE parse, set-title canonical reference)
- `pr-check/SKILL.md` (uncompromising HARD BLOCK, parser reference, divergence note)
- `coderabbit-review/SKILL.md` (parser reference, divergence note)
- `resume/SKILL.md` + `tasks/SKILL.md` (anchored TASK_ID matches)
- `scripts/test_skill_consistency.py` (+9 test classes)
- 8× `commands/*.md` (auto-synced)

## Punch list — remaining

After this PR:
- [ ] F9 (test infrastructure residual)
- [ ] F10 (metadata drift)
- [ ] F13 (operational hygiene)
- [ ] F14 (cosmetic/perf bucket — Option B = full sweep)
- [ ] F8 architectural decision tracked at #34