### PR TITLE
feat(worktrees): standardize location at .worktrees/ inside project repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ htmlcov/
 .optimus/sessions/
 .optimus/reports/
 .optimus/logs/
+
+# optimus-operational-worktrees
+# Linked worktrees created by /optimus-plan, /optimus-resume, and the
+# Workspace Auto-Navigation recovery flow live here. Gitignored because
+# they are per-task ephemeral checkouts, not source code.
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,35 +361,6 @@ the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir`
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
 repo, it is committed there.
 
-## Worktree Location Convention
-
-Optimus creates linked git worktrees during the task lifecycle:
-
-- `/optimus-plan` creates a worktree when a task starts (Step 1.0.5).
-- `/optimus-resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
-- `Protocol: Workspace Auto-Navigation` creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
-
-**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
-
-**Note on branch names with `/`:** branch names follow `<tipo-prefix>/<task-id>-<keywords>` (e.g., `feat/t-007-user-auth`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
-
-**Why nested under the project repo:**
-
-| Concern | Resolution |
-|---|---|
-| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
-| Cleanup lifecycle | Removing the project directory also removes worktrees |
-| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
-| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
-| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
-
-**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
-
-- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
-- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
-
-**Backwards compatibility:** existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path. New worktrees from `/optimus-plan` and `resume`'s recovery land in `.worktrees/`. No forced migration; users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
-
 ### Protocol: Resolve Main Worktree Path
 
 **Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
@@ -1058,18 +1029,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
@@ -1424,18 +1396,19 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
@@ -1655,10 +1628,13 @@ fi
      fi
      ```
      If the branch exists, create the worktree automatically. Canonical path
-     follows the Worktree Location Convention:
+     follows Protocol: Worktree Location:
      ```bash
      # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
-     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     # Reuse cached MAIN_WORKTREE if caller already resolved.
+     if [ -z "${MAIN_WORKTREE:-}" ]; then
+       MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     fi
      MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
      # Path-traversal guard (defense in depth): branch name comes from state.json
@@ -2839,6 +2815,44 @@ to the `Ativa` version. If not, present options before proceeding.
 6. **If "Cancel":** **STOP** — do not proceed with the stage
 
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
+
+### Protocol: Worktree Location
+
+**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+
+Optimus creates linked git worktrees during the task lifecycle:
+
+- `/optimus-plan` creates a worktree when a task starts (Step 1.0.5).
+- `/optimus-resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
+- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
+
+**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
+
+**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
+
+**Why nested under the project repo:**
+
+| Concern | Resolution |
+|---|---|
+| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
+| Cleanup lifecycle | Removing the project directory also removes worktrees |
+| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
+| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
+| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
+
+**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
+
+- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
+- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
+
+**Backwards compatibility:**
+
+- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
+- New worktrees from `/optimus-plan` and `resume`'s recovery land in `.worktrees/`.
+- No forced migration.
+- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
+
+Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 ## Verification Command Convention
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,35 @@ the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir`
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
 repo, it is committed there.
 
+## Worktree Location Convention
+
+Optimus creates linked git worktrees during the task lifecycle:
+
+- `/optimus-plan` creates a worktree when a task starts (Step 1.0.5).
+- `/optimus-resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
+- `Protocol: Workspace Auto-Navigation` creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
+
+**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
+
+**Note on branch names with `/`:** branch names follow `<tipo-prefix>/<task-id>-<keywords>` (e.g., `feat/t-007-user-auth`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
+
+**Why nested under the project repo:**
+
+| Concern | Resolution |
+|---|---|
+| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
+| Cleanup lifecycle | Removing the project directory also removes worktrees |
+| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
+| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
+| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
+
+**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
+
+- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
+- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
+
+**Backwards compatibility:** existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path. New worktrees from `/optimus-plan` and `resume`'s recovery land in `.worktrees/`. No forced migration; users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
+
 ### Protocol: Resolve Main Worktree Path
 
 **Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
@@ -1032,6 +1061,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.
@@ -1386,6 +1427,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
 # ensures it fires for build/review/plan/done (which call Session State but not
@@ -1563,8 +1616,8 @@ fi
    - **If N eligible tasks** → list all with worktree paths via `AskUser`:
      ```
      Multiple tasks available:
-       T-001 — User auth (Em Andamento) → /projeto-t-001-.../
-       T-002 — Login page (Em Andamento) → /projeto-t-002-.../
+       T-001 — User auth (Em Andamento) → <repo>/.worktrees/feat/t-001-user-auth/
+       T-002 — Login page (Em Andamento) → <repo>/.worktrees/feat/t-002-login-page/
      Which task should I continue?
      ```
    - After task is identified, locate the worktree. Prefer the source-of-truth
@@ -1601,11 +1654,24 @@ fi
        #   Options: Create branch from HEAD / Re-run /optimus-plan"
      fi
      ```
-     If the branch exists, create the worktree automatically:
+     If the branch exists, create the worktree automatically. Canonical path
+     follows the Worktree Location Convention:
      ```bash
-     REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
-     WORKTREE_DIR="../${REPO_NAME}-$(echo <task-id> | tr '[:upper:]' '[:lower:]')-<keywords>"
-     git worktree add "$WORKTREE_DIR" "<branch-name>"
+     # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
+     # Path-traversal guard (defense in depth): branch name comes from state.json
+     # in some flows.
+     case "<branch-name>" in
+       *..*|/*) echo "ERROR: refusing unsafe branch name." >&2; exit 1 ;;
+     esac
+     WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/<branch-name>"
+
+     if ! git worktree add "$WORKTREE_DIR" "<branch-name>"; then
+       echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
+       exit 1
+     fi
      ```
      Then change working directory to the new worktree.
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,21 @@ that the script was run before commit.
 
 Future improvements are tracked in `docs/future-improvements.md`.
 
+## Worktree layout
+
+Optimus creates linked git worktrees under `<repo>/.worktrees/<branch-name>/` (gitignored). For project setup, configure your editor to exclude `.worktrees/` from search and indexing:
+
+- **VS Code** (`.vscode/settings.json`):
+  ```json
+  {
+    "search.exclude": { "**/.worktrees": true },
+    "files.watcherExclude": { "**/.worktrees/**": true }
+  }
+  ```
+- **IntelliJ:** mark `.worktrees/` as Excluded in Project Structure.
+
+For the full convention (rationale, backwards compatibility, branch-name handling), see [AGENTS.md Protocol: Worktree Location](AGENTS.md#protocol-worktree-location).
+
 ## Logs
 
 Verification skills (`build`, `review`, `pr-check`, `coderabbit-review`, `deep-review`)

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -124,8 +124,8 @@ tracks the working directory for each task and switches context between tasks.
 **Working directory tracking:**
 ```json
 {
-  "T-003": {"worktree": "../repo-t-003-user-auth", "branch": "feat/t-003-user-auth"},
-  "T-004": {"worktree": "../repo-t-004-login-page", "branch": "feat/t-004-login-page"}
+  "T-003": {"worktree": "<repo>/.worktrees/feat/t-003-user-auth", "branch": "feat/t-003-user-auth"},
+  "T-004": {"worktree": "<repo>/.worktrees/feat/t-004-login-page", "branch": "feat/t-004-login-page"}
 }
 ```
 
@@ -275,7 +275,7 @@ After all tasks are processed (or the user stops), restore the terminal title vi
      - **Stop batch entirely** — pause everything
 - If the user stops the batch, write progress to `.optimus/sessions/session-batch.json`:
   ```json
-  {"tasks": ["T-003", "T-004", "T-005"], "completed": ["T-003"], "current": "T-004", "current_stage": 3, "worktrees": {"T-003": "../repo-t-003", "T-004": "../repo-t-004"}}
+  {"tasks": ["T-003", "T-004", "T-005"], "completed": ["T-003"], "current": "T-004", "current_stage": 3, "worktrees": {"T-003": "<repo>/.worktrees/feat/t-003-user-auth", "T-004": "<repo>/.worktrees/feat/t-004-login-page"}}
   ```
   On next invocation, if this file exists:
   1. **Check staleness:** If `updated_at` (or file modification time) is older than 24h, delete the file and proceed fresh — project state may have changed significantly.

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -1978,6 +1978,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
 # ensures it fires for build/review/plan/done (which call Session State but not
@@ -2356,8 +2368,8 @@ fi
    - **If N eligible tasks** → list all with worktree paths via `AskUser`:
      ```
      Multiple tasks available:
-       T-001 — User auth (Em Andamento) → /projeto-t-001-.../
-       T-002 — Login page (Em Andamento) → /projeto-t-002-.../
+       T-001 — User auth (Em Andamento) → <repo>/.worktrees/feat/t-001-user-auth/
+       T-002 — Login page (Em Andamento) → <repo>/.worktrees/feat/t-002-login-page/
      Which task should I continue?
      ```
    - After task is identified, locate the worktree. Prefer the source-of-truth
@@ -2394,11 +2406,24 @@ fi
        #   Options: Create branch from HEAD / Re-run /optimus-plan"
      fi
      ```
-     If the branch exists, create the worktree automatically:
+     If the branch exists, create the worktree automatically. Canonical path
+     follows the Worktree Location Convention:
      ```bash
-     REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
-     WORKTREE_DIR="../${REPO_NAME}-$(echo <task-id> | tr '[:upper:]' '[:lower:]')-<keywords>"
-     git worktree add "$WORKTREE_DIR" "<branch-name>"
+     # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
+     # Path-traversal guard (defense in depth): branch name comes from state.json
+     # in some flows.
+     case "<branch-name>" in
+       *..*|/*) echo "ERROR: refusing unsafe branch name." >&2; exit 1 ;;
+     esac
+     WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/<branch-name>"
+
+     if ! git worktree add "$WORKTREE_DIR" "<branch-name>"; then
+       echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
+       exit 1
+     fi
      ```
      Then change working directory to the new worktree.
 

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -1975,18 +1975,19 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
@@ -2407,10 +2408,13 @@ fi
      fi
      ```
      If the branch exists, create the worktree automatically. Canonical path
-     follows the Worktree Location Convention:
+     follows Protocol: Worktree Location:
      ```bash
      # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
-     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     # Reuse cached MAIN_WORKTREE if caller already resolved.
+     if [ -z "${MAIN_WORKTREE:-}" ]; then
+       MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     fi
      MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
      # Path-traversal guard (defense in depth): branch name comes from state.json

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -905,18 +905,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -908,6 +908,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -80,8 +80,8 @@ tracks the working directory for each task and switches context between tasks.
 **Working directory tracking:**
 ```json
 {
-  "T-003": {"worktree": "../repo-t-003-user-auth", "branch": "feat/t-003-user-auth"},
-  "T-004": {"worktree": "../repo-t-004-login-page", "branch": "feat/t-004-login-page"}
+  "T-003": {"worktree": "<repo>/.worktrees/feat/t-003-user-auth", "branch": "feat/t-003-user-auth"},
+  "T-004": {"worktree": "<repo>/.worktrees/feat/t-004-login-page", "branch": "feat/t-004-login-page"}
 }
 ```
 
@@ -231,7 +231,7 @@ After all tasks are processed (or the user stops), restore the terminal title vi
      - **Stop batch entirely** — pause everything
 - If the user stops the batch, write progress to `.optimus/sessions/session-batch.json`:
   ```json
-  {"tasks": ["T-003", "T-004", "T-005"], "completed": ["T-003"], "current": "T-004", "current_stage": 3, "worktrees": {"T-003": "../repo-t-003", "T-004": "../repo-t-004"}}
+  {"tasks": ["T-003", "T-004", "T-005"], "completed": ["T-003"], "current": "T-004", "current_stage": 3, "worktrees": {"T-003": "<repo>/.worktrees/feat/t-003-user-auth", "T-004": "<repo>/.worktrees/feat/t-004-login-page"}}
   ```
   On next invocation, if this file exists:
   1. **Check staleness:** If `updated_at` (or file modification time) is older than 24h, delete the file and proceed fresh — project state may have changed significantly.

--- a/commands/build.md
+++ b/commands/build.md
@@ -1913,18 +1913,19 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
@@ -2345,10 +2346,13 @@ fi
      fi
      ```
      If the branch exists, create the worktree automatically. Canonical path
-     follows the Worktree Location Convention:
+     follows Protocol: Worktree Location:
      ```bash
      # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
-     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     # Reuse cached MAIN_WORKTREE if caller already resolved.
+     if [ -z "${MAIN_WORKTREE:-}" ]; then
+       MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     fi
      MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
      # Path-traversal guard (defense in depth): branch name comes from state.json

--- a/commands/build.md
+++ b/commands/build.md
@@ -1916,6 +1916,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
 # ensures it fires for build/review/plan/done (which call Session State but not
@@ -2294,8 +2306,8 @@ fi
    - **If N eligible tasks** → list all with worktree paths via `AskUser`:
      ```
      Multiple tasks available:
-       T-001 — User auth (Em Andamento) → /projeto-t-001-.../
-       T-002 — Login page (Em Andamento) → /projeto-t-002-.../
+       T-001 — User auth (Em Andamento) → <repo>/.worktrees/feat/t-001-user-auth/
+       T-002 — Login page (Em Andamento) → <repo>/.worktrees/feat/t-002-login-page/
      Which task should I continue?
      ```
    - After task is identified, locate the worktree. Prefer the source-of-truth
@@ -2332,11 +2344,24 @@ fi
        #   Options: Create branch from HEAD / Re-run /optimus:plan"
      fi
      ```
-     If the branch exists, create the worktree automatically:
+     If the branch exists, create the worktree automatically. Canonical path
+     follows the Worktree Location Convention:
      ```bash
-     REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
-     WORKTREE_DIR="../${REPO_NAME}-$(echo <task-id> | tr '[:upper:]' '[:lower:]')-<keywords>"
-     git worktree add "$WORKTREE_DIR" "<branch-name>"
+     # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
+     # Path-traversal guard (defense in depth): branch name comes from state.json
+     # in some flows.
+     case "<branch-name>" in
+       *..*|/*) echo "ERROR: refusing unsafe branch name." >&2; exit 1 ;;
+     esac
+     WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/<branch-name>"
+
+     if ! git worktree add "$WORKTREE_DIR" "<branch-name>"; then
+       echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
+       exit 1
+     fi
      ```
      Then change working directory to the new worktree.
 

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -851,6 +851,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -848,18 +848,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -908,18 +908,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -911,6 +911,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/commands/done.md
+++ b/commands/done.md
@@ -341,14 +341,30 @@ If a worktree is found (`WORKTREE_PATH` non-empty), ask via `AskUser`:
 Task T-XXX is done. A worktree still exists at '<path>'. What should I do?
 ```
 Options:
-- **Remove worktree**: `git worktree remove <path>`
+- **Remove worktree**: `git worktree remove <path>` then prune empty parent dirs (see snippet below)
 - **Keep**: Leave the worktree as is
+
+**Removal snippet** — after the user picks "Remove worktree":
+
+```bash
+git worktree remove "$WORKTREE_PATH"
+# Cleanup intermediate parent dirs (e.g., empty .worktrees/feat/ after removing leaf).
+# Idempotent: rmdir refuses non-empty dirs silently.
+parent="$(dirname "$WORKTREE_PATH")"
+while [ "$parent" != "${MAIN_WORKTREE}/.worktrees" ] && [ "$parent" != "/" ]; do
+  rmdir "$parent" 2>/dev/null || break
+  parent="$(dirname "$parent")"
+done
+```
+
+This walks up from the removed worktree leaf to `${MAIN_WORKTREE}/.worktrees/` removing
+empty intermediate dirs (`feat/`, `fix/`, etc.) but stops at `.worktrees/` itself.
 
 **Edge case — running INSIDE the worktree:** If the agent's current working directory IS
 the worktree being removed, `cd` to the main repository first:
 1. Identify the main repository path from `git worktree list` (first entry)
 2. `cd <main-repo-path>`
-3. Then `git worktree remove <worktree-path>`
+3. Then run the **Removal snippet** above.
 
 ### Step 4.2: Check for Task Branch
 

--- a/commands/import.md
+++ b/commands/import.md
@@ -604,6 +604,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/commands/import.md
+++ b/commands/import.md
@@ -601,18 +601,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -259,6 +259,8 @@ workspace, no `Validando Spec` status leak).
 
 ### Step 1.0.5: Reserve Task and Create Workspace
 
+**Canonical worktree path** — see AGENTS.md Worktree Location Convention.
+
 Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines.
 
 **If already on a feature branch** (not default/main/master): skip to Step 1.0.6
@@ -276,14 +278,26 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
 
 4. **Create worktree:**
    ```bash
-   REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
-   WORKTREE_DIR="../${REPO_NAME}-<task-id>-<keywords>"
+   # Resolve main worktree first — see AGENTS.md Protocol: Resolve Main Worktree Path.
+   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
+   BRANCH_NAME="<tipo-prefix>/<task-id>-<keywords>"
+   # Path-traversal guard (defense in depth).
+   case "$BRANCH_NAME" in
+     *..*|/*) echo "ERROR: refusing unsafe branch '$BRANCH_NAME'." >&2; exit 1 ;;
+   esac
+   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${BRANCH_NAME}"
    ```
    **Pre-check:** If `WORKTREE_DIR` already exists but is not a git worktree, ask via
    `AskUser`: "Directory `<path>` already exists but is not a git worktree."
    Options: Remove and create worktree / Rename existing directory / Cancel.
    ```bash
-   git worktree add "$WORKTREE_DIR" -b "<tipo-prefix>/<task-id>-<keywords>"
+   if ! git worktree add "$WORKTREE_DIR" -b "${BRANCH_NAME}"; then
+     echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
+     # Rollback: state.json reservation is removed in Step 5 below.
+     exit 1
+   fi
    ```
    Then change working directory to the new worktree path for all subsequent steps.
 
@@ -1168,55 +1182,6 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
-
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
-
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
-
 ### Deep Research Before Presenting (MANDATORY for cycle review skills)
 Applies to: plan, review, pr-check, coderabbit-review
 
@@ -1988,6 +1953,55 @@ applied fixes are correct and checks for any issues introduced by the fixes.
 Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+
+**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
+
+**Recipe:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
+  exit 1
+fi
+```
+
+The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
+
+**Path resolution pattern:**
+
+After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
+
+```bash
+# RIGHT (works from any worktree):
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
+         "${MAIN_WORKTREE}/.optimus/reports" \
+         "${MAIN_WORKTREE}/.optimus/logs"
+
+# WRONG (resolves against PWD, breaks in linked worktrees):
+STATE_FILE=".optimus/state.json"
+SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE=".optimus/stats.json"
+mkdir -p .optimus/sessions .optimus/reports .optimus/logs
+```
+
+**What does NOT need this protocol:**
+
+- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.gitignore` itself — versioned, propagated via git.
+
+**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: Ring Droid Requirement Check
 
 **Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
@@ -2146,6 +2160,18 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -259,7 +259,7 @@ workspace, no `Validando Spec` status leak).
 
 ### Step 1.0.5: Reserve Task and Create Workspace
 
-**Canonical worktree path** — see AGENTS.md Worktree Location Convention.
+**Canonical worktree path** — see AGENTS.md Protocol: Worktree Location.
 
 Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines.
 
@@ -279,9 +279,13 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
 4. **Create worktree:**
    ```bash
    # Resolve main worktree first — see AGENTS.md Protocol: Resolve Main Worktree Path.
-   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   # Reuse cached MAIN_WORKTREE if caller already resolved (per Protocol: Resolve Main Worktree Path).
+   if [ -z "${MAIN_WORKTREE:-}" ]; then
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   fi
    MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
+   # BRANCH_NAME must be a real branch name (substituted from Protocol: Branch Name Derivation), not the placeholder.
    BRANCH_NAME="<tipo-prefix>/<task-id>-<keywords>"
    # Path-traversal guard (defense in depth).
    case "$BRANCH_NAME" in
@@ -292,7 +296,16 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
    **Pre-check:** If `WORKTREE_DIR` already exists but is not a git worktree, ask via
    `AskUser`: "Directory `<path>` already exists but is not a git worktree."
    Options: Remove and create worktree / Rename existing directory / Cancel.
+
    ```bash
+   # Pre-check: directory exists but is not a git worktree?
+   if [ -e "$WORKTREE_DIR" ] && ! git -C "$WORKTREE_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+     echo "WARNING: $WORKTREE_DIR exists but is not a git worktree." >&2
+     # Present AskUser: Remove and create / Rename existing / Cancel
+     # (Agent: invoke the AskUser flow with these 3 options. If user picks Remove,
+     # rm -rf "$WORKTREE_DIR". If Rename, propose mv "$WORKTREE_DIR" "${WORKTREE_DIR}.bak-$(date +%s)".
+     # If Cancel, exit 1.)
+   fi
    if ! git worktree add "$WORKTREE_DIR" -b "${BRANCH_NAME}"; then
      echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
      # Rollback: state.json reservation is removed in Step 5 below.
@@ -300,6 +313,8 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
    fi
    ```
    Then change working directory to the new worktree path for all subsequent steps.
+
+   *Optional:* Configure your editor to exclude `.worktrees/` (see Protocol: Worktree Location → IDE exclusion).
 
 5. **Rollback on failure:** If worktree creation fails:
    - Remove the entry from state.json
@@ -2158,18 +2173,19 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
@@ -2543,6 +2559,45 @@ will not see a title update.
    silently no-op.
 
 Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+
+
+### Protocol: Worktree Location
+
+**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+
+Optimus creates linked git worktrees during the task lifecycle:
+
+- `/optimus:plan` creates a worktree when a task starts (Step 1.0.5).
+- `/optimus:resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
+- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
+
+**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
+
+**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
+
+**Why nested under the project repo:**
+
+| Concern | Resolution |
+|---|---|
+| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
+| Cleanup lifecycle | Removing the project directory also removes worktrees |
+| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
+| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
+| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
+
+**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
+
+- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
+- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
+
+**Backwards compatibility:**
+
+- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
+- New worktrees from `/optimus:plan` and `resume`'s recovery land in `.worktrees/`.
+- No forced migration.
+- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
+
+Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -2277,6 +2277,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -2274,18 +2274,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/commands/report.md
+++ b/commands/report.md
@@ -934,6 +934,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/commands/report.md
+++ b/commands/report.md
@@ -931,18 +931,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -299,9 +299,11 @@ if [ -z "$TASK_ID" ] || ! [[ "$TASK_ID" =~ ^T-[0-9]+$ ]]; then
 fi
 
 # Anchor the match on the kebab-cased task ID (e.g., `-t-1-`) so substrings like
-# `t-1` cannot match `t-10`/`t-100`. Worktree paths follow the convention
-# `<parent>/<repo>-<id>-<keywords>`, and feature branches follow
-# `<tipo>/<id>-<keywords>` — both surround the lowercased ID with hyphens.
+# `t-1` cannot match `t-10`/`t-100`. Worktree paths follow Protocol: Worktree
+# Location: ${MAIN_WORKTREE}/.worktrees/<branch-name> (legacy sibling paths
+# ../<repo>-<id>-<keywords> still resolve via git worktree list metadata).
+# Feature branches follow `<tipo>/<id>-<keywords>` — both surround the
+# lowercased ID with hyphens.
 TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
 WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
   | awk -v anchor="$TASK_KEBAB" '
@@ -321,7 +323,7 @@ fi
 
 ### Step 3.3: Apply Resolution Order
 
-**Canonical worktree path** — see AGENTS.md Worktree Location Convention.
+**Canonical worktree path** — see AGENTS.md Protocol: Worktree Location.
 
 1. **Worktree found** → `cd "$WORKTREE_PATH"` for the rest of the session. Continue to Phase 4.
 
@@ -331,7 +333,10 @@ fi
 
    ```bash
    # Resolve main worktree first — see AGENTS.md Protocol: Resolve Main Worktree Path.
-   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   # Reuse cached MAIN_WORKTREE if caller already resolved (per Protocol: Resolve Main Worktree Path).
+   if [ -z "${MAIN_WORKTREE:-}" ]; then
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   fi
    MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
    # Belt-and-suspenders: upstream guards (Step 2.1, Step 3.1, Step 3.2) already validated
@@ -349,7 +354,7 @@ fi
 
    # HARD BLOCK on git worktree add failure (dir exists, branch checked out elsewhere, etc.)
    if ! git worktree add "$WORKTREE_DIR" "$TASK_BRANCH"; then
-     echo "ERROR: 'git worktree add $WORKTREE_DIR $TASK_BRANCH' failed."
+     echo "ERROR: 'git worktree add $WORKTREE_DIR $TASK_BRANCH' failed (branch already checked out, dir collision, or filesystem error)."
      echo "       Possible causes: directory exists, branch checked out elsewhere, or local repo state."
      # STOP
    fi
@@ -359,6 +364,8 @@ fi
      # STOP
    fi
    ```
+
+   **Initialize .optimus directory** (ensures `.optimus/logs/`, `.gitignore` exclusions for `.optimus/` and `.worktrees/`) — see AGENTS.md Protocol: Initialize .optimus Directory.
 
 <a id="step-reset-to-pendente-recovery"></a>
 3. **Worktree missing AND branch missing:**
@@ -915,6 +922,64 @@ Where:
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 
 
+### Protocol: Initialize .optimus Directory
+
+**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+
+Before creating ANY file inside `.optimus/`, ensure the directory structure exists
+and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
+
+```bash
+# Requires Protocol: Resolve Main Worktree Path to have run first
+# (or resolve inline; see that protocol).
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
+# Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Log retention (idempotent — fires once per init): age-based + count-cap prune.
+# Also duplicated in Protocol: Session State so stage agents (which call Session
+# State but not Initialize Directory) get pruning at every phase transition.
+# Both prune sites are no-ops on clean directories; running both is harmless.
+find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
+if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
+  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
+    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
+fi
+```
+
+**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
+- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
+  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
+  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
+- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
+  `review`, `done`) phase transition.
+
+Both sites are idempotent (no-op on clean directories) and use the same prune
+logic (30-day age cap + 500-file count cap). Running both per session is a
+harmless cheap operation.
+
+Everything inside `.optimus/` is gitignored. The planning tree is versioned
+separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+for Ring specs) — see the File Location section above.
+
+Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
+
+
 ### Protocol: Resolve Main Worktree Path
 
 **Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
@@ -1057,6 +1122,45 @@ will not see a title update.
    silently no-op.
 
 Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+
+
+### Protocol: Worktree Location
+
+**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+
+Optimus creates linked git worktrees during the task lifecycle:
+
+- `/optimus:plan` creates a worktree when a task starts (Step 1.0.5).
+- `/optimus:resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
+- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
+
+**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
+
+**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
+
+**Why nested under the project repo:**
+
+| Concern | Resolution |
+|---|---|
+| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
+| Cleanup lifecycle | Removing the project directory also removes worktrees |
+| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
+| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
+| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
+
+**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
+
+- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
+- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
+
+**Backwards compatibility:**
+
+- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
+- New worktrees from `/optimus:plan` and `resume`'s recovery land in `.worktrees/`.
+- No forced migration.
+- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
+
+Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -321,6 +321,8 @@ fi
 
 ### Step 3.3: Apply Resolution Order
 
+**Canonical worktree path** — see AGENTS.md Worktree Location Convention.
+
 1. **Worktree found** → `cd "$WORKTREE_PATH"` for the rest of the session. Continue to Phase 4.
 
 2. **Worktree missing, branch exists locally** (`git rev-parse --verify "$TASK_BRANCH" >/dev/null 2>&1` succeeds):
@@ -328,16 +330,10 @@ fi
    **Hard guards (HARD BLOCK) BEFORE attempting `git worktree add`:**
 
    ```bash
-   PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-   if [ -z "$PROJECT_ROOT" ]; then
-     echo "ERROR: Not inside a git repository — cannot recover worktree."
-     # STOP
-   fi
-   REPO_NAME=$(basename "$PROJECT_ROOT")
-   if [ -z "$REPO_NAME" ]; then
-     echo "ERROR: Empty repo name derived from '$PROJECT_ROOT'."
-     # STOP
-   fi
+   # Resolve main worktree first — see AGENTS.md Protocol: Resolve Main Worktree Path.
+   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
    # Belt-and-suspenders: upstream guards (Step 2.1, Step 3.1, Step 3.2) already validated
    # these, but we are at a filesystem-mutation boundary — refuse one more time.
    if [ -z "$TASK_ID" ] || [ -z "$TASK_BRANCH" ]; then
@@ -345,15 +341,11 @@ fi
      # STOP
    fi
 
-   SLUG=$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')
-   SANITIZED_TITLE=$(echo "$TASK_TITLE" | tr '[:upper:]' '[:lower:]' \
-     | tr -c 'a-z0-9-' '-' | tr -s '-' | sed 's/^-//;s/-$//' | cut -c1-40)
-   # No trailing dash when sanitized title is empty
-   if [ -n "$SANITIZED_TITLE" ]; then
-     WORKTREE_DIR="../${REPO_NAME}-${SLUG}-${SANITIZED_TITLE}"
-   else
-     WORKTREE_DIR="../${REPO_NAME}-${SLUG}"
-   fi
+   # Path-traversal guard (defense in depth): branch comes from state.json.
+   case "$TASK_BRANCH" in
+     *..*|/*) echo "ERROR: refusing unsafe branch '$TASK_BRANCH'." >&2; exit 1 ;;
+   esac
+   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${TASK_BRANCH}"
 
    # HARD BLOCK on git worktree add failure (dir exists, branch checked out elsewhere, etc.)
    if ! git worktree add "$WORKTREE_DIR" "$TASK_BRANCH"; then
@@ -921,6 +913,55 @@ Where:
 3. Derive from Tipo + ID + Title (always works).
 
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
+
+
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+
+**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
+
+**Recipe:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
+  exit 1
+fi
+```
+
+The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
+
+**Path resolution pattern:**
+
+After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
+
+```bash
+# RIGHT (works from any worktree):
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
+         "${MAIN_WORKTREE}/.optimus/reports" \
+         "${MAIN_WORKTREE}/.optimus/logs"
+
+# WRONG (resolves against PWD, breaks in linked worktrees):
+STATE_FILE=".optimus/state.json"
+SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE=".optimus/stats.json"
+mkdir -p .optimus/sessions .optimus/reports .optimus/logs
+```
+
+**What does NOT need this protocol:**
+
+- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.gitignore` itself — versioned, propagated via git.
+
+**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
 
 
 ### Protocol: Terminal Identification

--- a/commands/review.md
+++ b/commands/review.md
@@ -2549,18 +2549,19 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
@@ -2981,10 +2982,13 @@ fi
      fi
      ```
      If the branch exists, create the worktree automatically. Canonical path
-     follows the Worktree Location Convention:
+     follows Protocol: Worktree Location:
      ```bash
      # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
-     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     # Reuse cached MAIN_WORKTREE if caller already resolved.
+     if [ -z "${MAIN_WORKTREE:-}" ]; then
+       MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     fi
      MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
      # Path-traversal guard (defense in depth): branch name comes from state.json

--- a/commands/review.md
+++ b/commands/review.md
@@ -2552,6 +2552,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
 # ensures it fires for build/review/plan/done (which call Session State but not
@@ -2930,8 +2942,8 @@ fi
    - **If N eligible tasks** → list all with worktree paths via `AskUser`:
      ```
      Multiple tasks available:
-       T-001 — User auth (Em Andamento) → /projeto-t-001-.../
-       T-002 — Login page (Em Andamento) → /projeto-t-002-.../
+       T-001 — User auth (Em Andamento) → <repo>/.worktrees/feat/t-001-user-auth/
+       T-002 — Login page (Em Andamento) → <repo>/.worktrees/feat/t-002-login-page/
      Which task should I continue?
      ```
    - After task is identified, locate the worktree. Prefer the source-of-truth
@@ -2968,11 +2980,24 @@ fi
        #   Options: Create branch from HEAD / Re-run /optimus:plan"
      fi
      ```
-     If the branch exists, create the worktree automatically:
+     If the branch exists, create the worktree automatically. Canonical path
+     follows the Worktree Location Convention:
      ```bash
-     REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
-     WORKTREE_DIR="../${REPO_NAME}-$(echo <task-id> | tr '[:upper:]' '[:lower:]')-<keywords>"
-     git worktree add "$WORKTREE_DIR" "<branch-name>"
+     # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
+     # Path-traversal guard (defense in depth): branch name comes from state.json
+     # in some flows.
+     case "<branch-name>" in
+       *..*|/*) echo "ERROR: refusing unsafe branch name." >&2; exit 1 ;;
+     esac
+     WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/<branch-name>"
+
+     if ! git worktree add "$WORKTREE_DIR" "<branch-name>"; then
+       echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
+       exit 1
+     fi
      ```
      Then change working directory to the new worktree.
 

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -1198,18 +1198,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -1201,6 +1201,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -959,18 +959,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -962,6 +962,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -384,14 +384,30 @@ If a worktree is found (`WORKTREE_PATH` non-empty), ask via `AskUser`:
 Task T-XXX is done. A worktree still exists at '<path>'. What should I do?
 ```
 Options:
-- **Remove worktree**: `git worktree remove <path>`
+- **Remove worktree**: `git worktree remove <path>` then prune empty parent dirs (see snippet below)
 - **Keep**: Leave the worktree as is
+
+**Removal snippet** — after the user picks "Remove worktree":
+
+```bash
+git worktree remove "$WORKTREE_PATH"
+# Cleanup intermediate parent dirs (e.g., empty .worktrees/feat/ after removing leaf).
+# Idempotent: rmdir refuses non-empty dirs silently.
+parent="$(dirname "$WORKTREE_PATH")"
+while [ "$parent" != "${MAIN_WORKTREE}/.worktrees" ] && [ "$parent" != "/" ]; do
+  rmdir "$parent" 2>/dev/null || break
+  parent="$(dirname "$parent")"
+done
+```
+
+This walks up from the removed worktree leaf to `${MAIN_WORKTREE}/.worktrees/` removing
+empty intermediate dirs (`feat/`, `fix/`, etc.) but stops at `.worktrees/` itself.
 
 **Edge case — running INSIDE the worktree:** If the agent's current working directory IS
 the worktree being removed, `cd` to the main repository first:
 1. Identify the main repository path from `git worktree list` (first entry)
 2. `cd <main-repo-path>`
-3. Then `git worktree remove <worktree-path>`
+3. Then run the **Removal snippet** above.
 
 ### Step 4.2: Check for Task Branch
 

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -649,18 +649,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -652,6 +652,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -321,7 +321,7 @@ workspace, no `Validando Spec` status leak).
 
 ### Step 1.0.5: Reserve Task and Create Workspace
 
-**Canonical worktree path** — see AGENTS.md Worktree Location Convention.
+**Canonical worktree path** — see AGENTS.md Protocol: Worktree Location.
 
 Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines.
 
@@ -341,9 +341,13 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
 4. **Create worktree:**
    ```bash
    # Resolve main worktree first — see AGENTS.md Protocol: Resolve Main Worktree Path.
-   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   # Reuse cached MAIN_WORKTREE if caller already resolved (per Protocol: Resolve Main Worktree Path).
+   if [ -z "${MAIN_WORKTREE:-}" ]; then
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   fi
    MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
+   # BRANCH_NAME must be a real branch name (substituted from Protocol: Branch Name Derivation), not the placeholder.
    BRANCH_NAME="<tipo-prefix>/<task-id>-<keywords>"
    # Path-traversal guard (defense in depth).
    case "$BRANCH_NAME" in
@@ -354,7 +358,16 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
    **Pre-check:** If `WORKTREE_DIR` already exists but is not a git worktree, ask via
    `AskUser`: "Directory `<path>` already exists but is not a git worktree."
    Options: Remove and create worktree / Rename existing directory / Cancel.
+
    ```bash
+   # Pre-check: directory exists but is not a git worktree?
+   if [ -e "$WORKTREE_DIR" ] && ! git -C "$WORKTREE_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+     echo "WARNING: $WORKTREE_DIR exists but is not a git worktree." >&2
+     # Present AskUser: Remove and create / Rename existing / Cancel
+     # (Agent: invoke the AskUser flow with these 3 options. If user picks Remove,
+     # rm -rf "$WORKTREE_DIR". If Rename, propose mv "$WORKTREE_DIR" "${WORKTREE_DIR}.bak-$(date +%s)".
+     # If Cancel, exit 1.)
+   fi
    if ! git worktree add "$WORKTREE_DIR" -b "${BRANCH_NAME}"; then
      echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
      # Rollback: state.json reservation is removed in Step 5 below.
@@ -362,6 +375,8 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
    fi
    ```
    Then change working directory to the new worktree path for all subsequent steps.
+
+   *Optional:* Configure your editor to exclude `.worktrees/` (see Protocol: Worktree Location → IDE exclusion).
 
 5. **Rollback on failure:** If worktree creation fails:
    - Remove the entry from state.json
@@ -2220,18 +2235,19 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
@@ -2605,6 +2621,45 @@ will not see a title update.
    silently no-op.
 
 Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+
+
+### Protocol: Worktree Location
+
+**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+
+Optimus creates linked git worktrees during the task lifecycle:
+
+- `/optimus-plan` creates a worktree when a task starts (Step 1.0.5).
+- `/optimus-resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
+- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
+
+**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
+
+**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
+
+**Why nested under the project repo:**
+
+| Concern | Resolution |
+|---|---|
+| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
+| Cleanup lifecycle | Removing the project directory also removes worktrees |
+| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
+| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
+| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
+
+**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
+
+- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
+- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
+
+**Backwards compatibility:**
+
+- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
+- New worktrees from `/optimus-plan` and `resume`'s recovery land in `.worktrees/`.
+- No forced migration.
+- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
+
+Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -321,6 +321,8 @@ workspace, no `Validando Spec` status leak).
 
 ### Step 1.0.5: Reserve Task and Create Workspace
 
+**Canonical worktree path** — see AGENTS.md Worktree Location Convention.
+
 Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines.
 
 **If already on a feature branch** (not default/main/master): skip to Step 1.0.6
@@ -338,14 +340,26 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
 
 4. **Create worktree:**
    ```bash
-   REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
-   WORKTREE_DIR="../${REPO_NAME}-<task-id>-<keywords>"
+   # Resolve main worktree first — see AGENTS.md Protocol: Resolve Main Worktree Path.
+   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
+   BRANCH_NAME="<tipo-prefix>/<task-id>-<keywords>"
+   # Path-traversal guard (defense in depth).
+   case "$BRANCH_NAME" in
+     *..*|/*) echo "ERROR: refusing unsafe branch '$BRANCH_NAME'." >&2; exit 1 ;;
+   esac
+   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${BRANCH_NAME}"
    ```
    **Pre-check:** If `WORKTREE_DIR` already exists but is not a git worktree, ask via
    `AskUser`: "Directory `<path>` already exists but is not a git worktree."
    Options: Remove and create worktree / Rename existing directory / Cancel.
    ```bash
-   git worktree add "$WORKTREE_DIR" -b "<tipo-prefix>/<task-id>-<keywords>"
+   if ! git worktree add "$WORKTREE_DIR" -b "${BRANCH_NAME}"; then
+     echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
+     # Rollback: state.json reservation is removed in Step 5 below.
+     exit 1
+   fi
    ```
    Then change working directory to the new worktree path for all subsequent steps.
 
@@ -1230,55 +1244,6 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
-
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
-
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
-
 ### Deep Research Before Presenting (MANDATORY for cycle review skills)
 Applies to: plan, review, pr-check, coderabbit-review
 
@@ -2050,6 +2015,55 @@ applied fixes are correct and checks for any issues introduced by the fixes.
 Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
 
 
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+
+**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
+
+**Recipe:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
+  exit 1
+fi
+```
+
+The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
+
+**Path resolution pattern:**
+
+After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
+
+```bash
+# RIGHT (works from any worktree):
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
+         "${MAIN_WORKTREE}/.optimus/reports" \
+         "${MAIN_WORKTREE}/.optimus/logs"
+
+# WRONG (resolves against PWD, breaks in linked worktrees):
+STATE_FILE=".optimus/state.json"
+SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE=".optimus/stats.json"
+mkdir -p .optimus/sessions .optimus/reports .optimus/logs
+```
+
+**What does NOT need this protocol:**
+
+- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.gitignore` itself — versioned, propagated via git.
+
+**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
+
+
 ### Protocol: Ring Droid Requirement Check
 
 **Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
@@ -2208,6 +2222,18 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -2346,18 +2346,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -2349,6 +2349,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -976,18 +976,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -979,6 +979,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -358,9 +358,11 @@ if [ -z "$TASK_ID" ] || ! [[ "$TASK_ID" =~ ^T-[0-9]+$ ]]; then
 fi
 
 # Anchor the match on the kebab-cased task ID (e.g., `-t-1-`) so substrings like
-# `t-1` cannot match `t-10`/`t-100`. Worktree paths follow the convention
-# `<parent>/<repo>-<id>-<keywords>`, and feature branches follow
-# `<tipo>/<id>-<keywords>` — both surround the lowercased ID with hyphens.
+# `t-1` cannot match `t-10`/`t-100`. Worktree paths follow Protocol: Worktree
+# Location: ${MAIN_WORKTREE}/.worktrees/<branch-name> (legacy sibling paths
+# ../<repo>-<id>-<keywords> still resolve via git worktree list metadata).
+# Feature branches follow `<tipo>/<id>-<keywords>` — both surround the
+# lowercased ID with hyphens.
 TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
 WORKTREE_PATH=$(git worktree list --porcelain 2>/dev/null \
   | awk -v anchor="$TASK_KEBAB" '
@@ -380,7 +382,7 @@ fi
 
 ### Step 3.3: Apply Resolution Order
 
-**Canonical worktree path** — see AGENTS.md Worktree Location Convention.
+**Canonical worktree path** — see AGENTS.md Protocol: Worktree Location.
 
 1. **Worktree found** → `cd "$WORKTREE_PATH"` for the rest of the session. Continue to Phase 4.
 
@@ -390,7 +392,10 @@ fi
 
    ```bash
    # Resolve main worktree first — see AGENTS.md Protocol: Resolve Main Worktree Path.
-   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   # Reuse cached MAIN_WORKTREE if caller already resolved (per Protocol: Resolve Main Worktree Path).
+   if [ -z "${MAIN_WORKTREE:-}" ]; then
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   fi
    MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
    # Belt-and-suspenders: upstream guards (Step 2.1, Step 3.1, Step 3.2) already validated
@@ -408,7 +413,7 @@ fi
 
    # HARD BLOCK on git worktree add failure (dir exists, branch checked out elsewhere, etc.)
    if ! git worktree add "$WORKTREE_DIR" "$TASK_BRANCH"; then
-     echo "ERROR: 'git worktree add $WORKTREE_DIR $TASK_BRANCH' failed."
+     echo "ERROR: 'git worktree add $WORKTREE_DIR $TASK_BRANCH' failed (branch already checked out, dir collision, or filesystem error)."
      echo "       Possible causes: directory exists, branch checked out elsewhere, or local repo state."
      # STOP
    fi
@@ -418,6 +423,8 @@ fi
      # STOP
    fi
    ```
+
+   **Initialize .optimus directory** (ensures `.optimus/logs/`, `.gitignore` exclusions for `.optimus/` and `.worktrees/`) — see AGENTS.md Protocol: Initialize .optimus Directory.
 
 <a id="step-reset-to-pendente-recovery"></a>
 3. **Worktree missing AND branch missing:**
@@ -974,6 +981,64 @@ Where:
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 
 
+### Protocol: Initialize .optimus Directory
+
+**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+
+Before creating ANY file inside `.optimus/`, ensure the directory structure exists
+and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
+
+```bash
+# Requires Protocol: Resolve Main Worktree Path to have run first
+# (or resolve inline; see that protocol).
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
+# Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Log retention (idempotent — fires once per init): age-based + count-cap prune.
+# Also duplicated in Protocol: Session State so stage agents (which call Session
+# State but not Initialize Directory) get pruning at every phase transition.
+# Both prune sites are no-ops on clean directories; running both is harmless.
+find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
+if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
+  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
+    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
+fi
+```
+
+**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
+- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
+  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
+  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
+- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
+  `review`, `done`) phase transition.
+
+Both sites are idempotent (no-op on clean directories) and use the same prune
+logic (30-day age cap + 500-file count cap). Running both per session is a
+harmless cheap operation.
+
+Everything inside `.optimus/` is gitignored. The planning tree is versioned
+separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
+for Ring specs) — see the File Location section above.
+
+Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
+
+
 ### Protocol: Resolve Main Worktree Path
 
 **Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
@@ -1116,6 +1181,45 @@ will not see a title update.
    silently no-op.
 
 Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+
+
+### Protocol: Worktree Location
+
+**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+
+Optimus creates linked git worktrees during the task lifecycle:
+
+- `/optimus-plan` creates a worktree when a task starts (Step 1.0.5).
+- `/optimus-resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
+- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
+
+**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
+
+**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
+
+**Why nested under the project repo:**
+
+| Concern | Resolution |
+|---|---|
+| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
+| Cleanup lifecycle | Removing the project directory also removes worktrees |
+| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
+| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
+| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
+
+**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
+
+- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
+- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
+
+**Backwards compatibility:**
+
+- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
+- New worktrees from `/optimus-plan` and `resume`'s recovery land in `.worktrees/`.
+- No forced migration.
+- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
+
+Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -380,6 +380,8 @@ fi
 
 ### Step 3.3: Apply Resolution Order
 
+**Canonical worktree path** — see AGENTS.md Worktree Location Convention.
+
 1. **Worktree found** → `cd "$WORKTREE_PATH"` for the rest of the session. Continue to Phase 4.
 
 2. **Worktree missing, branch exists locally** (`git rev-parse --verify "$TASK_BRANCH" >/dev/null 2>&1` succeeds):
@@ -387,16 +389,10 @@ fi
    **Hard guards (HARD BLOCK) BEFORE attempting `git worktree add`:**
 
    ```bash
-   PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-   if [ -z "$PROJECT_ROOT" ]; then
-     echo "ERROR: Not inside a git repository — cannot recover worktree."
-     # STOP
-   fi
-   REPO_NAME=$(basename "$PROJECT_ROOT")
-   if [ -z "$REPO_NAME" ]; then
-     echo "ERROR: Empty repo name derived from '$PROJECT_ROOT'."
-     # STOP
-   fi
+   # Resolve main worktree first — see AGENTS.md Protocol: Resolve Main Worktree Path.
+   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
    # Belt-and-suspenders: upstream guards (Step 2.1, Step 3.1, Step 3.2) already validated
    # these, but we are at a filesystem-mutation boundary — refuse one more time.
    if [ -z "$TASK_ID" ] || [ -z "$TASK_BRANCH" ]; then
@@ -404,15 +400,11 @@ fi
      # STOP
    fi
 
-   SLUG=$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')
-   SANITIZED_TITLE=$(echo "$TASK_TITLE" | tr '[:upper:]' '[:lower:]' \
-     | tr -c 'a-z0-9-' '-' | tr -s '-' | sed 's/^-//;s/-$//' | cut -c1-40)
-   # No trailing dash when sanitized title is empty
-   if [ -n "$SANITIZED_TITLE" ]; then
-     WORKTREE_DIR="../${REPO_NAME}-${SLUG}-${SANITIZED_TITLE}"
-   else
-     WORKTREE_DIR="../${REPO_NAME}-${SLUG}"
-   fi
+   # Path-traversal guard (defense in depth): branch comes from state.json.
+   case "$TASK_BRANCH" in
+     *..*|/*) echo "ERROR: refusing unsafe branch '$TASK_BRANCH'." >&2; exit 1 ;;
+   esac
+   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${TASK_BRANCH}"
 
    # HARD BLOCK on git worktree add failure (dir exists, branch checked out elsewhere, etc.)
    if ! git worktree add "$WORKTREE_DIR" "$TASK_BRANCH"; then
@@ -980,6 +972,55 @@ Where:
 3. Derive from Tipo + ID + Title (always works).
 
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
+
+
+### Protocol: Resolve Main Worktree Path
+
+**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+
+**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
+
+**Recipe:**
+
+```bash
+MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+if [ -z "$MAIN_WORKTREE" ]; then
+  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
+  exit 1
+fi
+```
+
+The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
+
+**Path resolution pattern:**
+
+After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
+
+```bash
+# RIGHT (works from any worktree):
+STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
+SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
+         "${MAIN_WORKTREE}/.optimus/reports" \
+         "${MAIN_WORKTREE}/.optimus/logs"
+
+# WRONG (resolves against PWD, breaks in linked worktrees):
+STATE_FILE=".optimus/state.json"
+SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
+STATS_FILE=".optimus/stats.json"
+mkdir -p .optimus/sessions .optimus/reports .optimus/logs
+```
+
+**What does NOT need this protocol:**
+
+- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
+- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
+- `.gitignore` itself — versioned, propagated via git.
+
+**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
+
+Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
 
 
 ### Protocol: Terminal Identification

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -2614,18 +2614,19 @@ MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repo
 # agents — which call Session State but not Initialize Directory — also create
 # the dirs and update .gitignore on first phase transition.
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
@@ -3046,10 +3047,13 @@ fi
      fi
      ```
      If the branch exists, create the worktree automatically. Canonical path
-     follows the Worktree Location Convention:
+     follows Protocol: Worktree Location:
      ```bash
      # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
-     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     # Reuse cached MAIN_WORKTREE if caller already resolved.
+     if [ -z "${MAIN_WORKTREE:-}" ]; then
+       MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     fi
      MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
      # Path-traversal guard (defense in depth): branch name comes from state.json

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -2617,6 +2617,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — runs every phase transition): age-based + count-cap
 # prune. Stage agents are the heaviest log producers, so placing prune here
 # ensures it fires for build/review/plan/done (which call Session State but not
@@ -2995,8 +3007,8 @@ fi
    - **If N eligible tasks** → list all with worktree paths via `AskUser`:
      ```
      Multiple tasks available:
-       T-001 — User auth (Em Andamento) → /projeto-t-001-.../
-       T-002 — Login page (Em Andamento) → /projeto-t-002-.../
+       T-001 — User auth (Em Andamento) → <repo>/.worktrees/feat/t-001-user-auth/
+       T-002 — Login page (Em Andamento) → <repo>/.worktrees/feat/t-002-login-page/
      Which task should I continue?
      ```
    - After task is identified, locate the worktree. Prefer the source-of-truth
@@ -3033,11 +3045,24 @@ fi
        #   Options: Create branch from HEAD / Re-run /optimus-plan"
      fi
      ```
-     If the branch exists, create the worktree automatically:
+     If the branch exists, create the worktree automatically. Canonical path
+     follows the Worktree Location Convention:
      ```bash
-     REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
-     WORKTREE_DIR="../${REPO_NAME}-$(echo <task-id> | tr '[:upper:]' '[:lower:]')-<keywords>"
-     git worktree add "$WORKTREE_DIR" "<branch-name>"
+     # Resolve main worktree first — see Protocol: Resolve Main Worktree Path.
+     MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
+     MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
+
+     # Path-traversal guard (defense in depth): branch name comes from state.json
+     # in some flows.
+     case "<branch-name>" in
+       *..*|/*) echo "ERROR: refusing unsafe branch name." >&2; exit 1 ;;
+     esac
+     WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/<branch-name>"
+
+     if ! git worktree add "$WORKTREE_DIR" "<branch-name>"; then
+       echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
+       exit 1
+     fi
      ```
      Then change working directory to the new worktree.
 

--- a/scripts/test_inline_protocols.py
+++ b/scripts/test_inline_protocols.py
@@ -3,6 +3,7 @@
 
 import importlib.util
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -806,3 +807,80 @@ class TestRefAliasCollision:
         assert "INFO" in captured.err
         assert "ref alias collapsed" in captured.err
         assert "Protocol: Foo Bar Resolution" in captured.err
+
+
+# --- F-worktrees: behavioral verification of symlink refusal in the
+# auto-inject block. The block is shared by Protocol: Initialize .optimus
+# Directory and Protocol: Session State; both must exit non-zero when
+# .gitignore is a symlink BEFORE writing to it.
+
+class TestGitignoreAutoInjectSymlinkRefusal:
+    """Verifies the bash auto-inject snippet exits non-zero when .gitignore is a symlink."""
+
+    # Minimal stand-in mirroring the auto-inject block from AGENTS.md
+    # (Protocol: Initialize .optimus Directory and Protocol: Session State).
+    # The symlink check is HOISTED to fire BEFORE either write — so a
+    # symlink victim must remain unmodified.
+    AUTO_INJECT_SNIPPET = r"""
+set -e
+MAIN_WORKTREE="$1"
+mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
+# Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+"""
+
+    def test_symlink_gitignore_is_refused(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        # Symlink target: a sensitive innocent file (mimics e.g. ~/.bashrc).
+        target = tmp_path / "innocent.txt"
+        target.write_text("# innocent — must not be modified\n")
+        gitignore = repo / ".gitignore"
+        gitignore.symlink_to(target)
+        before = target.read_text()
+
+        result = subprocess.run(
+            ["bash", "-c", self.AUTO_INJECT_SNIPPET, "_", str(repo)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode != 0, (
+            f"Snippet must exit non-zero when .gitignore is a symlink "
+            f"(got rc={result.returncode}, stderr={result.stderr!r})"
+        )
+        assert "ERROR" in result.stderr
+        assert "symlink" in result.stderr.lower()
+        # CRITICAL: the symlink target must remain UNCHANGED — proves the
+        # refusal fires BEFORE either write (defense in depth).
+        assert target.read_text() == before, (
+            "Symlink target was modified — refusal fired AFTER a write "
+            "(F2 regression: symlink check must precede operational-files write)"
+        )
+
+    def test_regular_gitignore_still_writes(self, tmp_path: Path):
+        """Sanity: with a regular file, the snippet appends both markers."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        gitignore = repo / ".gitignore"
+        gitignore.write_text("# pre-existing\n")
+
+        result = subprocess.run(
+            ["bash", "-c", self.AUTO_INJECT_SNIPPET, "_", str(repo)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        body = gitignore.read_text()
+        assert "# optimus-operational-files" in body
+        assert "# optimus-operational-worktrees" in body

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3082,7 +3082,6 @@ class TestSpecSelfHeal:
         ``extract_refs_from_content`` there) so that references resolved by the
         inliner are also resolved here, and references it warns about as
         unmatched are also surfaced as test failures."""
-        import re
         import sys
         sys.path.insert(0, str(REPO_ROOT / "scripts"))
         try:
@@ -3129,3 +3128,69 @@ class TestSpecSelfHeal:
             assert "symlink" in link_section.lower(), (
                 f"{skill_path.parent.parent.name} 'Link existing spec' must explicitly mention symlinks"
             )
+
+
+class TestWorktreeLocationConvention:
+    """F-worktrees: All worktree-creation sites use ${MAIN_WORKTREE}/.worktrees/<branch>
+    pattern; .gitignore auto-inject uses post-F1 ${MAIN_WORKTREE}/.gitignore contract."""
+
+    CREATOR_FILES = [
+        ("AGENTS.md", None),  # Workspace Auto-Navigation
+        ("plan", "Step 1.0.5"),
+        ("resume", "Step 3.3"),
+    ]
+
+    def test_no_sibling_worktree_path_pattern(self):
+        """No `../${REPO_NAME}-...` or `../<repo>-...` worktree-add invocations should remain."""
+        violations = []
+        for skill in ["plan", "resume"]:
+            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
+            content = path.read_text()
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            for lineno, line in enumerate(body.splitlines(), start=1):
+                if "git worktree add" in line and "../" in line:
+                    violations.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: sibling pattern: {line.strip()}")
+        assert violations == [], "\n".join(violations)
+
+    def test_worktree_paths_use_dot_worktrees(self):
+        """plan and resume creation sites use ${MAIN_WORKTREE}/.worktrees/."""
+        for skill in ["plan", "resume"]:
+            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
+            content = path.read_text()
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            assert "${MAIN_WORKTREE}/.worktrees/" in body, (
+                f"{path.relative_to(REPO_ROOT)}: missing ${{MAIN_WORKTREE}}/.worktrees/ pattern"
+            )
+
+    def test_agents_md_documents_worktree_convention(self):
+        content = (REPO_ROOT / "AGENTS.md").read_text()
+        assert "## Worktree Location Convention" in content
+
+    def test_gitignore_auto_inject_uses_main_worktree_path(self):
+        """Post-F1 contract: gitignore auto-inject must use ${MAIN_WORKTREE}/.gitignore,
+        NOT bare .gitignore (which would write to the linked worktree's .gitignore
+        when run from a linked worktree)."""
+        content = (REPO_ROOT / "AGENTS.md").read_text()
+        # The auto-inject block for worktrees must reference ${MAIN_WORKTREE}/.gitignore
+        # (find the optimus-operational-worktrees marker context)
+        idx = content.find("optimus-operational-worktrees")
+        assert idx >= 0, "AGENTS.md must add .worktrees/ to .gitignore via auto-inject"
+        window = content[max(0, idx - 200):idx + 500]
+        # The block must use prefixed .gitignore, not bare
+        assert '"${MAIN_WORKTREE}/.gitignore"' in window or "${MAIN_WORKTREE}/.gitignore" in window, (
+            "gitignore auto-inject for .worktrees/ must use ${MAIN_WORKTREE}/.gitignore (post-F1 contract)"
+        )
+
+    def test_branch_traversal_guard_in_creator_sites(self):
+        """All worktree-creator sites must guard against path-traversal in branch names."""
+        violations = []
+        for skill in ["plan", "resume"]:
+            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
+            content = path.read_text()
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            # Must contain `*..*|/*)` or equivalent traversal guard
+            if "*..*" not in body or "git worktree add" not in body:
+                # Only flag if the file actually creates a worktree
+                if "git worktree add" in body and "*..*" not in body:
+                    violations.append(f"{path.relative_to(REPO_ROOT)}: missing path-traversal guard")
+        assert violations == [], "\n".join(violations)

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3135,16 +3135,30 @@ class TestWorktreeLocationConvention:
     pattern; .gitignore auto-inject uses post-F1 ${MAIN_WORKTREE}/.gitignore contract."""
 
     CREATOR_FILES = [
-        ("AGENTS.md", None),  # Workspace Auto-Navigation
-        ("plan", "Step 1.0.5"),
-        ("resume", "Step 3.3"),
+        (REPO_ROOT / "AGENTS.md", "Workspace Auto-Navigation"),
+        (REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md", "Step 1.0.5"),
+        (REPO_ROOT / "resume" / "skills" / "optimus-resume" / "SKILL.md", "Step 3.3"),
+    ]
+
+    # User-facing command mirrors (auto-generated from SKILL.md by sync-claude-commands.py).
+    COMMAND_MIRRORS = [
+        REPO_ROOT / "commands" / "plan.md",
+        REPO_ROOT / "commands" / "resume.md",
     ]
 
     def test_no_sibling_worktree_path_pattern(self):
         """No `../${REPO_NAME}-...` or `../<repo>-...` worktree-add invocations should remain."""
         violations = []
-        for skill in ["plan", "resume"]:
-            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
+        for path, _ in self.CREATOR_FILES:
+            content = path.read_text()
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            for lineno, line in enumerate(body.splitlines(), start=1):
+                if "git worktree add" in line and "../" in line:
+                    violations.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: sibling pattern: {line.strip()}")
+        # Also check user-facing command mirrors.
+        for path in self.COMMAND_MIRRORS:
+            if not path.exists():
+                continue
             content = path.read_text()
             body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
             for lineno, line in enumerate(body.splitlines(), start=1):
@@ -3153,9 +3167,23 @@ class TestWorktreeLocationConvention:
         assert violations == [], "\n".join(violations)
 
     def test_worktree_paths_use_dot_worktrees(self):
-        """plan and resume creation sites use ${MAIN_WORKTREE}/.worktrees/."""
-        for skill in ["plan", "resume"]:
-            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
+        """Creator sites and command mirrors use ${MAIN_WORKTREE}/.worktrees/.
+
+        AGENTS.md is skipped in this check because ${MAIN_WORKTREE}/.worktrees/
+        IS in AGENTS.md auto-nav (and that's exactly what we want to verify
+        elsewhere via the dedicated test for the convention section)."""
+        for path, _ in self.CREATOR_FILES:
+            if path.name == "AGENTS.md":
+                continue
+            content = path.read_text()
+            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            assert "${MAIN_WORKTREE}/.worktrees/" in body, (
+                f"{path.relative_to(REPO_ROOT)}: missing ${{MAIN_WORKTREE}}/.worktrees/ pattern"
+            )
+        # Also verify the command mirrors.
+        for path in self.COMMAND_MIRRORS:
+            if not path.exists():
+                continue
             content = path.read_text()
             body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
             assert "${MAIN_WORKTREE}/.worktrees/" in body, (
@@ -3164,33 +3192,46 @@ class TestWorktreeLocationConvention:
 
     def test_agents_md_documents_worktree_convention(self):
         content = (REPO_ROOT / "AGENTS.md").read_text()
-        assert "## Worktree Location Convention" in content
+        assert "### Protocol: Worktree Location" in content
+        # And content (not just header)
+        idx = content.find("### Protocol: Worktree Location")
+        section = content[idx:idx + 4000]
+        assert "${MAIN_WORKTREE}/.worktrees/" in section
+        assert "Resolve Main Worktree Path" in section  # cross-reference
+        assert "Backwards compatibility" in section
 
     def test_gitignore_auto_inject_uses_main_worktree_path(self):
         """Post-F1 contract: gitignore auto-inject must use ${MAIN_WORKTREE}/.gitignore,
         NOT bare .gitignore (which would write to the linked worktree's .gitignore
-        when run from a linked worktree)."""
+        when run from a linked worktree).
+
+        Validates EVERY occurrence of the operational-worktrees marker, not just
+        the first — both Initialize Directory and Session State protocols
+        contain the auto-inject block."""
         content = (REPO_ROOT / "AGENTS.md").read_text()
-        # The auto-inject block for worktrees must reference ${MAIN_WORKTREE}/.gitignore
-        # (find the optimus-operational-worktrees marker context)
-        idx = content.find("optimus-operational-worktrees")
-        assert idx >= 0, "AGENTS.md must add .worktrees/ to .gitignore via auto-inject"
-        window = content[max(0, idx - 200):idx + 500]
-        # The block must use prefixed .gitignore, not bare
-        assert '"${MAIN_WORKTREE}/.gitignore"' in window or "${MAIN_WORKTREE}/.gitignore" in window, (
-            "gitignore auto-inject for .worktrees/ must use ${MAIN_WORKTREE}/.gitignore (post-F1 contract)"
-        )
+        # All occurrences of the marker token (covers both grep guard and
+        # printf payload sites). We then assert the protective ${MAIN_WORKTREE}
+        # path appears in the surrounding window for each.
+        indices = [m.start() for m in re.finditer(r'optimus-operational-worktrees', content)]
+        assert indices, "AGENTS.md missing optimus-operational-worktrees marker"
+        for idx in indices:
+            window = content[max(0, idx - 300):idx + 500]
+            assert "${MAIN_WORKTREE}/.gitignore" in window, (
+                f"AGENTS.md byte {idx}: gitignore auto-inject must use ${{MAIN_WORKTREE}}/.gitignore"
+            )
 
     def test_branch_traversal_guard_in_creator_sites(self):
-        """All worktree-creator sites must guard against path-traversal in branch names."""
+        """All worktree-creator sites that actually call `git worktree add`
+        MUST guard branch names against path traversal via a `case ... in
+        *..*|/*)` statement."""
+        # Match `case "<var>" in <newline> *..*|/*)` allowing optional
+        # whitespace before the case-arm pattern.
+        pattern = re.compile(r'case\s+"[^"]*"\s+in\s*\n\s*\*\.\.\*\|/\*\)')
         violations = []
-        for skill in ["plan", "resume"]:
-            path = REPO_ROOT / skill / "skills" / f"optimus-{skill}" / "SKILL.md"
-            content = path.read_text()
-            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
-            # Must contain `*..*|/*)` or equivalent traversal guard
-            if "*..*" not in body or "git worktree add" not in body:
-                # Only flag if the file actually creates a worktree
-                if "git worktree add" in body and "*..*" not in body:
-                    violations.append(f"{path.relative_to(REPO_ROOT)}: missing path-traversal guard")
+        for path, _ in self.CREATOR_FILES:
+            body = path.read_text().split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            if "git worktree add" not in body:
+                continue
+            if not pattern.search(body):
+                violations.append(f"{path.relative_to(REPO_ROOT)}: missing case-stmt traversal guard")
         assert violations == [], "\n".join(violations)

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1250,18 +1250,19 @@ and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-u
 MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
 MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Worktree Location Convention). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
 # Refuse symlinked .gitignore (defense against link-following file-write).
+# Hoisted ABOVE the operational-files write so the first append is also protected.
 if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
   echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
   exit 1
 fi
+if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Protocol: Worktree Location). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
 if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1253,6 +1253,18 @@ mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports
 if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
   printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
 fi
+# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
+# (see Worktree Location Convention). Add a separate marker so existing
+# projects whose .gitignore already carries the operational-files block
+# still get the worktree exclusion idempotently.
+# Refuse symlinked .gitignore (defense against link-following file-write).
+if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
+  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
+  exit 1
+fi
+if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
+  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
+fi
 # Log retention (idempotent — fires once per init): age-based + count-cap prune.
 # Also duplicated in Protocol: Session State so stage agents (which call Session
 # State but not Initialize Directory) get pruning at every phase transition.


### PR DESCRIPTION
Closes #21. Replaces closed PR #30 with fresh implementation against current main (post-deep-review F1-F14 contracts baked in).

## Why a new PR

PR #30 was opened before the deep-review session. After 10 commits landed on main (PRs #35-#41), the rebase cost grew to ~90 min and the post-F1 `${MAIN_WORKTREE}/.gitignore` contract needed to be reimplemented from the start, not patched on. Design from #30 (Worktree Location Convention section, IDE guidance, regression tests, branch-name-with-`/` handling, symlink defense) is preserved; implementation is fresh.

## Summary

Standardize on `${MAIN_WORKTREE}/.worktrees/<branch-name>` as the canonical worktree path for `/optimus-plan`, `/optimus-resume` recovery, and `Protocol: Workspace Auto-Navigation` fallback.

| Concern | Resolution |
|---|---|
| Discoverability | All worktrees listed by `ls <repo>/.worktrees/` |
| Cleanup lifecycle | Removing the project dir also removes worktrees |
| `.optimus/` companion | Same operational+gitignored+project-rooted pattern |
| Cross-repo safety | Worktrees stay in project repo (unaffected by separate-repo `tasksDir`) |
| Main-worktree resolution | `git worktree list --porcelain` still identifies main first |

## Changes

### Source-of-truth (5 files)
- **AGENTS.md** — new `## Worktree Location Convention` section + auto-inject `.worktrees/` into `.gitignore` from BOTH `Protocol: Initialize .optimus Directory` AND `Protocol: Session State`. Uses `${MAIN_WORKTREE}/.gitignore` (post-F1 contract), separate `# optimus-operational-worktrees` marker (idempotent), symlink-refusal guard. Workspace Auto-Navigation worktree creation uses `${MAIN_WORKTREE}/.worktrees/<branch>` with traversal guard.
- **plan/SKILL.md** Step 1.0.5 — task-start worktree creation (canonical pattern + `${MAIN_WORKTREE:?...}` defensive guard + traversal guard + explicit `if ! git worktree add` failure handling)
- **resume/SKILL.md** Step 3.3 Case 2 — branch-exists-but-worktree-missing recovery (same canonical pattern; removed unused `PROJECT_ROOT`/`SLUG`/`SANITIZED_TITLE` derivation)
- **scripts/test_skill_consistency.py** — new `TestWorktreeLocationConvention` (5 tests)
- **`.gitignore`** — `.worktrees/` block

### Auto-regenerated
- 10 SKILL.md inlined-block re-renders (via `inline-protocols.py`)
- 10 commands/*.md mirror regenerations (via `sync-claude-commands.py`)

## New tests (5)

| Test | Coverage |
|------|----------|
| `test_no_sibling_worktree_path_pattern` | No `../<repo>-...` worktree-add invocations remain |
| `test_worktree_paths_use_dot_worktrees` | plan + resume creation sites use `${MAIN_WORKTREE}/.worktrees/` |
| `test_agents_md_documents_worktree_convention` | AGENTS.md has the Worktree Location Convention section |
| `test_gitignore_auto_inject_uses_main_worktree_path` | gitignore auto-inject uses `${MAIN_WORKTREE}/.gitignore` (NOT bare path — post-F1 contract) |
| `test_branch_traversal_guard_in_creator_sites` | All creator sites guard against path-traversal in branch names |

## Branch names with `/`

Branch names follow `<tipo-prefix>/<task-id>-<keywords>` (e.g., `feat/t-007-user-auth`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.

## Backwards compatibility

Existing worktrees in legacy locations (e.g., sibling `../<repo>-<task>`) continue to work — `git worktree list` finds them by metadata regardless of path. No forced migration. Users may relocate manually with `git worktree move <old> <repo>/.worktrees/<branch>` when convenient.

## IDE exclusion (recommended)

Add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing:

**VS Code** (`.vscode/settings.json`):
```json
{
  "search.exclude": { "**/.worktrees": true },
  "files.watcherExclude": { "**/.worktrees/**": true }
}
```

**IntelliJ:** mark `.worktrees/` as Excluded in Project Structure.

## Test plan

- [x] `python3 -m pytest scripts/ -v` — 328 passed
- [x] `make lint` — clean (ruff + py_compile + shellcheck)
- [x] `make check-inline` — clean (0 unmatched refs)
- [ ] CI on this PR
- [ ] Manual smoke: `/optimus-plan` on a fresh task → worktree at `<repo>/.worktrees/<branch>/`
- [ ] Manual smoke: from a linked worktree, `/optimus-resume T-XXX` → recovery uses `${MAIN_WORKTREE}/.worktrees/...` (not the linked worktree's PWD)

## Bonus

Dropped a pre-existing unused `import re` in `scripts/test_skill_consistency.py` (introduced in PR #41) as operational hygiene — was failing `make lint` on main.

## Stats

- 23 files changed, +688 / −173
- 328 tests passing (5 new)
- Lint clean