### PR TITLE
fix(plan): remove stale skip_when 'No task spec exists yet'

### DIFF
--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -7,10 +7,9 @@ trigger: >
   - Before invoking optimus-build for a task
 skip_when: >
   - Task is already implemented (use optimus-review instead)
-  - No task spec exists yet (use pre-dev workflow to create it first)
   - Task is pure research with no implementation deliverables
 prerequisite: >
-  - Task spec exists (user provides ID or skill auto-detects next pending task)
+  - Task exists in optimus-tasks.md (user provides ID or skill auto-detects next pending task). If TaskSpec is `-`, plan offers to generate it via ring:pre-dev-feature in Step 1.0.4.5 (self-heal).
   - Reference docs exist (PRD, TRD, API design, data model)
   - Coding standards / project rules file exists
 NOT_skip_when: >


### PR DESCRIPTION
## Summary

Drops the stale \`skip_when\` clause `"No task spec exists yet (use pre-dev workflow to create it first)"` from \`/optimus:plan\`. Since #41, plan self-heals missing specs via \`ring:pre-dev-feature\` (Step 1.0.4.5) — so missing spec is no longer a reason to skip plan.

Also rewrites the \`prerequisite\` line to point at the self-heal step instead of asserting "Task spec exists".

## Why

After #41, the \`skip_when\` and the new self-heal step contradict each other. A user reading the SKILL frontmatter would conclude "I shouldn't run plan without a spec," missing the fact that plan is now the canonical place to generate one.

## Closes

Cleanup item 1/3 from issue #22. Items 2-3 (track selection between \`ring:pre-dev-feature\` vs \`ring:pre-dev-full\`; \`tasksDir = "internal-docs/"\` documentation) are tracked separately if needed.

## Test plan
- [x] \`python3 scripts/sync-claude-commands.py\` — idempotent (commands/plan.md unchanged because the change is in frontmatter not body)
- [x] \`python3 -m pytest scripts/\` — 323 passed