### PR TITLE
fix(sync): force-refresh Claude optimus plugin via uninstall+install

### DIFF
--- a/scripts/test_sync_user_plugins.py
+++ b/scripts/test_sync_user_plugins.py
@@ -660,7 +660,14 @@ class TestClaudeCodeSync:
 
     def test_updates_existing_optimus_plugin(self, tmp_path: Path) -> None:
         """When `optimus@optimus` is already installed, the script issues
-        `plugin update` instead of `plugin install`."""
+        `plugin uninstall` + `plugin install` to force-refresh the cache.
+
+        Rationale: `claude plugin update` is a no-op when marketplace.json's
+        `version` field hasn't changed, even if the underlying source files
+        have. Optimus ships SKILL changes without bumping the marketplace
+        version on every PR, so update would leave users on stale cached
+        SKILL.md. Uninstall + reinstall guarantees a fresh fetch.
+        """
         installed = [
             {"id": "optimus@optimus", "version": "2.0.0", "scope": "user",
              "enabled": True},
@@ -671,10 +678,16 @@ class TestClaudeCodeSync:
                            env_extra=self._claude_only_env(tmp_path))
         assert result.returncode == 0
         assert "Updated: 1" in result.stdout
-        assert "* optimus ... OK" in result.stdout
+        assert "* optimus ... OK (refreshed)" in result.stdout
         log_content = log.read_text()
-        assert "plugin update optimus@optimus" in log_content
-        assert "plugin install optimus@optimus" not in log_content
+        assert "plugin uninstall optimus@optimus" in log_content
+        assert "plugin install optimus@optimus" in log_content
+        # Confirm uninstall happens BEFORE install in the call order.
+        assert log_content.find("plugin uninstall optimus@optimus") < log_content.find(
+            "plugin install optimus@optimus"
+        )
+        # Update is no longer used for refresh.
+        assert "plugin update optimus@optimus" not in log_content
 
     def test_uninstalls_legacy_per_skill_plugins(self, tmp_path: Path) -> None:
         """Pre-2.0 `optimus-<name>@optimus` installs are pruned as legacy.
@@ -717,18 +730,23 @@ class TestClaudeCodeSync:
         assert "plugin install optimus@optimus" in log.read_text()
 
     def test_update_failure_increments_failed_count(self, tmp_path: Path) -> None:
-        """A failing `claude plugin update optimus@optimus` is reported as FAIL."""
+        """A failing reinstall (during the force-refresh path) is reported as FAIL.
+
+        The Claude branch refreshes via uninstall + install (see
+        test_updates_existing_optimus_plugin). When the install half fails,
+        the summary surfaces it as FAIL on the optimus line.
+        """
         installed = [
             {"id": "optimus@optimus", "version": "2.0.0", "scope": "user",
              "enabled": True},
         ]
-        _install_claude_mock(tmp_path, installed_plugins=installed, update_exit=1)
+        _install_claude_mock(tmp_path, installed_plugins=installed, install_exit=1)
         _create_claude_marketplace_cache(tmp_path, ["alpha"])
         result = _run_sync(tmp_path, exclude_droid=True,
                            env_extra=self._claude_only_env(tmp_path))
         assert result.returncode == 1
         assert "Failed: 1" in result.stdout
-        assert "* optimus ... FAIL" in result.stdout
+        assert "* optimus ... FAIL (reinstall)" in result.stdout
 
     def test_uninstall_failure_increments_failed_count(self, tmp_path: Path) -> None:
         """A failing `claude plugin uninstall <legacy>@optimus` is reported as FAIL."""

--- a/sync/scripts/sync-user-plugins.sh
+++ b/sync/scripts/sync-user-plugins.sh
@@ -527,8 +527,19 @@ _sync_claude_code() {
 
   local added=0 updated=0 removed=0 failed=0
 
-  # Install or update the single `optimus` plugin. Each call has one retry on
+  # Install or refresh the single `optimus` plugin. Each call has one retry on
   # transient failure (no parallelism — Claude's plugin daemon owns the cache).
+  #
+  # NOTE: When the plugin is already installed we uninstall + reinstall instead
+  # of `claude plugin update`. Reason: `claude plugin update` is a no-op when
+  # the plugin's `version` field in marketplace.json hasn't changed, even if
+  # the underlying source files in the repo have. Since Optimus ships SKILL
+  # changes without bumping the marketplace version on every PR, `update` would
+  # leave users on stale cached SKILL.md content (e.g. the cache at
+  # `~/.claude/plugins/cache/optimus/optimus/2.0.0/...` would not refresh).
+  # Uninstall + install forces a fresh fetch from the marketplace cache,
+  # guaranteeing the user runs the latest committed prose. Cost: one extra
+  # round-trip to the plugin daemon (~1s); acceptable.
   if [ "$single_installed" = false ]; then
     if _claude_retry_once "install optimus@${marketplace}" \
         _claude_quiet plugin install "optimus@${marketplace}" --scope user; then
@@ -539,12 +550,17 @@ _sync_claude_code() {
       failed=$((failed + 1))
     fi
   else
-    if _claude_retry_once "update optimus@${marketplace}" \
-        _claude_quiet plugin update "optimus@${marketplace}"; then
-      echo "  * optimus ... OK"
+    # Force-refresh path: uninstall (best-effort) then reinstall. If the
+    # uninstall fails for a transient reason, the reinstall path will still
+    # try to install over whatever state remains — `claude plugin install`
+    # handles "already installed" gracefully when scopes match.
+    _claude_quiet plugin uninstall "optimus@${marketplace}" || true
+    if _claude_retry_once "reinstall optimus@${marketplace}" \
+        _claude_quiet plugin install "optimus@${marketplace}" --scope user; then
+      echo "  * optimus ... OK (refreshed)"
       updated=$((updated + 1))
     else
-      echo "  * optimus ... FAIL"
+      echo "  * optimus ... FAIL (reinstall)"
       failed=$((failed + 1))
     fi
   fi


### PR DESCRIPTION
## Summary

`claude plugin update` is a no-op when \`marketplace.json\`'s \`version\` field hasn't changed, even when the underlying source files have. Since Optimus ships SKILL changes without bumping the marketplace version on every PR, \`/optimus:sync\` was leaving users on stale cached SKILL.md.

The Claude branch of \`sync-user-plugins.sh\` now uninstalls then reinstalls when the plugin is already present. Cost: ~1s extra round-trip. Benefit: cache always reflects latest committed prose.

## Real-world impact

PR #41 added Step 1.0.4.5 (Generate via Ring / Link / Cancel) to \`/optimus:plan\`. After running \`/optimus:sync\`, users reported the cache still held the pre-#41 SKILL.md. Running \`/optimus:plan\` against a task with \`TaskSpec=-\` showed improvised options like "Author task_049.md now (I draft)" instead of the canonical "Generate via Ring".

## Changes

- \`sync/scripts/sync-user-plugins.sh\` — Claude branch: when \`single_installed=true\`, uninstall + reinstall instead of \`claude plugin update\`. Output marker changes from \`* optimus ... OK\` → \`* optimus ... OK (refreshed)\`.
- \`scripts/test_sync_user_plugins.py\` — \`test_updates_existing_optimus_plugin\` asserts uninstall happens before install (call order); \`test_update_failure_increments_failed_count\` asserts the FAIL (reinstall) marker.

## Why not just bump marketplace version on every PR

Considered. Rejected because:
1. Manual discipline — easy to forget on small PRs, defeats the safety guarantee.
2. Version-bump churn pollutes the marketplace.json diff in every PR.
3. Force-refresh is content-addressable in spirit (we know there might be drift; we resolve by re-fetch). Bumping is a workaround for the broken \`update\` semantics.
4. Droid branch unaffected — only Claude has the no-op-update behavior.

## Test plan
- [x] \`python3 -m pytest scripts/test_sync_user_plugins.py\` — 66 passed
- [x] \`python3 -m pytest scripts/\` — 330 passed
- [ ] Smoke test (manual after merge): edit any SKILL.md prose locally, push to main, run \`/optimus:sync\`, verify the cache at \`~/.claude/plugins/cache/optimus/optimus/2.0.0/...\` reflects the new prose.