### PR TITLE
feat(plan): self-heal missing TaskSpec via ring:pre-dev-feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,7 +530,7 @@ These operations require explicit user confirmation.
 
 ### Task Spec Resolution
 
-Every task MUST have a Ring pre-dev reference in the `TaskSpec` column. Stage agents
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus-plan` run will offer to generate or link a spec. Stage agents
 (plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
 referenced file for objective, acceptance criteria, and implementation details.
 
@@ -3266,6 +3266,8 @@ agents run simultaneously (e.g., two terminals), the last write wins and the fir
 task's status update may be lost. This is an accepted limitation — Optimus processes
 one task at a time. For parallel task work, use separate worktrees but run stage
 commands sequentially.
+
+Note: Self-heal in `/optimus:plan` Step 1.0.4.5 also mutates `optimus-tasks.md` (the TaskSpec column). The same caveat applies — run plan sequentially against the same task to avoid duplicate Ring invocations and merge conflicts on the TaskSpec column. The `optimus-resolve` skill handles the conflict if it occurs.
 
 ### Standalone Skills vs Ring Droid Dispatch
 The `deep-review` and `deep-doc-review` standalone skills apply fixes directly in their

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2236,7 +2236,7 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
 1. Read the task's `TaskSpec` column from `optimus-tasks.md`
-2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus-tasks` or `/optimus-import`."
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus-plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
    This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -692,7 +692,7 @@ These operations require explicit user confirmation.
 
 ### Task Spec Resolution
 
-Every task MUST have a Ring pre-dev reference in the `TaskSpec` column. Stage agents
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus-plan` run will offer to generate or link a spec. Stage agents
 (plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
 referenced file for objective, acceptance criteria, and implementation details.
 
@@ -2168,7 +2168,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
 1. Read the task's `TaskSpec` column from `optimus-tasks.md`
-2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus-tasks` or `/optimus-import`."
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus-plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
    This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the

--- a/commands/build.md
+++ b/commands/build.md
@@ -630,7 +630,7 @@ These operations require explicit user confirmation.
 
 ### Task Spec Resolution
 
-Every task MUST have a Ring pre-dev reference in the `TaskSpec` column. Stage agents
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus:plan` run will offer to generate or link a spec. Stage agents
 (plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
 referenced file for objective, acceptance criteria, and implementation details.
 
@@ -2106,7 +2106,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
 1. Read the task's `TaskSpec` column from `optimus-tasks.md`
-2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus:tasks` or `/optimus:import`."
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus:plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
    This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the

--- a/commands/import.md
+++ b/commands/import.md
@@ -233,15 +233,28 @@ without Ring pre-dev specs):
 1. Count tasks without specs
 2. Ask via `AskUser`:
    ```
-   N tasks have no Ring pre-dev spec. Generate specs now?
+   N tasks have no Ring pre-dev spec. How should I proceed?
    ```
    Options:
-   - **Generate all** — invoke `ring:pre-dev-feature` for each task
-   - **Skip** — keep TaskSpec as `-`, generate specs later
-3. If "Generate all":
-   - For each task, invoke `ring:pre-dev-feature` passing title and tipo
-   - After Ring generates the spec, update the task's TaskSpec value
-4. If Ring is not available, warn and keep TaskSpec as `-`
+   - **Generate all via Ring** — invoke `ring:pre-dev-feature` for each task
+   - **Generate selectively** — for each task, ask Generate via Ring / Link existing spec / Defer (per-task choice)
+   - **Skip all** — keep TaskSpec as `-` for all; the next `/optimus:plan T-XXX` will offer to resolve
+3. If "Generate all via Ring":
+   - For each task, invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+   - After Ring generates the spec, update the task's TaskSpec value.
+   - If Ring fails for a task, warn the user and keep that task's TaskSpec as `-` (the next `/optimus:plan T-XXX` will offer to resolve).
+4. If "Generate selectively":
+   - For each task with `TaskSpec = -`, ask via `AskUser`:
+     ```
+     [topic] (X/N) Task T-XXX (<title>) — how should I handle the spec?
+     ```
+     Options:
+     - **Generate via Ring** (recommended) — invoke `ring:pre-dev-feature`
+     - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`; pick from top 5 matches; **HARD BLOCK** validate the chosen path: (a) exists, (b) is a regular file (NOT a symlink), (c) resolves inside `<TASKS_DIR>` with no intermediate symlink components, (d) contains no pipe (`|`), control characters, newlines. Apply the realpath/case-glob/symlink rejection block from AGENTS.md Protocol: TaskSpec Resolution.
+     - **Defer** — keep TaskSpec as `-`; the next `/optimus:plan T-XXX` will offer to resolve.
+5. If "Skip all":
+   - Keep TaskSpec as `-` for every task; inform the user that `/optimus:plan T-XXX` will offer to generate or link a spec when they next plan that task.
+6. If Ring is not available at any point, warn and keep TaskSpec as `-` for the affected tasks.
 
 ---
 
@@ -560,6 +573,21 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
+### Task Spec Resolution
+
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus:plan` run will offer to generate or link a spec. Stage agents
+(plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
+referenced file for objective, acceptance criteria, and implementation details.
+
+The subtasks directory is derived automatically from the TaskSpec path:
+- TaskSpec: `tasks/task_001.md` → Subtasks: `<tasksDir>/subtasks/T-001/`
+- The `T-NNN` identifier is extracted from the task spec filename convention
+
+Agents read objective and acceptance criteria directly from the Ring source files.
+The optimus-tasks.md table only tracks structural data (dependencies, versions, priorities)
+— it does NOT duplicate content from Ring.
+
+
 ### Protocol: Initialize .optimus Directory
 
 **Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
@@ -800,6 +828,57 @@ and offer to run reconciliation before proceeding. This prevents tasks from sile
 appearing as `Pendente` when they actually have active worktrees.
 
 Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: State Management."
+
+
+### Protocol: TaskSpec Resolution
+
+**Referenced by:** plan, build, review
+
+Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
+
+1. Read the task's `TaskSpec` column from `optimus-tasks.md`
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus:plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
+3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
+4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
+   This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the
+   Ring pre-dev tree. Also rejects symlinks to prevent symlink-bypass TOCTOU attacks:
+   ```bash
+   TASKS_DIR_ABS=$(cd "$TASKS_DIR" 2>/dev/null && pwd) || { echo "ERROR: tasksDir does not exist." >&2; exit 1; }
+   RESOLVED_PATH=$(cd "$TASKS_DIR_ABS" && realpath -m "$TASK_SPEC" 2>/dev/null \
+     || python3 -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1], sys.argv[2])))" "$TASKS_DIR_ABS" "$TASK_SPEC" 2>/dev/null)
+   if [ -z "$RESOLVED_PATH" ]; then
+     echo "ERROR: Cannot resolve TaskSpec path — realpath and python3 both unavailable." >&2
+     exit 1
+   fi
+   case "$RESOLVED_PATH" in
+     "$TASKS_DIR_ABS"/*) ;; # OK — within tasksDir
+     *) echo "ERROR: TaskSpec path traversal detected — resolved path is outside tasksDir." >&2; exit 1 ;;
+   esac
+   # Reject symlinks: if TASK_SPEC itself or any intermediate component is a
+   # symlink, a TOCTOU attacker could swap the target between validation and
+   # read. realpath -m resolves symlinks transparently; this post-check ensures
+   # no symlink is present in the final path.
+   if [ -L "$RESOLVED_PATH" ]; then
+     echo "ERROR: TaskSpec resolves to a symlink — refusing to read." >&2
+     exit 1
+   fi
+   ```
+
+   **Validate `TASKS_DIR` itself:** `TASKS_DIR` must be inside a valid git repository
+   (same repo as project, OR a separate repo — both are allowed). Resolution of
+   `TASKS_GIT_SCOPE` (Protocol: Resolve Tasks Git Scope) already enforces this by
+   running `git -C "$TASKS_DIR" rev-parse --show-toplevel`. If that call fails,
+   `TASKS_DIR` is not a git repository and skills STOP.
+
+   **NOTE:** `TASKS_DIR` is NO LONGER required to be inside `PROJECT_ROOT`. Teams using
+   separate-repo scope (e.g., `tasksDir: ../tasks-repo/project-alfa`) are supported.
+   The security guarantee is that the **TaskSpec value** cannot escape `TASKS_DIR`.
+
+5. Read the task spec file at `TASK_SPEC_PATH`
+6. Derive subtasks directory: if TaskSpec is `tasks/task_001.md`, subtasks are at `<TASKS_DIR>/subtasks/T-001/`
+7. If subtasks directory exists, read all `.md` files inside it
+
+Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -246,6 +246,41 @@ Before loading docs, discover the project's structure:
 4. **Identify reference docs:** Look for task specs, API design, data model, architecture docs, business requirements, and dependency maps.
 5. **Identify doc hierarchy:** Determine the source-of-truth ordering for conflicting docs (typically: project rules/AI instructions > API design > data model > architecture > business requirements > task specs).
 
+### Step 1.2.0: Resolve Missing Spec
+
+Before invoking TaskSpec Resolution, detect and self-heal a missing spec.
+
+1. Parse `optimus-tasks.md` and read the task row's `TaskSpec` column.
+2. If `TaskSpec` is NOT `-`, skip this step (proceed to Step 1.2).
+3. If `TaskSpec` is `-`, ask via `AskUser`:
+
+   ```
+   [topic] (1/1) Task T-XXX has no Ring pre-dev spec. How should I proceed?
+   ```
+
+   Options:
+   - **Generate via Ring** (default) — invoke `ring:pre-dev-feature`
+   - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`
+   - **Cancel** — abort plan
+
+4. **If "Generate via Ring":**
+   1. Verify `ring:pre-dev-feature` is available. If unavailable → fall back to "Link existing spec" automatically and warn the user.
+   2. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and tipo (mirror `optimus-tasks` Step 2.3.1).
+   3. After Ring completes, capture the generated spec file path (relative to `<TASKS_DIR>`).
+   4. Update the task's `TaskSpec` column in `optimus-tasks.md`.
+   5. Re-validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation. If validation fails, abort and revert the in-memory edit; do not commit.
+   6. Commit the TaskSpec update via `tasks_git` — see AGENTS.md Protocol: tasks_git commit.
+
+5. **If "Link existing spec":**
+   1. Glob `<TASKS_DIR>/tasks/*.md`. Rank candidates by keyword overlap with the task title.
+   2. Present the top 5 matches via `AskUser`; user picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
+   3. Validate the chosen path exists and resolves inside `<TASKS_DIR>` (path-traversal protection — same rules as `Protocol: TaskSpec Resolution`).
+   4. Update the task's `TaskSpec` column. Re-validate and commit (steps 4.5 and 4.6 above).
+
+6. **If "Cancel":** **STOP** — "Plan cancelled — task spec required."
+
+7. Post-condition: `TaskSpec` is now a valid relative path (not `-`). Proceed to Step 1.2.
+
 ### Step 1.2: Load Documents
 
 Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution. Load the Ring pre-dev

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -189,7 +189,73 @@ from a previous run that was interrupted (crash, user closed terminal, etc.).
    3. Remove the task entry from state.json (resets to Pendente)
    4. **STOP** — task is back to Pendente, user can re-run stage-1 when ready
 
-4. **If no branch or worktree exists** → proceed to Step 1.0.5
+4. **If no branch or worktree exists** → proceed to Step 1.0.4.5
+
+### Step 1.0.4.5: Resolve Missing Spec
+
+Before reserving the task and creating the workspace, detect and self-heal a missing spec.
+This runs BEFORE Step 1.0.5 so that a Cancel here leaves the task untouched (no orphan
+workspace, no `Validando Spec` status leak).
+
+> Note: This prompt offers Cancel (not Defer) because plan needs the spec to do its work. To create a task without a spec, use `/optimus:tasks` and pick Defer.
+
+1. Parse `optimus-tasks.md` and read the task row's `TaskSpec` column.
+2. If `TaskSpec` is NOT `-`, skip this step (proceed to Step 1.0.5).
+3. If `TaskSpec` is `-`, ask via `AskUser`:
+
+   ```
+   [topic] (1/1) Task T-XXX has no Ring pre-dev spec. How should I proceed?
+   ```
+
+   Options:
+   - **Generate via Ring** (recommended) — invoke `ring:pre-dev-feature`
+   - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`
+   - **Cancel** — abort plan
+
+4. **If "Generate via Ring":**
+   1. Verify `ring:pre-dev-feature` is available. If unavailable → fall back to "Link existing spec" automatically and warn the user.
+   2. Invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+   3. **If Ring fails or returns no spec path:**
+      - Warn the user: "Ring failed to generate the spec: <error>."
+      - Re-prompt with `Link existing spec` / `Cancel`. Do NOT silently fall through.
+      - If user picks Cancel → STOP — "Plan cancelled — task spec required."
+   4. **If Ring succeeds:**
+      - Capture the generated spec file path (relative to `<TASKS_DIR>`). Save in a variable `SPEC_PATH`.
+      - Update the task's `TaskSpec` column in `optimus-tasks.md`.
+   5. **Re-validate** optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
+      - If validation fails:
+        a. Revert the in-memory edit to the TaskSpec column.
+        b. Remove the spec file Ring just created at `<TASKS_DIR>/<SPEC_PATH>` (rollback Ring's side effect).
+        c. STOP and report the validation error.
+   6. Commit the TaskSpec update:
+      ```bash
+      tasks_git add "$TASKS_GIT_REL"
+      COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+      chmod 600 "$COMMIT_MSG_FILE"
+      printf '%s' "chore(tasks): heal TaskSpec for T-XXX (self-heal)" > "$COMMIT_MSG_FILE"
+      tasks_git commit -F "$COMMIT_MSG_FILE"
+      rm -f "$COMMIT_MSG_FILE"
+      ```
+
+5. **If "Link existing spec":**
+   1. Glob `<TASKS_DIR>/tasks/*.md`. Rank candidates by keyword overlap with the task title.
+   2. Present the top 5 matches via `AskUser`; user picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
+   3. **HARD BLOCK** — Validate the chosen path: (a) exists, (b) is a regular file (NOT a symlink), (c) resolves inside `<TASKS_DIR>` with no intermediate symlink components, (d) contains no pipe (`|`), control characters, newlines. Apply the realpath/case-glob/symlink rejection block from AGENTS.md Protocol: TaskSpec Resolution. If validation fails, do NOT write to optimus-tasks.md; loop back to the picker.
+   4. Update the task's `TaskSpec` column in `optimus-tasks.md`.
+   5. **Re-validate** optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation. If validation fails, abort and revert the in-memory edit; do not commit.
+   6. Commit the TaskSpec update:
+      ```bash
+      tasks_git add "$TASKS_GIT_REL"
+      COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+      chmod 600 "$COMMIT_MSG_FILE"
+      printf '%s' "chore(tasks): heal TaskSpec for T-XXX (self-heal)" > "$COMMIT_MSG_FILE"
+      tasks_git commit -F "$COMMIT_MSG_FILE"
+      rm -f "$COMMIT_MSG_FILE"
+      ```
+
+6. **If "Cancel":** **STOP** — "Plan cancelled — task spec required."
+
+7. Post-condition: `TaskSpec` is now a valid relative path (not `-`). Proceed to Step 1.0.5.
 
 ### Step 1.0.5: Reserve Task and Create Workspace
 
@@ -245,41 +311,6 @@ Before loading docs, discover the project's structure:
 
 4. **Identify reference docs:** Look for task specs, API design, data model, architecture docs, business requirements, and dependency maps.
 5. **Identify doc hierarchy:** Determine the source-of-truth ordering for conflicting docs (typically: project rules/AI instructions > API design > data model > architecture > business requirements > task specs).
-
-### Step 1.2.0: Resolve Missing Spec
-
-Before invoking TaskSpec Resolution, detect and self-heal a missing spec.
-
-1. Parse `optimus-tasks.md` and read the task row's `TaskSpec` column.
-2. If `TaskSpec` is NOT `-`, skip this step (proceed to Step 1.2).
-3. If `TaskSpec` is `-`, ask via `AskUser`:
-
-   ```
-   [topic] (1/1) Task T-XXX has no Ring pre-dev spec. How should I proceed?
-   ```
-
-   Options:
-   - **Generate via Ring** (default) — invoke `ring:pre-dev-feature`
-   - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`
-   - **Cancel** — abort plan
-
-4. **If "Generate via Ring":**
-   1. Verify `ring:pre-dev-feature` is available. If unavailable → fall back to "Link existing spec" automatically and warn the user.
-   2. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and tipo (mirror `optimus-tasks` Step 2.3.1).
-   3. After Ring completes, capture the generated spec file path (relative to `<TASKS_DIR>`).
-   4. Update the task's `TaskSpec` column in `optimus-tasks.md`.
-   5. Re-validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation. If validation fails, abort and revert the in-memory edit; do not commit.
-   6. Commit the TaskSpec update via `tasks_git` — see AGENTS.md Protocol: tasks_git commit.
-
-5. **If "Link existing spec":**
-   1. Glob `<TASKS_DIR>/tasks/*.md`. Rank candidates by keyword overlap with the task title.
-   2. Present the top 5 matches via `AskUser`; user picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
-   3. Validate the chosen path exists and resolves inside `<TASKS_DIR>` (path-traversal protection — same rules as `Protocol: TaskSpec Resolution`).
-   4. Update the task's `TaskSpec` column. Re-validate and commit (steps 4.5 and 4.6 above).
-
-6. **If "Cancel":** **STOP** — "Plan cancelled — task spec required."
-
-7. Post-condition: `TaskSpec` is now a valid relative path (not `-`). Proceed to Step 1.2.
 
 ### Step 1.2: Load Documents
 
@@ -931,7 +962,7 @@ These operations require explicit user confirmation.
 
 ### Task Spec Resolution
 
-Every task MUST have a Ring pre-dev reference in the `TaskSpec` column. Stage agents
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus:plan` run will offer to generate or link a spec. Stage agents
 (plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
 referenced file for objective, acceptance criteria, and implementation details.
 
@@ -2349,7 +2380,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
 1. Read the task's `TaskSpec` column from `optimus-tasks.md`
-2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus:tasks` or `/optimus:import`."
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus:plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
    This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -590,6 +590,7 @@ Map current status + PR state to the recommended next command:
 
 | Current status     | PR state                      | Next recommended                               |
 |--------------------|-------------------------------|------------------------------------------------|
+| `Validando Spec` + `TaskSpec=-` | any              | `/optimus:plan` (spec is missing — re-run plan to resolve) |
 | `Validando Spec`   | any                           | `/optimus:build`                               |
 | `Em Andamento`     | any                           | `/optimus:review` (or re-run `/optimus:build`) |
 | `Validando Impl`   | OPEN                          | `/optimus:pr-check` (then `/optimus:done`)     |

--- a/commands/review.md
+++ b/commands/review.md
@@ -1041,7 +1041,7 @@ These operations require explicit user confirmation.
 
 ### Task Spec Resolution
 
-Every task MUST have a Ring pre-dev reference in the `TaskSpec` column. Stage agents
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus:plan` run will offer to generate or link a spec. Stage agents
 (plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
 referenced file for objective, acceptance criteria, and implementation details.
 
@@ -2742,7 +2742,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
 1. Read the task's `TaskSpec` column from `optimus-tasks.md`
-2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus:tasks` or `/optimus:import`."
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus:plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
    This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -119,8 +119,7 @@ Options:
 
 #### Built-in Templates
 
-Templates pre-fill Tipo and Priority. The task creation flow delegates to Ring
-pre-dev to generate the spec (Step 2.3.1).
+Templates pre-fill Tipo and Priority. The task creation flow delegates to Step 2.3.1 (Resolve TaskSpec for the New Task) which offers Generate/Link/Defer.
 
 **API Endpoint template:** Tipo: `Feature`, Priority: `Alta`
 **Bug Fix template:** Tipo: `Fix`, Priority: `Alta`
@@ -141,7 +140,7 @@ The user can then modify any field before confirming.
 4. **Estimate** (optional): Task size estimate (`S`, `M`, `L`, `XL`, `2h`, `1d`, etc.). Default: `-`
 5. **Version** (required): Must match a version in the Versions table. Default: the version with Status `Ativa`
 6. **Dependencies** (optional): Comma-separated task IDs (e.g., `T-001, T-003`) or `-` for none
-7. **Ring pre-dev reference** (required): Link to Ring pre-dev task spec. If not provided by the user, Ring pre-dev discovery (Step 2.3.1) will search for a match. A task cannot be created without a Ring reference.
+7. **Ring pre-dev reference** (optional): If not provided, Step 2.3.1 will offer to generate via Ring, link an existing spec, or defer (TaskSpec=-).
 
 If the user provided some of these in the initial request, use them and ask only for missing fields.
 
@@ -239,6 +238,8 @@ If the user specified dependencies:
 
 Ask the user how to handle the spec for this task. Always ask, even when Ring is available — the user may want to defer spec generation (e.g., creating multiple tasks in a row, batch-generating specs later).
 
+> Note: This prompt offers Defer (not Cancel) because task creation can succeed without an immediate spec; the next `/optimus:plan T-XXX` will offer to resolve.
+
 Ask via `AskUser`:
 
 ```
@@ -246,24 +247,28 @@ Ask via `AskUser`:
 ```
 
 Options:
-- **Generate via Ring** (default) — invoke `ring:pre-dev-feature` now
+- **Generate via Ring** (recommended) — invoke `ring:pre-dev-feature` now
 - **Link existing spec** — search `<TASKS_DIR>/tasks/` for matching specs
-- **Defer** — set TaskSpec to `-`. The next `/optimus:plan T-XXX` run will offer to generate it.
+- **Defer** — set TaskSpec to `-`. The next `/optimus:plan T-XXX` run will offer to generate it later.
 
 **If "Generate via Ring":**
 
 1. Verify `ring:pre-dev-feature` is available. If unavailable → warn and fall back to "Link existing spec" automatically.
-2. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and type.
-3. Ring generates the spec file in `<TASKS_DIR>/tasks/`.
-4. After Ring completes, capture the generated spec file path (relative to `TASKS_DIR`).
-5. Store as the `TaskSpec` value for this task.
+2. Invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+3. **If Ring fails or returns no spec path:**
+   - Warn the user: "Ring failed to generate the spec: <error>."
+   - Re-prompt with `Link existing spec` / `Defer`. Do NOT silently fall through.
+4. **If Ring succeeds:**
+   - Ring generates the spec file in `<TASKS_DIR>/tasks/`.
+   - Capture the generated spec file path (relative to `TASKS_DIR`).
+   - Store as the `TaskSpec` value for this task.
 
 **If "Link existing spec":**
 
 1. Search `<TASKS_DIR>/tasks/*.md` for task files.
 2. Rank candidates by keyword overlap with the task title; present the top 5 matches via `AskUser`.
 3. User picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
-4. Validate the chosen path exists and resolves inside `<TASKS_DIR>` (path-traversal protection — see AGENTS.md Protocol: TaskSpec Resolution).
+4. **HARD BLOCK** — Validate the chosen path: (a) exists, (b) is a regular file (NOT a symlink), (c) resolves inside `<TASKS_DIR>` with no intermediate symlink components, (d) contains no pipe (`|`), control characters, newlines. Apply the realpath/case-glob/symlink rejection block from AGENTS.md Protocol: TaskSpec Resolution. If validation fails, do NOT write to optimus-tasks.md; loop back to the picker.
 5. Store the chosen path as the `TaskSpec` value for this task.
 
 **If "Defer":**
@@ -1084,6 +1089,21 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
+### Task Spec Resolution
+
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus:plan` run will offer to generate or link a spec. Stage agents
+(plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
+referenced file for objective, acceptance criteria, and implementation details.
+
+The subtasks directory is derived automatically from the TaskSpec path:
+- TaskSpec: `tasks/task_001.md` → Subtasks: `<tasksDir>/subtasks/T-001/`
+- The `T-NNN` identifier is extracted from the task spec filename convention
+
+Agents read objective and acceptance criteria directly from the Ring source files.
+The optimus-tasks.md table only tracks structural data (dependencies, versions, priorities)
+— it does NOT duplicate content from Ring.
+
+
 ### Format Validation
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
@@ -1585,6 +1605,57 @@ and offer to run reconciliation before proceeding. This prevents tasks from sile
 appearing as `Pendente` when they actually have active worktrees.
 
 Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: State Management."
+
+
+### Protocol: TaskSpec Resolution
+
+**Referenced by:** plan, build, review
+
+Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
+
+1. Read the task's `TaskSpec` column from `optimus-tasks.md`
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus:plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
+3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
+4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
+   This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the
+   Ring pre-dev tree. Also rejects symlinks to prevent symlink-bypass TOCTOU attacks:
+   ```bash
+   TASKS_DIR_ABS=$(cd "$TASKS_DIR" 2>/dev/null && pwd) || { echo "ERROR: tasksDir does not exist." >&2; exit 1; }
+   RESOLVED_PATH=$(cd "$TASKS_DIR_ABS" && realpath -m "$TASK_SPEC" 2>/dev/null \
+     || python3 -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1], sys.argv[2])))" "$TASKS_DIR_ABS" "$TASK_SPEC" 2>/dev/null)
+   if [ -z "$RESOLVED_PATH" ]; then
+     echo "ERROR: Cannot resolve TaskSpec path — realpath and python3 both unavailable." >&2
+     exit 1
+   fi
+   case "$RESOLVED_PATH" in
+     "$TASKS_DIR_ABS"/*) ;; # OK — within tasksDir
+     *) echo "ERROR: TaskSpec path traversal detected — resolved path is outside tasksDir." >&2; exit 1 ;;
+   esac
+   # Reject symlinks: if TASK_SPEC itself or any intermediate component is a
+   # symlink, a TOCTOU attacker could swap the target between validation and
+   # read. realpath -m resolves symlinks transparently; this post-check ensures
+   # no symlink is present in the final path.
+   if [ -L "$RESOLVED_PATH" ]; then
+     echo "ERROR: TaskSpec resolves to a symlink — refusing to read." >&2
+     exit 1
+   fi
+   ```
+
+   **Validate `TASKS_DIR` itself:** `TASKS_DIR` must be inside a valid git repository
+   (same repo as project, OR a separate repo — both are allowed). Resolution of
+   `TASKS_GIT_SCOPE` (Protocol: Resolve Tasks Git Scope) already enforces this by
+   running `git -C "$TASKS_DIR" rev-parse --show-toplevel`. If that call fails,
+   `TASKS_DIR` is not a git repository and skills STOP.
+
+   **NOTE:** `TASKS_DIR` is NO LONGER required to be inside `PROJECT_ROOT`. Teams using
+   separate-repo scope (e.g., `tasksDir: ../tasks-repo/project-alfa`) are supported.
+   The security guarantee is that the **TaskSpec value** cannot escape `TASKS_DIR`.
+
+5. Read the task spec file at `TASK_SPEC_PATH`
+6. Derive subtasks directory: if TaskSpec is `tasks/task_001.md`, subtasks are at `<TASKS_DIR>/subtasks/T-001/`
+7. If subtasks directory exists, read all `.md` files inside it
+
+Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -235,25 +235,41 @@ If the user specified dependencies:
 3. Check for circular dependencies: if T-NEW depends on T-X, and T-X (directly or transitively) would depend on T-NEW → reject
 4. If any dependency ID is invalid → ask the user to correct it
 
-### Step 2.3.1: Generate Ring Pre-Dev Spec
+### Step 2.3.1: Resolve TaskSpec for the New Task
 
-Delegate to Ring to generate the task spec:
+Ask the user how to handle the spec for this task. Always ask, even when Ring is available — the user may want to defer spec generation (e.g., creating multiple tasks in a row, batch-generating specs later).
 
-1. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and type
-2. Ring generates the spec file in `<TASKS_DIR>/tasks/`
-3. After Ring completes, capture the generated spec file path (relative to `TASKS_DIR`)
-4. Store as the `TaskSpec` value for this task
+Ask via `AskUser`:
 
-**If Ring pre-dev is not available** (skill not installed), ask via `AskUser`:
 ```
-Ring pre-dev skill is not available. How should I proceed?
+[topic] (1/1) How should I handle the spec for this task?
 ```
+
 Options:
+- **Generate via Ring** (default) — invoke `ring:pre-dev-feature` now
 - **Link existing spec** — search `<TASKS_DIR>/tasks/` for matching specs
-- **Create with empty TaskSpec** — set TaskSpec to `-`, link later
+- **Defer** — set TaskSpec to `-`. The next `/optimus:plan T-XXX` run will offer to generate it.
 
-**If "Link existing spec"**, search `<TASKS_DIR>/tasks/*.md` for task files, present
-matches based on keyword overlap with the task title, and let the user select one.
+**If "Generate via Ring":**
+
+1. Verify `ring:pre-dev-feature` is available. If unavailable → warn and fall back to "Link existing spec" automatically.
+2. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and type.
+3. Ring generates the spec file in `<TASKS_DIR>/tasks/`.
+4. After Ring completes, capture the generated spec file path (relative to `TASKS_DIR`).
+5. Store as the `TaskSpec` value for this task.
+
+**If "Link existing spec":**
+
+1. Search `<TASKS_DIR>/tasks/*.md` for task files.
+2. Rank candidates by keyword overlap with the task title; present the top 5 matches via `AskUser`.
+3. User picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
+4. Validate the chosen path exists and resolves inside `<TASKS_DIR>` (path-traversal protection — see AGENTS.md Protocol: TaskSpec Resolution).
+5. Store the chosen path as the `TaskSpec` value for this task.
+
+**If "Defer":**
+
+1. Set TaskSpec to `-`.
+2. Note to user: "Task created without spec. Run `/optimus:plan T-XXX` later to generate or link one."
 
 ### Step 2.4: Apply Create
 

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -281,15 +281,28 @@ without Ring pre-dev specs):
 1. Count tasks without specs
 2. Ask via `AskUser`:
    ```
-   N tasks have no Ring pre-dev spec. Generate specs now?
+   N tasks have no Ring pre-dev spec. How should I proceed?
    ```
    Options:
-   - **Generate all** — invoke `ring:pre-dev-feature` for each task
-   - **Skip** — keep TaskSpec as `-`, generate specs later
-3. If "Generate all":
-   - For each task, invoke `ring:pre-dev-feature` passing title and tipo
-   - After Ring generates the spec, update the task's TaskSpec value
-4. If Ring is not available, warn and keep TaskSpec as `-`
+   - **Generate all via Ring** — invoke `ring:pre-dev-feature` for each task
+   - **Generate selectively** — for each task, ask Generate via Ring / Link existing spec / Defer (per-task choice)
+   - **Skip all** — keep TaskSpec as `-` for all; the next `/optimus-plan T-XXX` will offer to resolve
+3. If "Generate all via Ring":
+   - For each task, invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+   - After Ring generates the spec, update the task's TaskSpec value.
+   - If Ring fails for a task, warn the user and keep that task's TaskSpec as `-` (the next `/optimus-plan T-XXX` will offer to resolve).
+4. If "Generate selectively":
+   - For each task with `TaskSpec = -`, ask via `AskUser`:
+     ```
+     [topic] (X/N) Task T-XXX (<title>) — how should I handle the spec?
+     ```
+     Options:
+     - **Generate via Ring** (recommended) — invoke `ring:pre-dev-feature`
+     - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`; pick from top 5 matches; **HARD BLOCK** validate the chosen path: (a) exists, (b) is a regular file (NOT a symlink), (c) resolves inside `<TASKS_DIR>` with no intermediate symlink components, (d) contains no pipe (`|`), control characters, newlines. Apply the realpath/case-glob/symlink rejection block from AGENTS.md Protocol: TaskSpec Resolution.
+     - **Defer** — keep TaskSpec as `-`; the next `/optimus-plan T-XXX` will offer to resolve.
+5. If "Skip all":
+   - Keep TaskSpec as `-` for every task; inform the user that `/optimus-plan T-XXX` will offer to generate or link a spec when they next plan that task.
+6. If Ring is not available at any point, warn and keep TaskSpec as `-` for the affected tasks.
 
 ---
 
@@ -608,6 +621,21 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
+### Task Spec Resolution
+
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus-plan` run will offer to generate or link a spec. Stage agents
+(plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
+referenced file for objective, acceptance criteria, and implementation details.
+
+The subtasks directory is derived automatically from the TaskSpec path:
+- TaskSpec: `tasks/task_001.md` → Subtasks: `<tasksDir>/subtasks/T-001/`
+- The `T-NNN` identifier is extracted from the task spec filename convention
+
+Agents read objective and acceptance criteria directly from the Ring source files.
+The optimus-tasks.md table only tracks structural data (dependencies, versions, priorities)
+— it does NOT duplicate content from Ring.
+
+
 ### Protocol: Initialize .optimus Directory
 
 **Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
@@ -848,6 +876,57 @@ and offer to run reconciliation before proceeding. This prevents tasks from sile
 appearing as `Pendente` when they actually have active worktrees.
 
 Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: State Management."
+
+
+### Protocol: TaskSpec Resolution
+
+**Referenced by:** plan, build, review
+
+Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
+
+1. Read the task's `TaskSpec` column from `optimus-tasks.md`
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus-plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
+3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
+4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
+   This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the
+   Ring pre-dev tree. Also rejects symlinks to prevent symlink-bypass TOCTOU attacks:
+   ```bash
+   TASKS_DIR_ABS=$(cd "$TASKS_DIR" 2>/dev/null && pwd) || { echo "ERROR: tasksDir does not exist." >&2; exit 1; }
+   RESOLVED_PATH=$(cd "$TASKS_DIR_ABS" && realpath -m "$TASK_SPEC" 2>/dev/null \
+     || python3 -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1], sys.argv[2])))" "$TASKS_DIR_ABS" "$TASK_SPEC" 2>/dev/null)
+   if [ -z "$RESOLVED_PATH" ]; then
+     echo "ERROR: Cannot resolve TaskSpec path — realpath and python3 both unavailable." >&2
+     exit 1
+   fi
+   case "$RESOLVED_PATH" in
+     "$TASKS_DIR_ABS"/*) ;; # OK — within tasksDir
+     *) echo "ERROR: TaskSpec path traversal detected — resolved path is outside tasksDir." >&2; exit 1 ;;
+   esac
+   # Reject symlinks: if TASK_SPEC itself or any intermediate component is a
+   # symlink, a TOCTOU attacker could swap the target between validation and
+   # read. realpath -m resolves symlinks transparently; this post-check ensures
+   # no symlink is present in the final path.
+   if [ -L "$RESOLVED_PATH" ]; then
+     echo "ERROR: TaskSpec resolves to a symlink — refusing to read." >&2
+     exit 1
+   fi
+   ```
+
+   **Validate `TASKS_DIR` itself:** `TASKS_DIR` must be inside a valid git repository
+   (same repo as project, OR a separate repo — both are allowed). Resolution of
+   `TASKS_GIT_SCOPE` (Protocol: Resolve Tasks Git Scope) already enforces this by
+   running `git -C "$TASKS_DIR" rev-parse --show-toplevel`. If that call fails,
+   `TASKS_DIR` is not a git repository and skills STOP.
+
+   **NOTE:** `TASKS_DIR` is NO LONGER required to be inside `PROJECT_ROOT`. Teams using
+   separate-repo scope (e.g., `tasksDir: ../tasks-repo/project-alfa`) are supported.
+   The security guarantee is that the **TaskSpec value** cannot escape `TASKS_DIR`.
+
+5. Read the task spec file at `TASK_SPEC_PATH`
+6. Derive subtasks directory: if TaskSpec is `tasks/task_001.md`, subtasks are at `<TASKS_DIR>/subtasks/T-001/`
+7. If subtasks directory exists, read all `.md` files inside it
+
+Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -251,7 +251,73 @@ from a previous run that was interrupted (crash, user closed terminal, etc.).
    3. Remove the task entry from state.json (resets to Pendente)
    4. **STOP** — task is back to Pendente, user can re-run stage-1 when ready
 
-4. **If no branch or worktree exists** → proceed to Step 1.0.5
+4. **If no branch or worktree exists** → proceed to Step 1.0.4.5
+
+### Step 1.0.4.5: Resolve Missing Spec
+
+Before reserving the task and creating the workspace, detect and self-heal a missing spec.
+This runs BEFORE Step 1.0.5 so that a Cancel here leaves the task untouched (no orphan
+workspace, no `Validando Spec` status leak).
+
+> Note: This prompt offers Cancel (not Defer) because plan needs the spec to do its work. To create a task without a spec, use `/optimus-tasks` and pick Defer.
+
+1. Parse `optimus-tasks.md` and read the task row's `TaskSpec` column.
+2. If `TaskSpec` is NOT `-`, skip this step (proceed to Step 1.0.5).
+3. If `TaskSpec` is `-`, ask via `AskUser`:
+
+   ```
+   [topic] (1/1) Task T-XXX has no Ring pre-dev spec. How should I proceed?
+   ```
+
+   Options:
+   - **Generate via Ring** (recommended) — invoke `ring:pre-dev-feature`
+   - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`
+   - **Cancel** — abort plan
+
+4. **If "Generate via Ring":**
+   1. Verify `ring:pre-dev-feature` is available. If unavailable → fall back to "Link existing spec" automatically and warn the user.
+   2. Invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+   3. **If Ring fails or returns no spec path:**
+      - Warn the user: "Ring failed to generate the spec: <error>."
+      - Re-prompt with `Link existing spec` / `Cancel`. Do NOT silently fall through.
+      - If user picks Cancel → STOP — "Plan cancelled — task spec required."
+   4. **If Ring succeeds:**
+      - Capture the generated spec file path (relative to `<TASKS_DIR>`). Save in a variable `SPEC_PATH`.
+      - Update the task's `TaskSpec` column in `optimus-tasks.md`.
+   5. **Re-validate** optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
+      - If validation fails:
+        a. Revert the in-memory edit to the TaskSpec column.
+        b. Remove the spec file Ring just created at `<TASKS_DIR>/<SPEC_PATH>` (rollback Ring's side effect).
+        c. STOP and report the validation error.
+   6. Commit the TaskSpec update:
+      ```bash
+      tasks_git add "$TASKS_GIT_REL"
+      COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+      chmod 600 "$COMMIT_MSG_FILE"
+      printf '%s' "chore(tasks): heal TaskSpec for T-XXX (self-heal)" > "$COMMIT_MSG_FILE"
+      tasks_git commit -F "$COMMIT_MSG_FILE"
+      rm -f "$COMMIT_MSG_FILE"
+      ```
+
+5. **If "Link existing spec":**
+   1. Glob `<TASKS_DIR>/tasks/*.md`. Rank candidates by keyword overlap with the task title.
+   2. Present the top 5 matches via `AskUser`; user picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
+   3. **HARD BLOCK** — Validate the chosen path: (a) exists, (b) is a regular file (NOT a symlink), (c) resolves inside `<TASKS_DIR>` with no intermediate symlink components, (d) contains no pipe (`|`), control characters, newlines. Apply the realpath/case-glob/symlink rejection block from AGENTS.md Protocol: TaskSpec Resolution. If validation fails, do NOT write to optimus-tasks.md; loop back to the picker.
+   4. Update the task's `TaskSpec` column in `optimus-tasks.md`.
+   5. **Re-validate** optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation. If validation fails, abort and revert the in-memory edit; do not commit.
+   6. Commit the TaskSpec update:
+      ```bash
+      tasks_git add "$TASKS_GIT_REL"
+      COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
+      chmod 600 "$COMMIT_MSG_FILE"
+      printf '%s' "chore(tasks): heal TaskSpec for T-XXX (self-heal)" > "$COMMIT_MSG_FILE"
+      tasks_git commit -F "$COMMIT_MSG_FILE"
+      rm -f "$COMMIT_MSG_FILE"
+      ```
+
+6. **If "Cancel":** **STOP** — "Plan cancelled — task spec required."
+
+7. Post-condition: `TaskSpec` is now a valid relative path (not `-`). Proceed to Step 1.0.5.
 
 ### Step 1.0.5: Reserve Task and Create Workspace
 
@@ -307,41 +373,6 @@ Before loading docs, discover the project's structure:
 
 4. **Identify reference docs:** Look for task specs, API design, data model, architecture docs, business requirements, and dependency maps.
 5. **Identify doc hierarchy:** Determine the source-of-truth ordering for conflicting docs (typically: project rules/AI instructions > API design > data model > architecture > business requirements > task specs).
-
-### Step 1.2.0: Resolve Missing Spec
-
-Before invoking TaskSpec Resolution, detect and self-heal a missing spec.
-
-1. Parse `optimus-tasks.md` and read the task row's `TaskSpec` column.
-2. If `TaskSpec` is NOT `-`, skip this step (proceed to Step 1.2).
-3. If `TaskSpec` is `-`, ask via `AskUser`:
-
-   ```
-   [topic] (1/1) Task T-XXX has no Ring pre-dev spec. How should I proceed?
-   ```
-
-   Options:
-   - **Generate via Ring** (default) — invoke `ring:pre-dev-feature`
-   - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`
-   - **Cancel** — abort plan
-
-4. **If "Generate via Ring":**
-   1. Verify `ring:pre-dev-feature` is available. If unavailable → fall back to "Link existing spec" automatically and warn the user.
-   2. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and tipo (mirror `optimus-tasks` Step 2.3.1).
-   3. After Ring completes, capture the generated spec file path (relative to `<TASKS_DIR>`).
-   4. Update the task's `TaskSpec` column in `optimus-tasks.md`.
-   5. Re-validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation. If validation fails, abort and revert the in-memory edit; do not commit.
-   6. Commit the TaskSpec update via `tasks_git` — see AGENTS.md Protocol: tasks_git commit.
-
-5. **If "Link existing spec":**
-   1. Glob `<TASKS_DIR>/tasks/*.md`. Rank candidates by keyword overlap with the task title.
-   2. Present the top 5 matches via `AskUser`; user picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
-   3. Validate the chosen path exists and resolves inside `<TASKS_DIR>` (path-traversal protection — same rules as `Protocol: TaskSpec Resolution`).
-   4. Update the task's `TaskSpec` column. Re-validate and commit (steps 4.5 and 4.6 above).
-
-6. **If "Cancel":** **STOP** — "Plan cancelled — task spec required."
-
-7. Post-condition: `TaskSpec` is now a valid relative path (not `-`). Proceed to Step 1.2.
 
 ### Step 1.2: Load Documents
 
@@ -993,7 +1024,7 @@ These operations require explicit user confirmation.
 
 ### Task Spec Resolution
 
-Every task MUST have a Ring pre-dev reference in the `TaskSpec` column. Stage agents
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus-plan` run will offer to generate or link a spec. Stage agents
 (plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
 referenced file for objective, acceptance criteria, and implementation details.
 
@@ -2411,7 +2442,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
 1. Read the task's `TaskSpec` column from `optimus-tasks.md`
-2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus-tasks` or `/optimus-import`."
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus-plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
    This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -308,6 +308,41 @@ Before loading docs, discover the project's structure:
 4. **Identify reference docs:** Look for task specs, API design, data model, architecture docs, business requirements, and dependency maps.
 5. **Identify doc hierarchy:** Determine the source-of-truth ordering for conflicting docs (typically: project rules/AI instructions > API design > data model > architecture > business requirements > task specs).
 
+### Step 1.2.0: Resolve Missing Spec
+
+Before invoking TaskSpec Resolution, detect and self-heal a missing spec.
+
+1. Parse `optimus-tasks.md` and read the task row's `TaskSpec` column.
+2. If `TaskSpec` is NOT `-`, skip this step (proceed to Step 1.2).
+3. If `TaskSpec` is `-`, ask via `AskUser`:
+
+   ```
+   [topic] (1/1) Task T-XXX has no Ring pre-dev spec. How should I proceed?
+   ```
+
+   Options:
+   - **Generate via Ring** (default) — invoke `ring:pre-dev-feature`
+   - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`
+   - **Cancel** — abort plan
+
+4. **If "Generate via Ring":**
+   1. Verify `ring:pre-dev-feature` is available. If unavailable → fall back to "Link existing spec" automatically and warn the user.
+   2. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and tipo (mirror `optimus-tasks` Step 2.3.1).
+   3. After Ring completes, capture the generated spec file path (relative to `<TASKS_DIR>`).
+   4. Update the task's `TaskSpec` column in `optimus-tasks.md`.
+   5. Re-validate optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation. If validation fails, abort and revert the in-memory edit; do not commit.
+   6. Commit the TaskSpec update via `tasks_git` — see AGENTS.md Protocol: tasks_git commit.
+
+5. **If "Link existing spec":**
+   1. Glob `<TASKS_DIR>/tasks/*.md`. Rank candidates by keyword overlap with the task title.
+   2. Present the top 5 matches via `AskUser`; user picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
+   3. Validate the chosen path exists and resolves inside `<TASKS_DIR>` (path-traversal protection — same rules as `Protocol: TaskSpec Resolution`).
+   4. Update the task's `TaskSpec` column. Re-validate and commit (steps 4.5 and 4.6 above).
+
+6. **If "Cancel":** **STOP** — "Plan cancelled — task spec required."
+
+7. Post-condition: `TaskSpec` is now a valid relative path (not `-`). Proceed to Step 1.2.
+
 ### Step 1.2: Load Documents
 
 Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution. Load the Ring pre-dev

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -649,6 +649,7 @@ Map current status + PR state to the recommended next command:
 
 | Current status     | PR state                      | Next recommended                               |
 |--------------------|-------------------------------|------------------------------------------------|
+| `Validando Spec` + `TaskSpec=-` | any              | `/optimus-plan` (spec is missing — re-run plan to resolve) |
 | `Validando Spec`   | any                           | `/optimus-build`                               |
 | `Em Andamento`     | any                           | `/optimus-review` (or re-run `/optimus-build`) |
 | `Validando Impl`   | OPEN                          | `/optimus-pr-check` (then `/optimus-done`)     |

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -1106,7 +1106,7 @@ These operations require explicit user confirmation.
 
 ### Task Spec Resolution
 
-Every task MUST have a Ring pre-dev reference in the `TaskSpec` column. Stage agents
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus-plan` run will offer to generate or link a spec. Stage agents
 (plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
 referenced file for objective, acceptance criteria, and implementation details.
 
@@ -2807,7 +2807,7 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 
 1. Read the task's `TaskSpec` column from `optimus-tasks.md`
-2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Link one via `/optimus-tasks` or `/optimus-import`."
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus-plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
 3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
 4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
    This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3021,3 +3021,18 @@ class TestSpecSelfHeal:
                 f"{skill} SKILL.md body must not invoke ring:pre-dev-feature — "
                 "only plan self-heals; build/review delegate via TaskSpec Resolution protocol"
             )
+
+    def test_tasks_creation_offers_defer_option(self):
+        """tasks SKILL.md must offer 'Defer' as a first-class option at creation time
+        (not just a fallback when Ring is unavailable). This keeps the user in control
+        and is symmetric with plan's self-heal flow."""
+        tasks_md = (REPO_ROOT / "tasks" / "skills" / "optimus-tasks" / "SKILL.md").read_text()
+        assert "**Defer**" in tasks_md or "**Defer —" in tasks_md, (
+            "tasks SKILL.md must expose a 'Defer' option at task creation time "
+            "(sets TaskSpec to `-`, deferring spec generation to /optimus:plan)"
+        )
+        # Old fallback-only phrasing must be gone — Defer is now a top-level choice
+        assert "Create with empty TaskSpec" not in tasks_md, (
+            "tasks SKILL.md must not retain the old 'Create with empty TaskSpec' fallback "
+            "phrasing — replaced by the unconditional 'Defer' option"
+        )

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -1836,10 +1836,11 @@ class TestDualPlatformParity:
             f"Claude marketplace plugin must be named `optimus`, got "
             f"{plugins[0]['name']!r}."
         )
-        assert plugins[0]["source"] == ".", (
-            f"Claude `optimus` plugin source must be `.` (repo root) so the "
-            f"top-level `commands/` directory is discovered, got "
-            f"{plugins[0]['source']!r}."
+        assert plugins[0]["source"] == "./", (
+            f"Claude `optimus` plugin source must be `./` (repo root) so the "
+            f"top-level `commands/` directory is discovered. Note: the leading "
+            f"`./` is required by the marketplace schema validator (bare `.` "
+            f"fails). Got {plugins[0]['source']!r}."
         )
 
     def test_every_plugin_has_both_platform_surfaces(self):
@@ -2960,3 +2961,63 @@ class TestTasksReValidatesAfterMutation:
         assert violations == [], (
             "Mutating operations must re-validate after edits:\n" + "\n".join(violations)
         )
+
+
+# --- TaskSpec self-heal in /optimus:plan ---
+
+
+class TestSpecSelfHeal:
+    """plan auto-heals missing TaskSpec via ring:pre-dev-feature; build/review redirect to plan."""
+
+    def test_plan_has_resolve_missing_spec_step(self):
+        """plan SKILL.md must declare a self-heal step that runs before TaskSpec Resolution."""
+        plan_md = (REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md").read_text()
+        assert "Resolve Missing Spec" in plan_md, (
+            "plan SKILL.md must contain a 'Resolve Missing Spec' step that handles TaskSpec=-"
+        )
+        assert "ring:pre-dev-feature" in plan_md, (
+            "plan SKILL.md must delegate to ring:pre-dev-feature for spec generation"
+        )
+        assert "Link existing spec" in plan_md, (
+            "plan SKILL.md must offer 'Link existing spec' as a fallback when Ring unavailable"
+        )
+
+    def test_plan_self_heal_runs_before_taskspec_resolution(self):
+        """The self-heal step must appear textually before the TaskSpec Resolution call."""
+        plan_md = (REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md").read_text()
+        heal_idx = plan_md.find("Resolve Missing Spec")
+        resolve_idx = plan_md.find("Protocol: TaskSpec Resolution")
+        assert heal_idx > 0 and resolve_idx > 0, (
+            "Both 'Resolve Missing Spec' and 'Protocol: TaskSpec Resolution' must be present"
+        )
+        assert heal_idx < resolve_idx, (
+            "'Resolve Missing Spec' must appear BEFORE 'Protocol: TaskSpec Resolution' "
+            "so the spec is guaranteed valid by the time Resolution runs"
+        )
+
+    def test_protocol_redirects_to_plan(self):
+        """AGENTS.md Protocol: TaskSpec Resolution STOP message must redirect to /optimus-plan."""
+        agents_md = AGENTS_MD.read_text()
+        # New message redirects to plan
+        assert "Run `/optimus-plan T-XXX`" in agents_md, (
+            "Protocol: TaskSpec Resolution STOP message must redirect users to /optimus-plan"
+        )
+        assert "ring:pre-dev-feature" in agents_md, (
+            "Protocol message must mention ring:pre-dev-feature so users know what to expect"
+        )
+        # Old message removed (the specific phrasing that pointed at tasks/import)
+        assert "Link one via `/optimus-tasks` or `/optimus-import`" not in agents_md, (
+            "Old TaskSpec Resolution STOP message must be removed"
+        )
+
+    def test_build_review_dont_self_heal(self):
+        """build and review SKILL.md bodies must not introduce their own self-heal logic."""
+        for skill in ("build", "review"):
+            content = (REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md").read_text()
+            # Body = everything after the second `---` (closing frontmatter delimiter)
+            parts = content.split("---", 2)
+            body = parts[2] if len(parts) >= 3 else content
+            assert "ring:pre-dev-feature" not in body, (
+                f"{skill} SKILL.md body must not invoke ring:pre-dev-feature — "
+                "only plan self-heals; build/review delegate via TaskSpec Resolution protocol"
+            )

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -2972,8 +2972,9 @@ class TestSpecSelfHeal:
     def test_plan_has_resolve_missing_spec_step(self):
         """plan SKILL.md must declare a self-heal step that runs before TaskSpec Resolution."""
         plan_md = (REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md").read_text()
-        assert "Resolve Missing Spec" in plan_md, (
-            "plan SKILL.md must contain a 'Resolve Missing Spec' step that handles TaskSpec=-"
+        assert "Step 1.0.4.5" in plan_md or "Resolve Missing Spec" in plan_md, (
+            "plan SKILL.md must contain a 'Step 1.0.4.5: Resolve Missing Spec' step "
+            "that handles TaskSpec=- BEFORE the workspace is created"
         )
         assert "ring:pre-dev-feature" in plan_md, (
             "plan SKILL.md must delegate to ring:pre-dev-feature for spec generation"
@@ -2998,25 +2999,23 @@ class TestSpecSelfHeal:
     def test_protocol_redirects_to_plan(self):
         """AGENTS.md Protocol: TaskSpec Resolution STOP message must redirect to /optimus-plan."""
         agents_md = AGENTS_MD.read_text()
-        # New message redirects to plan
-        assert "Run `/optimus-plan T-XXX`" in agents_md, (
-            "Protocol: TaskSpec Resolution STOP message must redirect users to /optimus-plan"
-        )
-        assert "ring:pre-dev-feature" in agents_md, (
-            "Protocol message must mention ring:pre-dev-feature so users know what to expect"
-        )
-        # Old message removed (the specific phrasing that pointed at tasks/import)
-        assert "Link one via `/optimus-tasks` or `/optimus-import`" not in agents_md, (
-            "Old TaskSpec Resolution STOP message must be removed"
-        )
+        start = agents_md.find("### Protocol: TaskSpec Resolution")
+        assert start > 0, "Protocol: TaskSpec Resolution section missing"
+        end = agents_md.find("\n### ", start + 1)
+        section = agents_md[start:end if end > 0 else len(agents_md)]
+        assert "Run `/optimus-plan T-XXX`" in section
+        assert "ring:pre-dev-feature" in section
+        assert "Link one via `/optimus-tasks` or `/optimus-import`" not in section
 
     def test_build_review_dont_self_heal(self):
         """build and review SKILL.md bodies must not introduce their own self-heal logic."""
         for skill in ("build", "review"):
             content = (REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md").read_text()
-            # Body = everything after the second `---` (closing frontmatter delimiter)
-            parts = content.split("---", 2)
-            body = parts[2] if len(parts) >= 3 else content
+            # Body = SKILL.md content excluding the inlined-protocols block.
+            # The inlined block legitimately contains "ring:pre-dev-feature"
+            # (from the new TaskSpec Resolution STOP message), so we strip it
+            # before asserting the host body is self-heal-free.
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
             assert "ring:pre-dev-feature" not in body, (
                 f"{skill} SKILL.md body must not invoke ring:pre-dev-feature — "
                 "only plan self-heals; build/review delegate via TaskSpec Resolution protocol"
@@ -3036,3 +3035,97 @@ class TestSpecSelfHeal:
             "tasks SKILL.md must not retain the old 'Create with empty TaskSpec' fallback "
             "phrasing — replaced by the unconditional 'Defer' option"
         )
+
+    def test_plan_self_heal_offers_cancel_option(self):
+        """Cancel must be a first-class option that aborts the plan with a clear STOP message."""
+        body = (REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md").read_text()
+        body = body.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        assert "**Cancel**" in body, "plan self-heal must offer Cancel as first-class option"
+        assert "Plan cancelled" in body, "Cancel branch must STOP with deterministic message"
+
+    def test_plan_self_heal_revalidates_and_commits(self):
+        """Step 1.0.4.5 mutates optimus-tasks.md; it MUST re-validate + commit per AGENTS.md protocols."""
+        body = (REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md").read_text()
+        body = body.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        start = body.find("### Step 1.0.4.5")
+        end = body.find("### Step 1.0.5", start + 1)
+        section = body[start:end] if start >= 0 and end > start else ""
+        assert "Re-validate" in section, "self-heal must re-validate optimus-tasks.md after mutation"
+        assert "Protocol: optimus-tasks.md Validation" in section
+        assert "tasks_git" in section, "self-heal must commit via tasks_git"
+
+    def test_tasks_defer_documents_handoff_to_plan(self):
+        """Tasks Defer branch must point user at /optimus-plan for later spec generation."""
+        body = (REPO_ROOT / "tasks" / "skills" / "optimus-tasks" / "SKILL.md").read_text()
+        body = body.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        assert "/optimus-plan" in body and "later" in body, (
+            "tasks Defer must inform user that /optimus-plan T-XXX will pick this up later"
+        )
+
+    def test_plan_self_heal_uses_progress_topic_format(self):
+        """The new AskUser prompt must use the canonical [topic] (X/N) progress prefix."""
+        import re
+        body = (REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md").read_text()
+        body = body.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        start = body.find("### Step 1.0.4.5")
+        end = body.find("### Step 1.0.5", start + 1)
+        section = body[start:end] if start >= 0 and end > start else ""
+        assert re.search(r"\[topic\]\s+\(\d+/\d+\)", section), (
+            "Resolve Missing Spec AskUser prompt must use [topic] (X/N) format"
+        )
+
+    def test_protocol_references_resolve(self):
+        """Every 'AGENTS.md Protocol: X' reference in any SKILL.md must resolve
+        to a real `### Protocol: X` heading in AGENTS.md. Catches dangling refs early.
+
+        Uses the same heuristic chain as inline-protocols.py (see
+        ``extract_refs_from_content`` there) so that references resolved by the
+        inliner are also resolved here, and references it warns about as
+        unmatched are also surfaced as test failures."""
+        import re
+        import sys
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        try:
+            inline_protocols = __import__("inline-protocols")
+        finally:
+            sys.path.pop(0)
+
+        agents_sections = inline_protocols.parse_agents_md()
+        violations = []
+        for path in _all_skill_files():
+            # Use the inliner's body-only extraction to skip the inlined block.
+            content = path.read_text()
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            refs = inline_protocols.extract_refs_from_content(body)
+            for ref in refs:
+                if not ref.startswith("Protocol: "):
+                    continue
+                if inline_protocols.match_ref_to_section(ref, agents_sections) is None:
+                    rel = path.relative_to(REPO_ROOT)
+                    violations.append(f"{rel}: '{ref}' has no matching heading in AGENTS.md")
+        assert violations == [], "Dangling protocol references:\n" + "\n".join(violations)
+
+    def test_link_existing_spec_uses_canonical_protocol_reference(self):
+        """Both plan and tasks 'Link existing spec' must reference the canonical protocol."""
+        canonical = "AGENTS.md Protocol: TaskSpec Resolution"
+        for skill_path in [
+            REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md",
+            REPO_ROOT / "tasks" / "skills" / "optimus-tasks" / "SKILL.md",
+        ]:
+            content = skill_path.read_text().split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            link_section = content.split("Link existing spec", 1)[1].split("\n\n###", 1)[0]
+            assert canonical in link_section, (
+                f"{skill_path.parent.parent.name} 'Link existing spec' must reference {canonical}"
+            )
+
+    def test_link_existing_spec_mentions_symlink(self):
+        """Symlink TOCTOU is part of the protocol — prose must surface it at the new entry point."""
+        for skill_path in [
+            REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md",
+            REPO_ROOT / "tasks" / "skills" / "optimus-tasks" / "SKILL.md",
+        ]:
+            content = skill_path.read_text().split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            link_section = content.split("Link existing spec", 1)[1].split("\n\n###", 1)[0]
+            assert "symlink" in link_section.lower(), (
+                f"{skill_path.parent.parent.name} 'Link existing spec' must explicitly mention symlinks"
+            )

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -171,8 +171,7 @@ Options:
 
 #### Built-in Templates
 
-Templates pre-fill Tipo and Priority. The task creation flow delegates to Ring
-pre-dev to generate the spec (Step 2.3.1).
+Templates pre-fill Tipo and Priority. The task creation flow delegates to Step 2.3.1 (Resolve TaskSpec for the New Task) which offers Generate/Link/Defer.
 
 **API Endpoint template:** Tipo: `Feature`, Priority: `Alta`
 **Bug Fix template:** Tipo: `Fix`, Priority: `Alta`
@@ -193,7 +192,7 @@ The user can then modify any field before confirming.
 4. **Estimate** (optional): Task size estimate (`S`, `M`, `L`, `XL`, `2h`, `1d`, etc.). Default: `-`
 5. **Version** (required): Must match a version in the Versions table. Default: the version with Status `Ativa`
 6. **Dependencies** (optional): Comma-separated task IDs (e.g., `T-001, T-003`) or `-` for none
-7. **Ring pre-dev reference** (required): Link to Ring pre-dev task spec. If not provided by the user, Ring pre-dev discovery (Step 2.3.1) will search for a match. A task cannot be created without a Ring reference.
+7. **Ring pre-dev reference** (optional): If not provided, Step 2.3.1 will offer to generate via Ring, link an existing spec, or defer (TaskSpec=-).
 
 If the user provided some of these in the initial request, use them and ask only for missing fields.
 
@@ -291,6 +290,8 @@ If the user specified dependencies:
 
 Ask the user how to handle the spec for this task. Always ask, even when Ring is available — the user may want to defer spec generation (e.g., creating multiple tasks in a row, batch-generating specs later).
 
+> Note: This prompt offers Defer (not Cancel) because task creation can succeed without an immediate spec; the next `/optimus-plan T-XXX` will offer to resolve.
+
 Ask via `AskUser`:
 
 ```
@@ -298,24 +299,28 @@ Ask via `AskUser`:
 ```
 
 Options:
-- **Generate via Ring** (default) — invoke `ring:pre-dev-feature` now
+- **Generate via Ring** (recommended) — invoke `ring:pre-dev-feature` now
 - **Link existing spec** — search `<TASKS_DIR>/tasks/` for matching specs
-- **Defer** — set TaskSpec to `-`. The next `/optimus-plan T-XXX` run will offer to generate it.
+- **Defer** — set TaskSpec to `-`. The next `/optimus-plan T-XXX` run will offer to generate it later.
 
 **If "Generate via Ring":**
 
 1. Verify `ring:pre-dev-feature` is available. If unavailable → warn and fall back to "Link existing spec" automatically.
-2. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and type.
-3. Ring generates the spec file in `<TASKS_DIR>/tasks/`.
-4. After Ring completes, capture the generated spec file path (relative to `TASKS_DIR`).
-5. Store as the `TaskSpec` value for this task.
+2. Invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+3. **If Ring fails or returns no spec path:**
+   - Warn the user: "Ring failed to generate the spec: <error>."
+   - Re-prompt with `Link existing spec` / `Defer`. Do NOT silently fall through.
+4. **If Ring succeeds:**
+   - Ring generates the spec file in `<TASKS_DIR>/tasks/`.
+   - Capture the generated spec file path (relative to `TASKS_DIR`).
+   - Store as the `TaskSpec` value for this task.
 
 **If "Link existing spec":**
 
 1. Search `<TASKS_DIR>/tasks/*.md` for task files.
 2. Rank candidates by keyword overlap with the task title; present the top 5 matches via `AskUser`.
 3. User picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
-4. Validate the chosen path exists and resolves inside `<TASKS_DIR>` (path-traversal protection — see AGENTS.md Protocol: TaskSpec Resolution).
+4. **HARD BLOCK** — Validate the chosen path: (a) exists, (b) is a regular file (NOT a symlink), (c) resolves inside `<TASKS_DIR>` with no intermediate symlink components, (d) contains no pipe (`|`), control characters, newlines. Apply the realpath/case-glob/symlink rejection block from AGENTS.md Protocol: TaskSpec Resolution. If validation fails, do NOT write to optimus-tasks.md; loop back to the picker.
 5. Store the chosen path as the `TaskSpec` value for this task.
 
 **If "Defer":**
@@ -1136,6 +1141,21 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
+### Task Spec Resolution
+
+Every task SHOULD have a Ring pre-dev reference in the `TaskSpec` column. Tasks may be created with `TaskSpec=-` (deferred); the next `/optimus-plan` run will offer to generate or link a spec. Stage agents
+(plan, build, review) resolve the full path as `<tasksDir>/<TaskSpec>` and read the
+referenced file for objective, acceptance criteria, and implementation details.
+
+The subtasks directory is derived automatically from the TaskSpec path:
+- TaskSpec: `tasks/task_001.md` → Subtasks: `<tasksDir>/subtasks/T-001/`
+- The `T-NNN` identifier is extracted from the task spec filename convention
+
+Agents read objective and acceptance criteria directly from the Ring source files.
+The optimus-tasks.md table only tracks structural data (dependencies, versions, priorities)
+— it does NOT duplicate content from Ring.
+
+
 ### Format Validation
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
@@ -1637,6 +1657,57 @@ and offer to run reconciliation before proceeding. This prevents tasks from sile
 appearing as `Pendente` when they actually have active worktrees.
 
 Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: State Management."
+
+
+### Protocol: TaskSpec Resolution
+
+**Referenced by:** plan, build, review
+
+Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
+
+1. Read the task's `TaskSpec` column from `optimus-tasks.md`
+2. If `TaskSpec` is `-` → **STOP**: "Task T-XXX has no Ring pre-dev spec. Run `/optimus-plan T-XXX` to generate one (it will offer to invoke `ring:pre-dev-feature` interactively)."
+3. Resolve full path: `TASK_SPEC_PATH = <TASKS_DIR>/<TaskSpec>`
+4. **Path traversal validation (HARD BLOCK):** `TaskSpec` must resolve to a file **inside `TASKS_DIR`**.
+   This prevents a malicious TaskSpec value like `../../../etc/passwd` from escaping the
+   Ring pre-dev tree. Also rejects symlinks to prevent symlink-bypass TOCTOU attacks:
+   ```bash
+   TASKS_DIR_ABS=$(cd "$TASKS_DIR" 2>/dev/null && pwd) || { echo "ERROR: tasksDir does not exist." >&2; exit 1; }
+   RESOLVED_PATH=$(cd "$TASKS_DIR_ABS" && realpath -m "$TASK_SPEC" 2>/dev/null \
+     || python3 -c "import os,sys; print(os.path.realpath(os.path.join(sys.argv[1], sys.argv[2])))" "$TASKS_DIR_ABS" "$TASK_SPEC" 2>/dev/null)
+   if [ -z "$RESOLVED_PATH" ]; then
+     echo "ERROR: Cannot resolve TaskSpec path — realpath and python3 both unavailable." >&2
+     exit 1
+   fi
+   case "$RESOLVED_PATH" in
+     "$TASKS_DIR_ABS"/*) ;; # OK — within tasksDir
+     *) echo "ERROR: TaskSpec path traversal detected — resolved path is outside tasksDir." >&2; exit 1 ;;
+   esac
+   # Reject symlinks: if TASK_SPEC itself or any intermediate component is a
+   # symlink, a TOCTOU attacker could swap the target between validation and
+   # read. realpath -m resolves symlinks transparently; this post-check ensures
+   # no symlink is present in the final path.
+   if [ -L "$RESOLVED_PATH" ]; then
+     echo "ERROR: TaskSpec resolves to a symlink — refusing to read." >&2
+     exit 1
+   fi
+   ```
+
+   **Validate `TASKS_DIR` itself:** `TASKS_DIR` must be inside a valid git repository
+   (same repo as project, OR a separate repo — both are allowed). Resolution of
+   `TASKS_GIT_SCOPE` (Protocol: Resolve Tasks Git Scope) already enforces this by
+   running `git -C "$TASKS_DIR" rev-parse --show-toplevel`. If that call fails,
+   `TASKS_DIR` is not a git repository and skills STOP.
+
+   **NOTE:** `TASKS_DIR` is NO LONGER required to be inside `PROJECT_ROOT`. Teams using
+   separate-repo scope (e.g., `tasksDir: ../tasks-repo/project-alfa`) are supported.
+   The security guarantee is that the **TaskSpec value** cannot escape `TASKS_DIR`.
+
+5. Read the task spec file at `TASK_SPEC_PATH`
+6. Derive subtasks directory: if TaskSpec is `tasks/task_001.md`, subtasks are at `<TASKS_DIR>/subtasks/T-001/`
+7. If subtasks directory exists, read all `.md` files inside it
+
+Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -287,25 +287,41 @@ If the user specified dependencies:
 3. Check for circular dependencies: if T-NEW depends on T-X, and T-X (directly or transitively) would depend on T-NEW → reject
 4. If any dependency ID is invalid → ask the user to correct it
 
-### Step 2.3.1: Generate Ring Pre-Dev Spec
+### Step 2.3.1: Resolve TaskSpec for the New Task
 
-Delegate to Ring to generate the task spec:
+Ask the user how to handle the spec for this task. Always ask, even when Ring is available — the user may want to defer spec generation (e.g., creating multiple tasks in a row, batch-generating specs later).
 
-1. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and type
-2. Ring generates the spec file in `<TASKS_DIR>/tasks/`
-3. After Ring completes, capture the generated spec file path (relative to `TASKS_DIR`)
-4. Store as the `TaskSpec` value for this task
+Ask via `AskUser`:
 
-**If Ring pre-dev is not available** (skill not installed), ask via `AskUser`:
 ```
-Ring pre-dev skill is not available. How should I proceed?
+[topic] (1/1) How should I handle the spec for this task?
 ```
+
 Options:
+- **Generate via Ring** (default) — invoke `ring:pre-dev-feature` now
 - **Link existing spec** — search `<TASKS_DIR>/tasks/` for matching specs
-- **Create with empty TaskSpec** — set TaskSpec to `-`, link later
+- **Defer** — set TaskSpec to `-`. The next `/optimus-plan T-XXX` run will offer to generate it.
 
-**If "Link existing spec"**, search `<TASKS_DIR>/tasks/*.md` for task files, present
-matches based on keyword overlap with the task title, and let the user select one.
+**If "Generate via Ring":**
+
+1. Verify `ring:pre-dev-feature` is available. If unavailable → warn and fall back to "Link existing spec" automatically.
+2. Invoke `ring:pre-dev-feature` via `Skill` tool, passing the task title and type.
+3. Ring generates the spec file in `<TASKS_DIR>/tasks/`.
+4. After Ring completes, capture the generated spec file path (relative to `TASKS_DIR`).
+5. Store as the `TaskSpec` value for this task.
+
+**If "Link existing spec":**
+
+1. Search `<TASKS_DIR>/tasks/*.md` for task files.
+2. Rank candidates by keyword overlap with the task title; present the top 5 matches via `AskUser`.
+3. User picks one or types a custom relative path under `<TASKS_DIR>/tasks/`.
+4. Validate the chosen path exists and resolves inside `<TASKS_DIR>` (path-traversal protection — see AGENTS.md Protocol: TaskSpec Resolution).
+5. Store the chosen path as the `TaskSpec` value for this task.
+
+**If "Defer":**
+
+1. Set TaskSpec to `-`.
+2. Note to user: "Task created without spec. Run `/optimus-plan T-XXX` later to generate or link one."
 
 ### Step 2.4: Apply Create
 


### PR DESCRIPTION
## Summary

Makes the spec contract between Optimus and Ring more flexible at both ends:

1. **`/optimus:plan` self-heals missing TaskSpec** (commit 1) — instead of hard-stopping when `TaskSpec=-`, plan asks via AskUser whether to **Generate via Ring** (`ring:pre-dev-feature`), **Link existing spec**, or **Cancel**.
2. **`/optimus:tasks` makes spec generation optional at creation time** (commit 2) — instead of unconditionally invoking Ring when available, tasks now asks: **Generate via Ring** (default) / **Link existing spec** / **Defer** (TaskSpec=-, self-heals at plan time).

`/optimus:build` and `/optimus:review` remain strict (HARD STOP if `TaskSpec=-`) but the protocol error message now redirects users to `/optimus:plan` (which can self-heal) instead of `/optimus:tasks`/`/optimus:import`.

## Why

Two related friction points:

- Tasks created via `/optimus:tasks` with the "Create with empty TaskSpec — link later" fallback (when Ring is unavailable at creation time, `tasks/skills/optimus-tasks/SKILL.md:305`) used to hit a HARD STOP at plan time. Users had to drop out, run `/optimus:tasks` (or `/optimus:import`) to add the spec, then come back.
- Even when Ring WAS available, `/optimus:tasks` forced spec generation immediately — no way to defer when creating tasks in a row or batching spec generation later.

Plan is the natural place to resolve missing specs (it's the gate that needs the spec first), and the delegation pattern already existed in `optimus-tasks` Step 2.3.1 — plan now mirrors it. Tasks creation now exposes the same three-option UX so users have the same control.

## Files changed

| File | Change |
|---|---|
| `plan/skills/optimus-plan/SKILL.md` | New Step 1.2.0 ("Resolve Missing Spec") before Step 1.2 |
| `tasks/skills/optimus-tasks/SKILL.md` | Step 2.3.1 reshaped — always ask first; "Defer" promoted to first-class option |
| `AGENTS.md` | Protocol: TaskSpec Resolution STOP message updated |
| `commands/plan.md`, `commands/tasks.md` | Regenerated by `scripts/sync-claude-commands.py` |
| `scripts/test_skill_consistency.py` | New `TestSpecSelfHeal` (5 tests) + fix stale `source==\".\"` assertion (now `\"./\"` after #33) |

`build`, `review`, `done`, `import` SKILL.md files: **unchanged**.

## Three-option UX (consistent across plan and tasks)

```
┌─ /optimus:tasks (creation) ────────┬─ /optimus:plan (self-heal) ──────┐
│  Generate via Ring (default)       │  Generate via Ring (default)     │
│  Link existing spec                │  Link existing spec              │
│  Defer → TaskSpec=-                │  Cancel                          │
└────────────────────────────────────┴──────────────────────────────────┘
```

`Defer` and `Cancel` differ semantically: Defer creates the task with `TaskSpec=-` (deliberate choice); Cancel aborts plan without state mutation.

## Test plan

- [x] `python3 -m pytest scripts/test_skill_consistency.py scripts/test_sync_user_plugins.py` → **207 passed**
- [x] `TestSpecSelfHeal` (5 tests) covers: plan has the step; step appears before TaskSpec Resolution; AGENTS.md message redirects to plan; build/review do NOT self-heal; tasks creation offers Defer
- [x] `scripts/sync-claude-commands.py` is idempotent (commands/plan.md, commands/tasks.md regenerated; second run shows no diff)
- [ ] Smoke test (manual, post-merge):
  - Create task via `/optimus:tasks` — confirm 3-option AskUser appears (was forced Ring before)
  - Choose "Defer" → task created with TaskSpec=-
  - Run `/optimus:plan T-XXX` → AskUser appears with Generate/Link/Cancel
  - Choose "Generate via Ring" → ring:pre-dev-feature invoked, TaskSpec column populated, plan continues
  - `/optimus:build T-YYY` against TaskSpec=- → HARD STOP with new message citing /optimus:plan

## Commits

1. `feat(plan): self-heal missing TaskSpec via ring:pre-dev-feature`
2. `feat(tasks): make spec generation optional at task creation`