### PR TITLE
feat(inliner): Phase 1 inline-protocol bloat reduction (issue #34)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ rationalize these away.
 
 - **Canonical protocol reference phrasing:** Skills MUST reference protocols using the exact form `see AGENTS.md Protocol: <Exact Heading>` (with optional verb prefix like `Execute`, `Verify`, etc.). Variants like `AGENTS.md "Common Patterns > X"` are tolerated only for Common Patterns. The inliner regex is anchored on these forms; deviations cause silent unmatched refs.
 - **Bash code-block contract:** Bash code blocks in SKILL.md (between triple-backtick `bash` fences) execute in an environment where `set -euo pipefail` MUST be assumed active. The harness or invoking shell is responsible for setting these flags before executing block content. Authors may add `set -euo pipefail` explicitly at the top of a block to be defensive in copy-paste contexts. The Quiet Command Execution helper and other shared protocols rely on this contract — disabling these flags inside a block (e.g., `set +u`, `set +e`, `set +o pipefail`) is forbidden and enforced by `scripts/test_skill_consistency.py::TestBashBlockHygiene`.
+- **Summarize mode for high-fan-out protocols:** Protocols inlined into >=5 skills MAY carry an `<!-- inline-mode: summarize -->` marker. When present, the inliner emits only a terse 5-10 line stub in consumers (keeping the full body only in AGENTS.md). Each protocol's `**Summary:**` subsection (placed immediately after the marker) is the canonical stub content. This reduces SKILL.md token cost without losing correctness — agents reading the stub know to consult AGENTS.md for the full recipe when they need bash details. Phase 1 of issue #34 applies this to the top three most-duplicated protocols (`Resolve Main Worktree Path`, `Session State`, `Initialize .optimus Directory`). Run `make inline-stats` to see current bloat metrics; the inliner respects `--no-summarize` to fall back to full-body inlining for diagnostic runs.
 
 ### SKILL.md Files
 - Preserve YAML frontmatter structure (---, name, description, trigger, skip_when, etc.)
@@ -362,6 +363,10 @@ the project repo, it is committed alongside the code; if `tasksDir` is in a sepa
 repo, it is committed there.
 
 ### Protocol: Resolve Main Worktree Path
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 **Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
 
@@ -1018,6 +1023,10 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 
 ### Protocol: Initialize .optimus Directory
 
+<!-- inline-mode: summarize -->
+
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
+
 **Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
 
 Before creating ANY file inside `.optimus/`, ensure the directory structure exists
@@ -1281,6 +1290,10 @@ Follow these rules to prevent injection and silent failures:
 Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines."
 
 ### Protocol: Session State
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
 **Referenced by:** all stage agents (1-4)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint check-inline sync-plugins
+.PHONY: test lint check-inline inline-stats sync-plugins
 
 test:
 	python3 -m pytest scripts/ -v
@@ -11,6 +11,12 @@ lint:
 check-inline:
 	python3 scripts/inline-protocols.py
 	@git diff --exit-code -- '*/skills/*/SKILL.md' || (echo "ERROR: SKILL.md files are stale. Run 'python3 scripts/inline-protocols.py' and commit." && exit 1)
+
+# Phase 1 of issue #34: report on inline-protocol bloat across all SKILLs.
+# Doesn't modify any files. Use --no-summarize via `python3 scripts/inline-protocols.py
+# --stats-only --no-summarize` for a baseline (all-full-body) measurement.
+inline-stats:
+	@python3 scripts/inline-protocols.py --stats-only
 
 sync-plugins:
 	bash sync/scripts/sync-user-plugins.sh

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ SKILL or an alias to keep the Claude side in sync. Tests in
 `scripts/test_skill_consistency.py` (class `TestClaudeCommandsSync`) enforce
 that the script was run before commit.
 
+**Phase 1 of inline-protocol bloat reduction (issue #34):** The top three
+most-duplicated protocols (`Resolve Main Worktree Path`, `Session State`,
+`Initialize .optimus Directory`) now propagate as terse summaries instead
+of full-body inlines. SKILL.md sizes are reduced significantly across all
+stage skills. Run `make inline-stats` for current numbers, or pass
+`--no-summarize` to `scripts/inline-protocols.py` for full-body inlining
+during diagnostics.
+
 Future improvements are tracked in `docs/future-improvements.md`.
 
 ## Worktree layout

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -599,54 +599,11 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution
 

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -898,54 +898,11 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Finding Presentation (Unified Model)
 All cycle review skills follow this pattern:
@@ -1859,172 +1816,11 @@ droid is not installed, **STOP** and list missing droids.
 Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
 
 
-### Protocol: Session State
+### Protocol: Session State (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Session State`.**
 
-Stage agents write a session state file to track progress. This enables resumption
-when a session is interrupted (agent crash, user closes terminal, context window limit).
-
-**IMPORTANT — Write timing:** The session file MUST be written **immediately after the
-status change in state.json** (before any work begins). This ensures crash recovery has
-a record even if the agent fails before producing any output. Do NOT wait until
-"key phase transitions" to write the initial session file.
-
-**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `${MAIN_WORKTREE}/.optimus/sessions/session-T-003.json`).
-The `$MAIN_WORKTREE` prefix is REQUIRED — see Protocol: Resolve Main Worktree Path.
-
-```json
-{
-  "task_id": "T-003",
-  "stage": "<stage-name>",
-  "status": "<stage-output-status>",
-  "branch": "feat/t-003-user-auth",
-  "started_at": "2025-01-15T10:30:00Z",
-  "updated_at": "2025-01-15T11:45:00Z",
-  "phase": "Phase 1: Implementation",
-  "convergence_round": 0,
-  "convergence_status": null,
-  "findings_count": 0,
-  "notes": "Implementation in progress"
-}
-```
-
-**Convergence checkpoint:** During the convergence loop, update `convergence_round`,
-`convergence_status`, and `findings_count` after each round completes (and after each
-user gate decision). The `convergence_status` field MUST be persisted **before**
-proceeding past any user gate so crash recovery does not re-prompt an already-answered
-gate. Valid values: `null` (loop not entered yet, or round 1 not complete),
-`"IN_PROGRESS"` (a round was dispatched and the orchestrator has not yet recorded the
-exit status), `"CONVERGED"`, `"USER_STOPPED"`, `"SKIPPED"`, `"HARD_LIMIT"`,
-`"DISPATCH_FAILED_ABORTED"`. On resume, the orchestrator reads `convergence_status`
-to decide whether to skip the remainder of the loop (terminal status set), continue
-with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
-
-**On stage start (after task ID is known):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-if [ -f "$SESSION_FILE" ]; then
-  if ! jq empty "$SESSION_FILE" 2>/dev/null; then
-    echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
-    rm -f "$SESSION_FILE"
-  else
-    cat "$SESSION_FILE"
-  fi
-fi
-```
-
-- If the file exists AND the task's status in `state.json` matches the session's `status`:
-  - Present via `AskUser`:
-    ```
-    Previous session found:
-      Task: T-XXX — [title]
-      Stage: <stage-name>
-      Last active: <time since updated_at>
-      Progress: <phase from session>
-    Resume this session?
-    ```
-    Options: Resume / Start fresh (delete session) / Continue (keep session file)
-  - If **Resume**: skip to the phase indicated in the session file
-  - If **Start fresh (delete session)**: delete the session file and proceed from the beginning
-  - If **Continue (keep session file)**: proceed from the beginning without deleting the session file
-- If the file is stale (>24h) or the task status has changed → delete and proceed normally.
-  **Staleness check example:**
-  ```bash
-  UPDATED=$(jq -r '.updated_at // empty' "$SESSION_FILE" 2>/dev/null)
-  if [ -z "$UPDATED" ]; then
-    # Session file has no updated_at (corrupted or incomplete write) — treat as
-    # stale to prevent orphan session files from accumulating.
-    echo "WARNING: Session file has no updated_at. Deleting as stale."
-    rm -f "$SESSION_FILE"
-  else
-    NOW_EPOCH=$(date +%s)
-    if [ "$(uname)" = "Darwin" ]; then
-      UPDATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s 2>/dev/null || echo 0)
-    else
-      UPDATED_EPOCH=$(date -d "$UPDATED" +%s 2>/dev/null || echo 0)
-    fi
-    AGE=$(( NOW_EPOCH - UPDATED_EPOCH ))
-    if [ "$AGE" -gt 86400 ]; then
-      echo "Session file is stale (>24h). Deleting."
-      rm -f "$SESSION_FILE"
-    fi
-  fi
-  ```
-- **External status change detection:** If the session file exists AND the task's status
-  does NOT match the session's `status`, check if the difference is explainable by normal
-  stage progression (e.g., session says `Em Andamento` but task is now `Validando Impl` —
-  the task was advanced externally via `/optimus-tasks`). If the status change is NOT
-  explainable by forward progression, treat the session as stale and delete it.
-- If no file exists → proceed normally
-
-**On stage progress (at key phase transitions):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-# Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
-# agents — which call Session State but not Initialize Directory — also create
-# the dirs and update .gitignore on first phase transition.
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — runs every phase transition): age-based + count-cap
-# prune. Stage agents are the heaviest log producers, so placing prune here
-# ensures it fires for build/review/plan/done (which call Session State but not
-# Initialize .optimus Directory).
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-# Count-cap: keep at most 500 most-recent log files. Uses `while read -r` (not
-# `xargs`) for portability across GNU/BSD (`xargs -r` is GNU-only). Filename
-# safety: `_optimus_quiet_run` sanitizes labels to `[:alnum:]-_`, so log
-# filenames cannot contain spaces or newlines.
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-BRANCH_NAME=$(git branch --show-current 2>/dev/null)
-# `git branch --show-current` exits 0 with empty stdout on detached HEAD; the
-# `|| echo "detached"` fallback was dead code. Use an explicit check instead.
-[ -z "$BRANCH_NAME" ] && BRANCH_NAME="detached"
-jq -n \
-  --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
-  --arg branch "${BRANCH_NAME}" --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg phase "<current-phase>" \
-  --arg notes "<progress>" \
-  '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
-    started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-**On stage completion:** Delete the session file:
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
-
+**Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
 ### Protocol: State Management
 

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -611,54 +611,11 @@ After all phases complete:
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Finding Presentation (Unified Model)
 All cycle review skills follow this pattern:
@@ -892,63 +849,11 @@ Flag business-logic functions with 0% as HIGH, infrastructure/generated code wit
 Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: Parse CodeRabbit Review Body
 

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -555,54 +555,11 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution
 

--- a/commands/build.md
+++ b/commands/build.md
@@ -836,54 +836,11 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Finding Presentation (Unified Model)
 All cycle review skills follow this pattern:
@@ -1797,172 +1754,11 @@ droid is not installed, **STOP** and list missing droids.
 Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
 
 
-### Protocol: Session State
+### Protocol: Session State (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Session State`.**
 
-Stage agents write a session state file to track progress. This enables resumption
-when a session is interrupted (agent crash, user closes terminal, context window limit).
-
-**IMPORTANT — Write timing:** The session file MUST be written **immediately after the
-status change in state.json** (before any work begins). This ensures crash recovery has
-a record even if the agent fails before producing any output. Do NOT wait until
-"key phase transitions" to write the initial session file.
-
-**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `${MAIN_WORKTREE}/.optimus/sessions/session-T-003.json`).
-The `$MAIN_WORKTREE` prefix is REQUIRED — see Protocol: Resolve Main Worktree Path.
-
-```json
-{
-  "task_id": "T-003",
-  "stage": "<stage-name>",
-  "status": "<stage-output-status>",
-  "branch": "feat/t-003-user-auth",
-  "started_at": "2025-01-15T10:30:00Z",
-  "updated_at": "2025-01-15T11:45:00Z",
-  "phase": "Phase 1: Implementation",
-  "convergence_round": 0,
-  "convergence_status": null,
-  "findings_count": 0,
-  "notes": "Implementation in progress"
-}
-```
-
-**Convergence checkpoint:** During the convergence loop, update `convergence_round`,
-`convergence_status`, and `findings_count` after each round completes (and after each
-user gate decision). The `convergence_status` field MUST be persisted **before**
-proceeding past any user gate so crash recovery does not re-prompt an already-answered
-gate. Valid values: `null` (loop not entered yet, or round 1 not complete),
-`"IN_PROGRESS"` (a round was dispatched and the orchestrator has not yet recorded the
-exit status), `"CONVERGED"`, `"USER_STOPPED"`, `"SKIPPED"`, `"HARD_LIMIT"`,
-`"DISPATCH_FAILED_ABORTED"`. On resume, the orchestrator reads `convergence_status`
-to decide whether to skip the remainder of the loop (terminal status set), continue
-with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
-
-**On stage start (after task ID is known):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-if [ -f "$SESSION_FILE" ]; then
-  if ! jq empty "$SESSION_FILE" 2>/dev/null; then
-    echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
-    rm -f "$SESSION_FILE"
-  else
-    cat "$SESSION_FILE"
-  fi
-fi
-```
-
-- If the file exists AND the task's status in `state.json` matches the session's `status`:
-  - Present via `AskUser`:
-    ```
-    Previous session found:
-      Task: T-XXX — [title]
-      Stage: <stage-name>
-      Last active: <time since updated_at>
-      Progress: <phase from session>
-    Resume this session?
-    ```
-    Options: Resume / Start fresh (delete session) / Continue (keep session file)
-  - If **Resume**: skip to the phase indicated in the session file
-  - If **Start fresh (delete session)**: delete the session file and proceed from the beginning
-  - If **Continue (keep session file)**: proceed from the beginning without deleting the session file
-- If the file is stale (>24h) or the task status has changed → delete and proceed normally.
-  **Staleness check example:**
-  ```bash
-  UPDATED=$(jq -r '.updated_at // empty' "$SESSION_FILE" 2>/dev/null)
-  if [ -z "$UPDATED" ]; then
-    # Session file has no updated_at (corrupted or incomplete write) — treat as
-    # stale to prevent orphan session files from accumulating.
-    echo "WARNING: Session file has no updated_at. Deleting as stale."
-    rm -f "$SESSION_FILE"
-  else
-    NOW_EPOCH=$(date +%s)
-    if [ "$(uname)" = "Darwin" ]; then
-      UPDATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s 2>/dev/null || echo 0)
-    else
-      UPDATED_EPOCH=$(date -d "$UPDATED" +%s 2>/dev/null || echo 0)
-    fi
-    AGE=$(( NOW_EPOCH - UPDATED_EPOCH ))
-    if [ "$AGE" -gt 86400 ]; then
-      echo "Session file is stale (>24h). Deleting."
-      rm -f "$SESSION_FILE"
-    fi
-  fi
-  ```
-- **External status change detection:** If the session file exists AND the task's status
-  does NOT match the session's `status`, check if the difference is explainable by normal
-  stage progression (e.g., session says `Em Andamento` but task is now `Validando Impl` —
-  the task was advanced externally via `/optimus:tasks`). If the status change is NOT
-  explainable by forward progression, treat the session as stale and delete it.
-- If no file exists → proceed normally
-
-**On stage progress (at key phase transitions):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-# Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
-# agents — which call Session State but not Initialize Directory — also create
-# the dirs and update .gitignore on first phase transition.
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — runs every phase transition): age-based + count-cap
-# prune. Stage agents are the heaviest log producers, so placing prune here
-# ensures it fires for build/review/plan/done (which call Session State but not
-# Initialize .optimus Directory).
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-# Count-cap: keep at most 500 most-recent log files. Uses `while read -r` (not
-# `xargs`) for portability across GNU/BSD (`xargs -r` is GNU-only). Filename
-# safety: `_optimus_quiet_run` sanitizes labels to `[:alnum:]-_`, so log
-# filenames cannot contain spaces or newlines.
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-BRANCH_NAME=$(git branch --show-current 2>/dev/null)
-# `git branch --show-current` exits 0 with empty stdout on detached HEAD; the
-# `|| echo "detached"` fallback was dead code. Use an explicit check instead.
-[ -z "$BRANCH_NAME" ] && BRANCH_NAME="detached"
-jq -n \
-  --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
-  --arg branch "${BRANCH_NAME}" --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg phase "<current-phase>" \
-  --arg notes "<progress>" \
-  '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
-    started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-**On stage completion:** Delete the session file:
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
-
+**Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
 ### Protocol: State Management
 

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -554,54 +554,11 @@ After all phases complete:
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Finding Presentation (Unified Model)
 All cycle review skills follow this pattern:
@@ -835,63 +792,11 @@ Flag business-logic functions with 0% as HIGH, infrastructure/generated code wit
 Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: Parse CodeRabbit Review Body
 

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -494,54 +494,11 @@ After the convergence loop exits and all findings are processed:
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Finding Presentation (Unified Model)
 All cycle review skills follow this pattern:
@@ -895,63 +852,11 @@ message instructing the user to install the missing droids and re-run.
 Skills reference this as: "Execute Protocol: Discover Review Droids — see AGENTS.md Protocol: Discover Review Droids."
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: Per-Droid Quality Checklists
 

--- a/commands/done.md
+++ b/commands/done.md
@@ -1173,54 +1173,11 @@ If `tasks-hooks.sh` does not exist, hooks are silently skipped.
 Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: State Management
 

--- a/commands/import.md
+++ b/commands/import.md
@@ -588,112 +588,17 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
-
-### Protocol: Resolve Main Worktree Path
-
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
-
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: State Management
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1968,54 +1968,11 @@ applied fixes are correct and checks for any issues introduced by the fixes.
 Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: Ring Droid Requirement Check
 
@@ -2057,172 +2014,11 @@ droid is not installed, **STOP** and list missing droids.
 Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
 
 
-### Protocol: Session State
+### Protocol: Session State (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Session State`.**
 
-Stage agents write a session state file to track progress. This enables resumption
-when a session is interrupted (agent crash, user closes terminal, context window limit).
-
-**IMPORTANT — Write timing:** The session file MUST be written **immediately after the
-status change in state.json** (before any work begins). This ensures crash recovery has
-a record even if the agent fails before producing any output. Do NOT wait until
-"key phase transitions" to write the initial session file.
-
-**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `${MAIN_WORKTREE}/.optimus/sessions/session-T-003.json`).
-The `$MAIN_WORKTREE` prefix is REQUIRED — see Protocol: Resolve Main Worktree Path.
-
-```json
-{
-  "task_id": "T-003",
-  "stage": "<stage-name>",
-  "status": "<stage-output-status>",
-  "branch": "feat/t-003-user-auth",
-  "started_at": "2025-01-15T10:30:00Z",
-  "updated_at": "2025-01-15T11:45:00Z",
-  "phase": "Phase 1: Implementation",
-  "convergence_round": 0,
-  "convergence_status": null,
-  "findings_count": 0,
-  "notes": "Implementation in progress"
-}
-```
-
-**Convergence checkpoint:** During the convergence loop, update `convergence_round`,
-`convergence_status`, and `findings_count` after each round completes (and after each
-user gate decision). The `convergence_status` field MUST be persisted **before**
-proceeding past any user gate so crash recovery does not re-prompt an already-answered
-gate. Valid values: `null` (loop not entered yet, or round 1 not complete),
-`"IN_PROGRESS"` (a round was dispatched and the orchestrator has not yet recorded the
-exit status), `"CONVERGED"`, `"USER_STOPPED"`, `"SKIPPED"`, `"HARD_LIMIT"`,
-`"DISPATCH_FAILED_ABORTED"`. On resume, the orchestrator reads `convergence_status`
-to decide whether to skip the remainder of the loop (terminal status set), continue
-with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
-
-**On stage start (after task ID is known):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-if [ -f "$SESSION_FILE" ]; then
-  if ! jq empty "$SESSION_FILE" 2>/dev/null; then
-    echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
-    rm -f "$SESSION_FILE"
-  else
-    cat "$SESSION_FILE"
-  fi
-fi
-```
-
-- If the file exists AND the task's status in `state.json` matches the session's `status`:
-  - Present via `AskUser`:
-    ```
-    Previous session found:
-      Task: T-XXX — [title]
-      Stage: <stage-name>
-      Last active: <time since updated_at>
-      Progress: <phase from session>
-    Resume this session?
-    ```
-    Options: Resume / Start fresh (delete session) / Continue (keep session file)
-  - If **Resume**: skip to the phase indicated in the session file
-  - If **Start fresh (delete session)**: delete the session file and proceed from the beginning
-  - If **Continue (keep session file)**: proceed from the beginning without deleting the session file
-- If the file is stale (>24h) or the task status has changed → delete and proceed normally.
-  **Staleness check example:**
-  ```bash
-  UPDATED=$(jq -r '.updated_at // empty' "$SESSION_FILE" 2>/dev/null)
-  if [ -z "$UPDATED" ]; then
-    # Session file has no updated_at (corrupted or incomplete write) — treat as
-    # stale to prevent orphan session files from accumulating.
-    echo "WARNING: Session file has no updated_at. Deleting as stale."
-    rm -f "$SESSION_FILE"
-  else
-    NOW_EPOCH=$(date +%s)
-    if [ "$(uname)" = "Darwin" ]; then
-      UPDATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s 2>/dev/null || echo 0)
-    else
-      UPDATED_EPOCH=$(date -d "$UPDATED" +%s 2>/dev/null || echo 0)
-    fi
-    AGE=$(( NOW_EPOCH - UPDATED_EPOCH ))
-    if [ "$AGE" -gt 86400 ]; then
-      echo "Session file is stale (>24h). Deleting."
-      rm -f "$SESSION_FILE"
-    fi
-  fi
-  ```
-- **External status change detection:** If the session file exists AND the task's status
-  does NOT match the session's `status`, check if the difference is explainable by normal
-  stage progression (e.g., session says `Em Andamento` but task is now `Validando Impl` —
-  the task was advanced externally via `/optimus:tasks`). If the status change is NOT
-  explainable by forward progression, treat the session as stale and delete it.
-- If no file exists → proceed normally
-
-**On stage progress (at key phase transitions):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-# Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
-# agents — which call Session State but not Initialize Directory — also create
-# the dirs and update .gitignore on first phase transition.
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — runs every phase transition): age-based + count-cap
-# prune. Stage agents are the heaviest log producers, so placing prune here
-# ensures it fires for build/review/plan/done (which call Session State but not
-# Initialize .optimus Directory).
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-# Count-cap: keep at most 500 most-recent log files. Uses `while read -r` (not
-# `xargs`) for portability across GNU/BSD (`xargs -r` is GNU-only). Filename
-# safety: `_optimus_quiet_run` sanitizes labels to `[:alnum:]-_`, so log
-# filenames cannot contain spaces or newlines.
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-BRANCH_NAME=$(git branch --show-current 2>/dev/null)
-# `git branch --show-current` exits 0 with empty stdout on detached HEAD; the
-# `|| echo "detached"` fallback was dead code. Use an explicit check instead.
-[ -z "$BRANCH_NAME" ] && BRANCH_NAME="detached"
-jq -n \
-  --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
-  --arg branch "${BRANCH_NAME}" --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg phase "<current-phase>" \
-  --arg notes "<progress>" \
-  '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
-    started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-**On stage completion:** Delete the session file:
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
-
+**Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
 ### Protocol: Shell Safety Guidelines
 

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -1727,54 +1727,11 @@ If the user requests a dry-run (e.g., "dry-run pr-check", "preview PR review"):
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Deep Research Before Presenting (MANDATORY for cycle review skills)
 Applies to: plan, review, pr-check, coderabbit-review
@@ -2261,63 +2218,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: PR Title Validation
 

--- a/commands/quick-report.md
+++ b/commands/quick-report.md
@@ -354,54 +354,11 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: Default Scope Resolution
 

--- a/commands/report.md
+++ b/commands/report.md
@@ -786,54 +786,11 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: Default Scope Resolution
 
@@ -918,63 +875,11 @@ version name (version names are case-sensitive to match the Versions table).
 Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Default Scope Resolution."
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: Resolve Tasks Git Scope
 

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -922,112 +922,17 @@ Where:
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
-
-### Protocol: Resolve Main Worktree Path
-
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
-
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: Terminal Identification
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1247,54 +1247,11 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Deep Research Before Presenting (MANDATORY for cycle review skills)
 Applies to: plan, review, pr-check, coderabbit-review
@@ -2433,172 +2390,11 @@ droid is not installed, **STOP** and list missing droids.
 Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
 
 
-### Protocol: Session State
+### Protocol: Session State (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Session State`.**
 
-Stage agents write a session state file to track progress. This enables resumption
-when a session is interrupted (agent crash, user closes terminal, context window limit).
-
-**IMPORTANT — Write timing:** The session file MUST be written **immediately after the
-status change in state.json** (before any work begins). This ensures crash recovery has
-a record even if the agent fails before producing any output. Do NOT wait until
-"key phase transitions" to write the initial session file.
-
-**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `${MAIN_WORKTREE}/.optimus/sessions/session-T-003.json`).
-The `$MAIN_WORKTREE` prefix is REQUIRED — see Protocol: Resolve Main Worktree Path.
-
-```json
-{
-  "task_id": "T-003",
-  "stage": "<stage-name>",
-  "status": "<stage-output-status>",
-  "branch": "feat/t-003-user-auth",
-  "started_at": "2025-01-15T10:30:00Z",
-  "updated_at": "2025-01-15T11:45:00Z",
-  "phase": "Phase 1: Implementation",
-  "convergence_round": 0,
-  "convergence_status": null,
-  "findings_count": 0,
-  "notes": "Implementation in progress"
-}
-```
-
-**Convergence checkpoint:** During the convergence loop, update `convergence_round`,
-`convergence_status`, and `findings_count` after each round completes (and after each
-user gate decision). The `convergence_status` field MUST be persisted **before**
-proceeding past any user gate so crash recovery does not re-prompt an already-answered
-gate. Valid values: `null` (loop not entered yet, or round 1 not complete),
-`"IN_PROGRESS"` (a round was dispatched and the orchestrator has not yet recorded the
-exit status), `"CONVERGED"`, `"USER_STOPPED"`, `"SKIPPED"`, `"HARD_LIMIT"`,
-`"DISPATCH_FAILED_ABORTED"`. On resume, the orchestrator reads `convergence_status`
-to decide whether to skip the remainder of the loop (terminal status set), continue
-with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
-
-**On stage start (after task ID is known):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-if [ -f "$SESSION_FILE" ]; then
-  if ! jq empty "$SESSION_FILE" 2>/dev/null; then
-    echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
-    rm -f "$SESSION_FILE"
-  else
-    cat "$SESSION_FILE"
-  fi
-fi
-```
-
-- If the file exists AND the task's status in `state.json` matches the session's `status`:
-  - Present via `AskUser`:
-    ```
-    Previous session found:
-      Task: T-XXX — [title]
-      Stage: <stage-name>
-      Last active: <time since updated_at>
-      Progress: <phase from session>
-    Resume this session?
-    ```
-    Options: Resume / Start fresh (delete session) / Continue (keep session file)
-  - If **Resume**: skip to the phase indicated in the session file
-  - If **Start fresh (delete session)**: delete the session file and proceed from the beginning
-  - If **Continue (keep session file)**: proceed from the beginning without deleting the session file
-- If the file is stale (>24h) or the task status has changed → delete and proceed normally.
-  **Staleness check example:**
-  ```bash
-  UPDATED=$(jq -r '.updated_at // empty' "$SESSION_FILE" 2>/dev/null)
-  if [ -z "$UPDATED" ]; then
-    # Session file has no updated_at (corrupted or incomplete write) — treat as
-    # stale to prevent orphan session files from accumulating.
-    echo "WARNING: Session file has no updated_at. Deleting as stale."
-    rm -f "$SESSION_FILE"
-  else
-    NOW_EPOCH=$(date +%s)
-    if [ "$(uname)" = "Darwin" ]; then
-      UPDATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s 2>/dev/null || echo 0)
-    else
-      UPDATED_EPOCH=$(date -d "$UPDATED" +%s 2>/dev/null || echo 0)
-    fi
-    AGE=$(( NOW_EPOCH - UPDATED_EPOCH ))
-    if [ "$AGE" -gt 86400 ]; then
-      echo "Session file is stale (>24h). Deleting."
-      rm -f "$SESSION_FILE"
-    fi
-  fi
-  ```
-- **External status change detection:** If the session file exists AND the task's status
-  does NOT match the session's `status`, check if the difference is explainable by normal
-  stage progression (e.g., session says `Em Andamento` but task is now `Validando Impl` —
-  the task was advanced externally via `/optimus:tasks`). If the status change is NOT
-  explainable by forward progression, treat the session as stale and delete it.
-- If no file exists → proceed normally
-
-**On stage progress (at key phase transitions):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-# Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
-# agents — which call Session State but not Initialize Directory — also create
-# the dirs and update .gitignore on first phase transition.
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — runs every phase transition): age-based + count-cap
-# prune. Stage agents are the heaviest log producers, so placing prune here
-# ensures it fires for build/review/plan/done (which call Session State but not
-# Initialize .optimus Directory).
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-# Count-cap: keep at most 500 most-recent log files. Uses `while read -r` (not
-# `xargs`) for portability across GNU/BSD (`xargs -r` is GNU-only). Filename
-# safety: `_optimus_quiet_run` sanitizes labels to `[:alnum:]-_`, so log
-# filenames cannot contain spaces or newlines.
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-BRANCH_NAME=$(git branch --show-current 2>/dev/null)
-# `git branch --show-current` exits 0 with empty stdout on detached HEAD; the
-# `|| echo "detached"` fallback was dead code. Use an explicit check instead.
-[ -z "$BRANCH_NAME" ] && BRANCH_NAME="detached"
-jq -n \
-  --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
-  --arg branch "${BRANCH_NAME}" --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg phase "<current-phase>" \
-  --arg notes "<progress>" \
-  '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
-    started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-**On stage completion:** Delete the session file:
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
-
+**Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
 ### Protocol: State Management
 

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -1136,112 +1136,17 @@ each task. If any task appears twice in the chain, a cycle exists. Report ALL ta
 in the cycle so the user can fix it with `/optimus:tasks`.
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus:build`, `/optimus:review`, `/optimus:done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus:done` cleanup), the writes are lost — silent data loss.
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-**Recipe:**
+### Protocol: Initialize .optimus Directory (summarized)
 
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus:tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
-
-### Protocol: Initialize .optimus Directory
-
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
-
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus:tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: Notification Hooks
 

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -545,54 +545,11 @@ After the convergence loop exits and all findings are processed:
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Finding Presentation (Unified Model)
 All cycle review skills follow this pattern:
@@ -946,63 +903,11 @@ message instructing the user to install the missing droids and re-run.
 Skills reference this as: "Execute Protocol: Discover Review Droids — see AGENTS.md Protocol: Discover Review Droids."
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: Per-Droid Quality Checklists
 

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -1216,54 +1216,11 @@ If `tasks-hooks.sh` does not exist, hooks are silently skipped.
 Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: State Management
 

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -636,112 +636,17 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
-
-### Protocol: Resolve Main Worktree Path
-
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
-
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: State Management
 

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -2030,54 +2030,11 @@ applied fixes are correct and checks for any issues introduced by the fixes.
 Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: Ring Droid Requirement Check
 
@@ -2119,172 +2076,11 @@ droid is not installed, **STOP** and list missing droids.
 Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
 
 
-### Protocol: Session State
+### Protocol: Session State (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Session State`.**
 
-Stage agents write a session state file to track progress. This enables resumption
-when a session is interrupted (agent crash, user closes terminal, context window limit).
-
-**IMPORTANT — Write timing:** The session file MUST be written **immediately after the
-status change in state.json** (before any work begins). This ensures crash recovery has
-a record even if the agent fails before producing any output. Do NOT wait until
-"key phase transitions" to write the initial session file.
-
-**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `${MAIN_WORKTREE}/.optimus/sessions/session-T-003.json`).
-The `$MAIN_WORKTREE` prefix is REQUIRED — see Protocol: Resolve Main Worktree Path.
-
-```json
-{
-  "task_id": "T-003",
-  "stage": "<stage-name>",
-  "status": "<stage-output-status>",
-  "branch": "feat/t-003-user-auth",
-  "started_at": "2025-01-15T10:30:00Z",
-  "updated_at": "2025-01-15T11:45:00Z",
-  "phase": "Phase 1: Implementation",
-  "convergence_round": 0,
-  "convergence_status": null,
-  "findings_count": 0,
-  "notes": "Implementation in progress"
-}
-```
-
-**Convergence checkpoint:** During the convergence loop, update `convergence_round`,
-`convergence_status`, and `findings_count` after each round completes (and after each
-user gate decision). The `convergence_status` field MUST be persisted **before**
-proceeding past any user gate so crash recovery does not re-prompt an already-answered
-gate. Valid values: `null` (loop not entered yet, or round 1 not complete),
-`"IN_PROGRESS"` (a round was dispatched and the orchestrator has not yet recorded the
-exit status), `"CONVERGED"`, `"USER_STOPPED"`, `"SKIPPED"`, `"HARD_LIMIT"`,
-`"DISPATCH_FAILED_ABORTED"`. On resume, the orchestrator reads `convergence_status`
-to decide whether to skip the remainder of the loop (terminal status set), continue
-with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
-
-**On stage start (after task ID is known):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-if [ -f "$SESSION_FILE" ]; then
-  if ! jq empty "$SESSION_FILE" 2>/dev/null; then
-    echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
-    rm -f "$SESSION_FILE"
-  else
-    cat "$SESSION_FILE"
-  fi
-fi
-```
-
-- If the file exists AND the task's status in `state.json` matches the session's `status`:
-  - Present via `AskUser`:
-    ```
-    Previous session found:
-      Task: T-XXX — [title]
-      Stage: <stage-name>
-      Last active: <time since updated_at>
-      Progress: <phase from session>
-    Resume this session?
-    ```
-    Options: Resume / Start fresh (delete session) / Continue (keep session file)
-  - If **Resume**: skip to the phase indicated in the session file
-  - If **Start fresh (delete session)**: delete the session file and proceed from the beginning
-  - If **Continue (keep session file)**: proceed from the beginning without deleting the session file
-- If the file is stale (>24h) or the task status has changed → delete and proceed normally.
-  **Staleness check example:**
-  ```bash
-  UPDATED=$(jq -r '.updated_at // empty' "$SESSION_FILE" 2>/dev/null)
-  if [ -z "$UPDATED" ]; then
-    # Session file has no updated_at (corrupted or incomplete write) — treat as
-    # stale to prevent orphan session files from accumulating.
-    echo "WARNING: Session file has no updated_at. Deleting as stale."
-    rm -f "$SESSION_FILE"
-  else
-    NOW_EPOCH=$(date +%s)
-    if [ "$(uname)" = "Darwin" ]; then
-      UPDATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s 2>/dev/null || echo 0)
-    else
-      UPDATED_EPOCH=$(date -d "$UPDATED" +%s 2>/dev/null || echo 0)
-    fi
-    AGE=$(( NOW_EPOCH - UPDATED_EPOCH ))
-    if [ "$AGE" -gt 86400 ]; then
-      echo "Session file is stale (>24h). Deleting."
-      rm -f "$SESSION_FILE"
-    fi
-  fi
-  ```
-- **External status change detection:** If the session file exists AND the task's status
-  does NOT match the session's `status`, check if the difference is explainable by normal
-  stage progression (e.g., session says `Em Andamento` but task is now `Validando Impl` —
-  the task was advanced externally via `/optimus-tasks`). If the status change is NOT
-  explainable by forward progression, treat the session as stale and delete it.
-- If no file exists → proceed normally
-
-**On stage progress (at key phase transitions):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-# Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
-# agents — which call Session State but not Initialize Directory — also create
-# the dirs and update .gitignore on first phase transition.
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — runs every phase transition): age-based + count-cap
-# prune. Stage agents are the heaviest log producers, so placing prune here
-# ensures it fires for build/review/plan/done (which call Session State but not
-# Initialize .optimus Directory).
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-# Count-cap: keep at most 500 most-recent log files. Uses `while read -r` (not
-# `xargs`) for portability across GNU/BSD (`xargs -r` is GNU-only). Filename
-# safety: `_optimus_quiet_run` sanitizes labels to `[:alnum:]-_`, so log
-# filenames cannot contain spaces or newlines.
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-BRANCH_NAME=$(git branch --show-current 2>/dev/null)
-# `git branch --show-current` exits 0 with empty stdout on detached HEAD; the
-# `|| echo "detached"` fallback was dead code. Use an explicit check instead.
-[ -z "$BRANCH_NAME" ] && BRANCH_NAME="detached"
-jq -n \
-  --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
-  --arg branch "${BRANCH_NAME}" --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg phase "<current-phase>" \
-  --arg notes "<progress>" \
-  '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
-    started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-**On stage completion:** Delete the session file:
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
-
+**Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
 ### Protocol: Shell Safety Guidelines
 

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -1799,54 +1799,11 @@ If the user requests a dry-run (e.g., "dry-run pr-check", "preview PR review"):
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Deep Research Before Presenting (MANDATORY for cycle review skills)
 Applies to: plan, review, pr-check, coderabbit-review
@@ -2333,63 +2290,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: PR Title Validation
 

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -392,54 +392,11 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: Default Scope Resolution
 

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -831,54 +831,11 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: Default Scope Resolution
 
@@ -963,63 +920,11 @@ version name (version names are case-sensitive to match the Versions table).
 Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Default Scope Resolution."
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: Resolve Tasks Git Scope
 

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -981,112 +981,17 @@ Where:
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 
 
-### Protocol: Initialize .optimus Directory
+### Protocol: Initialize .optimus Directory (summarized)
 
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
-
-### Protocol: Resolve Main Worktree Path
-
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
-
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Protocol: Terminal Identification
 

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -1312,54 +1312,11 @@ project repo). `tasks_git push` pushes the tasks repo. The project repo is unaff
 Skills reference this as: "Resolve tasks git scope — see AGENTS.md Protocol: Resolve Tasks Git Scope."
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
-
-**Recipe:**
-
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
-
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
 ### Deep Research Before Presenting (MANDATORY for cycle review skills)
 Applies to: plan, review, pr-check, coderabbit-review
@@ -2498,172 +2455,11 @@ droid is not installed, **STOP** and list missing droids.
 Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
 
 
-### Protocol: Session State
+### Protocol: Session State (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Session State`.**
 
-Stage agents write a session state file to track progress. This enables resumption
-when a session is interrupted (agent crash, user closes terminal, context window limit).
-
-**IMPORTANT — Write timing:** The session file MUST be written **immediately after the
-status change in state.json** (before any work begins). This ensures crash recovery has
-a record even if the agent fails before producing any output. Do NOT wait until
-"key phase transitions" to write the initial session file.
-
-**Session file location:** `${MAIN_WORKTREE}/.optimus/sessions/session-<task-id>.json` (gitignored).
-Each task gets its own file (e.g., `${MAIN_WORKTREE}/.optimus/sessions/session-T-003.json`).
-The `$MAIN_WORKTREE` prefix is REQUIRED — see Protocol: Resolve Main Worktree Path.
-
-```json
-{
-  "task_id": "T-003",
-  "stage": "<stage-name>",
-  "status": "<stage-output-status>",
-  "branch": "feat/t-003-user-auth",
-  "started_at": "2025-01-15T10:30:00Z",
-  "updated_at": "2025-01-15T11:45:00Z",
-  "phase": "Phase 1: Implementation",
-  "convergence_round": 0,
-  "convergence_status": null,
-  "findings_count": 0,
-  "notes": "Implementation in progress"
-}
-```
-
-**Convergence checkpoint:** During the convergence loop, update `convergence_round`,
-`convergence_status`, and `findings_count` after each round completes (and after each
-user gate decision). The `convergence_status` field MUST be persisted **before**
-proceeding past any user gate so crash recovery does not re-prompt an already-answered
-gate. Valid values: `null` (loop not entered yet, or round 1 not complete),
-`"IN_PROGRESS"` (a round was dispatched and the orchestrator has not yet recorded the
-exit status), `"CONVERGED"`, `"USER_STOPPED"`, `"SKIPPED"`, `"HARD_LIMIT"`,
-`"DISPATCH_FAILED_ABORTED"`. On resume, the orchestrator reads `convergence_status`
-to decide whether to skip the remainder of the loop (terminal status set), continue
-with the next gate (still `IN_PROGRESS`), or re-show the entry gate (`null`).
-
-**On stage start (after task ID is known):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-if [ -f "$SESSION_FILE" ]; then
-  if ! jq empty "$SESSION_FILE" 2>/dev/null; then
-    echo "WARNING: Session file is corrupted. Deleting and proceeding fresh."
-    rm -f "$SESSION_FILE"
-  else
-    cat "$SESSION_FILE"
-  fi
-fi
-```
-
-- If the file exists AND the task's status in `state.json` matches the session's `status`:
-  - Present via `AskUser`:
-    ```
-    Previous session found:
-      Task: T-XXX — [title]
-      Stage: <stage-name>
-      Last active: <time since updated_at>
-      Progress: <phase from session>
-    Resume this session?
-    ```
-    Options: Resume / Start fresh (delete session) / Continue (keep session file)
-  - If **Resume**: skip to the phase indicated in the session file
-  - If **Start fresh (delete session)**: delete the session file and proceed from the beginning
-  - If **Continue (keep session file)**: proceed from the beginning without deleting the session file
-- If the file is stale (>24h) or the task status has changed → delete and proceed normally.
-  **Staleness check example:**
-  ```bash
-  UPDATED=$(jq -r '.updated_at // empty' "$SESSION_FILE" 2>/dev/null)
-  if [ -z "$UPDATED" ]; then
-    # Session file has no updated_at (corrupted or incomplete write) — treat as
-    # stale to prevent orphan session files from accumulating.
-    echo "WARNING: Session file has no updated_at. Deleting as stale."
-    rm -f "$SESSION_FILE"
-  else
-    NOW_EPOCH=$(date +%s)
-    if [ "$(uname)" = "Darwin" ]; then
-      UPDATED_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED" +%s 2>/dev/null || echo 0)
-    else
-      UPDATED_EPOCH=$(date -d "$UPDATED" +%s 2>/dev/null || echo 0)
-    fi
-    AGE=$(( NOW_EPOCH - UPDATED_EPOCH ))
-    if [ "$AGE" -gt 86400 ]; then
-      echo "Session file is stale (>24h). Deleting."
-      rm -f "$SESSION_FILE"
-    fi
-  fi
-  ```
-- **External status change detection:** If the session file exists AND the task's status
-  does NOT match the session's `status`, check if the difference is explainable by normal
-  stage progression (e.g., session says `Em Andamento` but task is now `Validando Impl` —
-  the task was advanced externally via `/optimus-tasks`). If the status change is NOT
-  explainable by forward progression, treat the session as stale and delete it.
-- If no file exists → proceed normally
-
-**On stage progress (at key phase transitions):**
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-# Mirror Protocol: Initialize .optimus Directory (mkdir + gitignore) so stage
-# agents — which call Session State but not Initialize Directory — also create
-# the dirs and update .gitignore on first phase transition.
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — runs every phase transition): age-based + count-cap
-# prune. Stage agents are the heaviest log producers, so placing prune here
-# ensures it fires for build/review/plan/done (which call Session State but not
-# Initialize .optimus Directory).
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-# Count-cap: keep at most 500 most-recent log files. Uses `while read -r` (not
-# `xargs`) for portability across GNU/BSD (`xargs -r` is GNU-only). Filename
-# safety: `_optimus_quiet_run` sanitizes labels to `[:alnum:]-_`, so log
-# filenames cannot contain spaces or newlines.
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-BRANCH_NAME=$(git branch --show-current 2>/dev/null)
-# `git branch --show-current` exits 0 with empty stdout on detached HEAD; the
-# `|| echo "detached"` fallback was dead code. Use an explicit check instead.
-[ -z "$BRANCH_NAME" ] && BRANCH_NAME="detached"
-jq -n \
-  --arg task_id "${TASK_ID}" --arg stage "<stage-name>" --arg status "<status>" \
-  --arg branch "${BRANCH_NAME}" --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg phase "<current-phase>" \
-  --arg notes "<progress>" \
-  '{task_id: $task_id, stage: $stage, status: $status, branch: $branch,
-    started_at: $started, updated_at: $updated, phase: $phase, notes: $notes}' \
-  > "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-**On stage completion:** Delete the session file:
-```bash
-rm -f "${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-```
-
-Skills reference this as: "Execute session state protocol from AGENTS.md using stage=`<name>`, status=`<status>`."
-
+**Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
 ### Protocol: State Management
 

--- a/scripts/inline-protocols.py
+++ b/scripts/inline-protocols.py
@@ -8,10 +8,19 @@ Skills reference "see AGENTS.md Protocol: X" but agents can't find AGENTS.md.
 Solution: Append only the referenced protocols/patterns to each SKILL.md,
 making each plugin self-contained.
 
-Usage: python3 scripts/inline-protocols.py
+Phase 1 of issue #34 (inline-protocol bloat reduction):
+Protocols carrying `<!-- inline-mode: summarize -->` immediately under their
+heading propagate as a 5-10 line stub (their `**Summary:**` block) instead of
+the full body. Pass `--no-summarize` to fall back to full-body inlining.
+
+Usage:
+    python3 scripts/inline-protocols.py             # summarize mode (default)
+    python3 scripts/inline-protocols.py --no-summarize
+    python3 scripts/inline-protocols.py --stats-only
 """
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -20,6 +29,8 @@ REPO_ROOT = Path(__file__).parent.parent
 AGENTS_MD = REPO_ROOT / "AGENTS.md"
 MARKER_START = "<!-- INLINE-PROTOCOLS:START -->"
 MARKER_END = "<!-- INLINE-PROTOCOLS:END -->"
+SUMMARIZE_MARKER = "<!-- inline-mode: summarize -->"
+SUMMARY_PREFIX = "**Summary:**"
 # Max file size (5 MB) — prevents hanging on bloated or corrupted inputs.
 MAX_FILE_SIZE = 5 * 1024 * 1024
 
@@ -32,6 +43,7 @@ MAIN_WORKTREE_PROTOCOL_KEY = "Protocol: Resolve Main Worktree Path"
 
 # Module-level compiled patterns.
 HEADING_RE = re.compile(r'^(?:#{2,3})\s+(.+)$')
+H2_OR_H3_RE = re.compile(r'^#{2,3}\s+')
 PROTOCOL_RE = re.compile(r'AGENTS\.md Protocol:\s*([^\n"]+)')
 COMMON_PATTERN_RE = re.compile(r'AGENTS\.md\s*"Common Patterns\s*>\s*([^"]+)"')
 FINDING_PRESENTATION_RE = re.compile(r'AGENTS\.md\s*"Finding Presentation"')
@@ -40,8 +52,67 @@ TRAILING_CONTEXT_RE = re.compile(r',\s+(?:with |followed )|;\s|\*\*')
 PAREN_SUFFIX_RE = re.compile(r'\s*\([^)]*\)\s*$')
 
 
-def parse_agents_md() -> dict[str, str]:
-    """Parse AGENTS.md into named sections keyed by heading text."""
+def _extract_summary(body: str) -> str | None:
+    """Extract the `**Summary:** ...` block from a protocol body.
+
+    Returns the prose between `**Summary:**` and the next blank-line-followed-by
+    a structural marker (bold heading, `**Referenced by:**`, fenced code block,
+    or H2/H3 heading). The summary is normalized to start with `**Summary:**`
+    so consumers can render it unchanged. Returns None if no summary is found.
+    """
+    lines = body.splitlines()
+    start_idx = None
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith(SUMMARY_PREFIX):
+            start_idx = i
+            break
+    if start_idx is None:
+        return None
+
+    end_idx = len(lines)
+    # Walk forward until we hit a blank line followed by a new structural
+    # element (bold prose marker like `**Foo:**`, fenced code, or another
+    # H2/H3). We tolerate a single blank line inside the summary itself when
+    # the next non-blank line continues plain prose.
+    i = start_idx + 1
+    while i < len(lines):
+        stripped = lines[i].lstrip()
+        if not stripped:
+            # blank — peek next non-blank line
+            j = i + 1
+            while j < len(lines) and not lines[j].lstrip():
+                j += 1
+            if j >= len(lines):
+                end_idx = i
+                break
+            nxt = lines[j].lstrip()
+            if (
+                nxt.startswith("**")
+                or nxt.startswith("```")
+                or H2_OR_H3_RE.match(lines[j])
+            ):
+                end_idx = i
+                break
+            # otherwise continue — summary spans the blank
+            i = j + 1
+            continue
+        if H2_OR_H3_RE.match(lines[i]):
+            end_idx = i
+            break
+        i += 1
+
+    summary = "\n".join(lines[start_idx:end_idx]).rstrip()
+    return summary or None
+
+
+def parse_agents_md() -> tuple[dict[str, str], dict[str, str]]:
+    """Parse AGENTS.md into named sections keyed by heading text.
+
+    Returns a `(sections, summaries)` pair:
+      * `sections[heading] = full body` for every H2/H3 heading.
+      * `summaries[heading] = summary text` only for protocols carrying the
+        `<!-- inline-mode: summarize -->` marker AND a `**Summary:**` block.
+    """
     if not AGENTS_MD.exists():
         print(f"ERROR: {AGENTS_MD} not found. Run from repo root.", file=sys.stderr)
         sys.exit(1)
@@ -54,6 +125,7 @@ def parse_agents_md() -> dict[str, str]:
         sys.exit(1)
     lines = AGENTS_MD.read_text().splitlines()
     sections: dict[str, str] = {}
+    summaries: dict[str, str] = {}
     seen: set[str] = set()
     current_key = None
     current_lines: list[str] = []
@@ -70,7 +142,28 @@ def parse_agents_md() -> dict[str, str]:
                 file=sys.stderr,
             )
         seen.add(key)
-        sections[key] = "\n".join(body_lines)
+        body = "\n".join(body_lines)
+        sections[key] = body
+        # Detect summarize mode: the marker MUST appear on a line by itself
+        # (after whitespace strip). Prose mentions in backticks/inline-code
+        # don't count — that prevents the meta-doc in `## Editing Rules`
+        # from accidentally marking itself.
+        marker_present = any(
+            line.strip() == SUMMARIZE_MARKER for line in body_lines
+        )
+        # Missing summary while marker is present (and we're sure the
+        # marker is a real marker) is a SOURCE-OF-TRUTH bug — warn.
+        if marker_present:
+            summary = _extract_summary(body)
+            if summary is None:
+                print(
+                    f"  WARNING: '{key}' carries {SUMMARIZE_MARKER} but "
+                    "no **Summary:** subsection found — falling back to "
+                    "full-body inlining for this protocol",
+                    file=sys.stderr,
+                )
+            else:
+                summaries[key] = summary
 
     for line in lines:
         heading_match = HEADING_RE.match(line)
@@ -86,7 +179,7 @@ def parse_agents_md() -> dict[str, str]:
     if current_key:
         _flush(current_key, current_lines)
 
-    return sections
+    return sections, summaries
 
 
 def extract_refs_from_content(content: str) -> set[str]:
@@ -225,10 +318,44 @@ def strip_existing_inline(content: str) -> str:
     return content[:start_idx].rstrip() + after
 
 
-def inline_protocols() -> None:
-    """Main: inline referenced protocols into each SKILL.md."""
-    sections = parse_agents_md()
-    print(f"Parsed {len(sections)} sections from AGENTS.md")
+def _build_summary_stub(key: str, summary: str) -> str:
+    """Render the inlined stub for a summarize-marked protocol."""
+    lines: list[str] = []
+    lines.append(f"### {key} (summarized)")
+    lines.append("")
+    lines.append(
+        f"> **Summary inlined here. Full recipe at "
+        f"`AGENTS.md -> {key}`.**"
+    )
+    lines.append("")
+    lines.append(summary)
+    return "\n".join(lines)
+
+
+def inline_protocols(
+    *,
+    summarize: bool = True,
+    stats_only: bool = False,
+) -> dict | None:
+    """Main: inline referenced protocols into each SKILL.md.
+
+    Parameters
+    ----------
+    summarize:
+        When True (default), protocols carrying `<!-- inline-mode: summarize -->`
+        propagate as their `**Summary:**` stub instead of the full body.
+    stats_only:
+        When True, no files are written. Returns a stats dict for callers
+        (e.g., `make inline-stats`) to render a table.
+    """
+    sections, summaries = parse_agents_md()
+    print(f"Parsed {len(sections)} sections from AGENTS.md", file=sys.stderr)
+    if summaries:
+        print(
+            f"  {len(summaries)} carry summarize markers: "
+            f"{sorted(summaries)}",
+            file=sys.stderr,
+        )
 
     # Also include some foundational sections that provide context
     # for protocol references (e.g., State Management references state.json format)
@@ -242,7 +369,14 @@ def inline_protocols() -> None:
 
     # Find all SKILL.md files
     skill_files = sorted(REPO_ROOT.glob("*/skills/*/SKILL.md"))
-    print(f"Found {len(skill_files)} SKILL.md files\n")
+    print(f"Found {len(skill_files)} SKILL.md files\n", file=sys.stderr)
+
+    # Stats accumulators for `--stats-only` mode.
+    per_skill: list[dict] = []
+    protocol_consumers: dict[str, list[str]] = {}
+    protocol_lines: dict[str, int] = {}
+    pre_summarize_total = 0
+    post_summarize_total = 0
 
     total_inlined = 0
 
@@ -370,20 +504,77 @@ def inline_protocols() -> None:
         inline_parts.append("extracted from the Optimus AGENTS.md to make this plugin self-contained.")
         inline_parts.append("")
 
+        # Track which protocols got summarized vs full-bodied for this skill,
+        # plus the lines saved by summarization (for both stats and the
+        # per-skill log line below).
+        summarized_count = 0
+        full_count = 0
+        lines_saved = 0
+
+        def _emit(key: str, full_text: str) -> None:
+            """Append either summary stub or full body for `key`."""
+            nonlocal summarized_count, full_count, lines_saved
+            if summarize and key in summaries:
+                stub = _build_summary_stub(key, summaries[key])
+                inline_parts.append(stub)
+                summarized_count += 1
+                full_lines = full_text.count("\n") + 1
+                stub_lines = stub.count("\n") + 1
+                lines_saved += max(full_lines - stub_lines, 0)
+            else:
+                inline_parts.append(full_text)
+                full_count += 1
+            inline_parts.append("")
+
         # Add foundational context first
         for key, text in extra.items():
             if key not in sections_to_inline:
-                inline_parts.append(text)
-                inline_parts.append("")
+                _emit(key, text)
 
         # Add referenced protocols/patterns
         for key, text in sections_to_inline.items():
-            inline_parts.append(text)
-            inline_parts.append("")
+            _emit(key, text)
 
         inline_parts.append(MARKER_END)
 
         new_content = content + "\n".join(inline_parts) + "\n"
+
+        # Update accumulators that are needed by both write and stats-only paths.
+        # `inlined_keys` is the union of sections_to_inline + extra (foundational).
+        inlined_keys = set(sections_to_inline) | {
+            k for k in extra if k not in sections_to_inline
+        }
+        for key in inlined_keys:
+            protocol_consumers.setdefault(key, []).append(plugin_name)
+            full_text = sections_to_inline.get(key) or extra.get(key) or ""
+            protocol_lines.setdefault(
+                key, full_text.count("\n") + 1 if full_text else 0
+            )
+        # Per-skill stats: count lines in inlined block (full vs stub).
+        inlined_block_lines = sum(part.count("\n") + 1 for part in inline_parts)
+        skill_total_lines = new_content.count("\n") + 1
+        body_lines = content.count("\n") + 1
+        per_skill.append({
+            "plugin": plugin_name,
+            "total": skill_total_lines,
+            "inlined": inlined_block_lines,
+            "body": body_lines,
+            "summarized": summarized_count,
+            "full": full_count,
+            "lines_saved": lines_saved,
+        })
+        # The "before summarize" estimate sums full-body line counts for ALL
+        # inlined keys; "after" sums summary lines for keys with a summary
+        # plus full lines for the rest (= what the skill currently emits).
+        for key in inlined_keys:
+            full_text = sections_to_inline.get(key) or extra.get(key) or ""
+            full_len = full_text.count("\n") + 1 if full_text else 0
+            pre_summarize_total += full_len
+            if summarize and key in summaries:
+                stub_text = _build_summary_stub(key, summaries[key])
+                post_summarize_total += stub_text.count("\n") + 1
+            else:
+                post_summarize_total += full_len
 
         # F14e: Skip the write when the inlined output is byte-identical to
         # what's already on disk. Keeps mtime stable on no-op runs, which
@@ -391,13 +582,25 @@ def inline_protocols() -> None:
         # spurious git diffs. The matched/unmatched accounting is still
         # printed below so reviewers see the full picture.
         if new_content == raw_content:
+            if not stats_only:
+                print(
+                    f"  {plugin_name}: no changes (already up to date) "
+                    f"({len(refs)} refs, {len(unmatched)} unmatched)"
+                )
+                if unmatched:
+                    for u in unmatched:
+                        print(f"    WARNING: unmatched ref: {u}", file=sys.stderr)
+            continue
+
+        # In stats-only mode, never write. Still log per-skill summary so
+        # callers can verify the dry-run path is producing sensible numbers.
+        if stats_only:
             print(
-                f"  {plugin_name}: no changes (already up to date) "
-                f"({len(refs)} refs, {len(unmatched)} unmatched)"
+                f"  [stats-only] {plugin_name}: would inline "
+                f"{len(sections_to_inline)} protocols "
+                f"({summarized_count} summarized, {full_count} full) + "
+                f"{len(extra)} foundational, {lines_saved} lines saved via summarize"
             )
-            if unmatched:
-                for u in unmatched:
-                    print(f"    WARNING: unmatched ref: {u}", file=sys.stderr)
             continue
 
         # F3.3d: Refuse to write through a symlink. Defense-in-depth against
@@ -429,13 +632,110 @@ def inline_protocols() -> None:
             continue
 
         total_inlined += 1
-        print(f"  {plugin_name}: inlined {len(sections_to_inline)} protocols + {len(extra)} foundational ({len(refs)} refs, {len(unmatched)} unmatched)")
+        print(
+            f"  {plugin_name}: inlined {len(sections_to_inline)} protocols "
+            f"({summarized_count} summarized, {full_count} full) + "
+            f"{len(extra)} foundational, {lines_saved} lines saved via "
+            f"summarize ({len(refs)} refs, {len(unmatched)} unmatched)"
+        )
         if unmatched:
             for u in unmatched:
                 print(f"    WARNING: unmatched ref: {u}", file=sys.stderr)
 
+    if stats_only:
+        _render_stats(per_skill, protocol_consumers, protocol_lines,
+                      pre_summarize_total, post_summarize_total, summarize)
+        return {
+            "per_skill": per_skill,
+            "protocol_consumers": protocol_consumers,
+            "protocol_lines": protocol_lines,
+            "pre_summarize_total": pre_summarize_total,
+            "post_summarize_total": post_summarize_total,
+        }
+
     print(f"\nDone. Inlined protocols into {total_inlined} SKILL.md files.")
+    return None
+
+
+def _render_stats(
+    per_skill: list[dict],
+    protocol_consumers: dict[str, list[str]],
+    protocol_lines: dict[str, int],
+    pre_summarize_total: int,
+    post_summarize_total: int,
+    summarize: bool,
+) -> None:
+    """Pretty-print the stats table to stdout (for `make inline-stats`)."""
+    print()
+    print("Per-skill inlining stats")
+    print("-" * 72)
+    header = f"{'Skill':<24} {'Total LOC':>10} {'Inlined LOC':>12} {'Body LOC':>10} {'Inline %':>9}"
+    print(header)
+    print("-" * 72)
+    for row in sorted(per_skill, key=lambda r: -r["inlined"]):
+        pct = (row["inlined"] / row["total"] * 100) if row["total"] else 0
+        print(
+            f"{row['plugin']:<24} {row['total']:>10} "
+            f"{row['inlined']:>12} {row['body']:>10} {pct:>8.0f}%"
+        )
+    print()
+    print("Duplication summary (by protocol)")
+    print("-" * 72)
+    print(f"{'Protocol':<48} {'Consumers':>10} {'Lines/copy':>11}")
+    print("-" * 72)
+    rows = []
+    for key, consumers in protocol_consumers.items():
+        rows.append((key, len(consumers), protocol_lines.get(key, 0)))
+    for key, n, lines in sorted(rows, key=lambda r: -(r[1] * r[2])):
+        total = n * lines
+        label = key
+        if len(label) > 47:
+            label = label[:44] + "..."
+        print(f"{label:<48} {n:>10} {lines:>11}  (total {total})")
+    print()
+    print("Estimated total inlined LOC")
+    print("-" * 72)
+    print(f"  Before summarize: {pre_summarize_total} LOC across {len(per_skill)} SKILLs")
+    if summarize and pre_summarize_total:
+        delta = pre_summarize_total - post_summarize_total
+        pct = delta / pre_summarize_total * 100
+        print(
+            f"  After summarize : {post_summarize_total} LOC "
+            f"(-{delta} LOC, -{pct:.0f}%)"
+        )
+    else:
+        print(
+            "  Summarize disabled (--no-summarize) — using full-body inlining"
+        )
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Inline AGENTS.md protocols into each SKILL.md."
+    )
+    parser.add_argument(
+        "--no-summarize",
+        action="store_true",
+        help=(
+            "Disable summarize mode. Protocols carrying "
+            f"{SUMMARIZE_MARKER!r} will inline their full body instead of "
+            "the summary stub. Useful for diagnostic or full-rebuild runs."
+        ),
+    )
+    parser.add_argument(
+        "--stats-only",
+        action="store_true",
+        help=(
+            "Don't write any files. Print a per-skill / per-protocol table "
+            "and a before/after summarize-mode estimate to stdout."
+        ),
+    )
+    return parser.parse_args(argv)
 
 
 if __name__ == "__main__":
-    inline_protocols()
+    args = _parse_args()
+    inline_protocols(
+        summarize=not args.no_summarize,
+        stats_only=args.stats_only,
+    )

--- a/scripts/test_inline_protocols.py
+++ b/scripts/test_inline_protocols.py
@@ -23,7 +23,7 @@ class TestParseAgentsMd:
         agents = tmp_path / "AGENTS.md"
         agents.write_text("## Section A\nContent A\n### Section B\nContent B\n")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        sections = ip.parse_agents_md()
+        sections, _summaries = ip.parse_agents_md()
         assert "Section A" in sections
         assert "Section B" in sections
         assert "Content A" in sections["Section A"]
@@ -33,7 +33,7 @@ class TestParseAgentsMd:
         agents = tmp_path / "AGENTS.md"
         agents.write_text("# H1\nIgnored\n## H2\nKept\n#### H4\nAlso kept in H2\n")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        sections = ip.parse_agents_md()
+        sections, _summaries = ip.parse_agents_md()
         assert "H1" not in sections
         assert "H4" not in sections
         assert "H2" in sections
@@ -43,7 +43,9 @@ class TestParseAgentsMd:
         agents = tmp_path / "AGENTS.md"
         agents.write_text("")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        assert ip.parse_agents_md() == {}
+        sections, summaries = ip.parse_agents_md()
+        assert sections == {}
+        assert summaries == {}
 
     def test_missing_file_exits(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(ip, "AGENTS_MD", tmp_path / "nonexistent.md")
@@ -404,7 +406,7 @@ class TestCriticalPaths:
         agents = tmp_path / "AGENTS.md"
         agents.write_text("## Same\nFirst content\n## Same\nSecond content\n")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        sections = ip.parse_agents_md()
+        sections, _summaries = ip.parse_agents_md()
         assert "Second content" in sections["Same"]
         assert "First content" not in sections["Same"]
         captured = capsys.readouterr()
@@ -424,7 +426,7 @@ class TestCriticalPaths:
         agents = tmp_path / "AGENTS.md"
         agents.write_text("## Dup\nA\n## Dup\nB\n")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        sections = ip.parse_agents_md()
+        sections, _summaries = ip.parse_agents_md()
         assert "Dup" in sections
         captured = capsys.readouterr()
         assert "WARNING" in captured.err
@@ -502,7 +504,7 @@ class TestEdgeCases:
         agents = tmp_path / "AGENTS.md"
         agents.write_text("## Protocol: optimus-tasks.md Validation (HARD BLOCK)\nValidation content\n")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        sections = ip.parse_agents_md()
+        sections, _summaries = ip.parse_agents_md()
         assert "Protocol: optimus-tasks.md Validation (HARD BLOCK)" in sections
 
     def test_protocol_with_trailing_paren(self, tmp_path: Path):
@@ -515,7 +517,7 @@ class TestEdgeCases:
         agents = tmp_path / "AGENTS.md"
         agents.write_text("## Protocol: Notifica\u00e7\u00e3o de Status\nContent\n")
         monkeypatch.setattr(ip, "AGENTS_MD", agents)
-        sections = ip.parse_agents_md()
+        sections, _summaries = ip.parse_agents_md()
         assert "Protocol: Notifica\u00e7\u00e3o de Status" in sections
 
     def test_includes_foundational_for_taskspec(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -884,3 +886,176 @@ fi
         body = gitignore.read_text()
         assert "# optimus-operational-files" in body
         assert "# optimus-operational-worktrees" in body
+
+
+# --- Phase 1 of issue #34: inline-protocol bloat reduction (summarize mode) ---
+
+
+class TestSummarizeMode:
+    """Phase 1 of issue #34: protocols marked <!-- inline-mode: summarize -->
+    inline only their Summary block in consumer skills, not the full body."""
+
+    def _setup_summarize_repo(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        skill_body: str = "see AGENTS.md Protocol: Foo.\n",
+        plugin: str = "fooplug",
+    ) -> tuple[Path, Path]:
+        """Build a tmp repo with one summarize-marked protocol + one consumer."""
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(
+            "# Test\n\n"
+            "## Reusable Protocols\n\n"
+            "### Protocol: Foo\n\n"
+            f"{ip.SUMMARIZE_MARKER}\n\n"
+            "**Summary:** Foo summary line one. See AGENTS.md.\n\n"
+            "**Referenced by:** test consumers.\n\n"
+            "Full body of Foo with lots of bash:\n\n"
+            "```bash\n"
+            "echo full body line 1\n"
+            "echo full body line 2\n"
+            "echo full body line 3\n"
+            "echo full body line 4\n"
+            "echo full body line 5\n"
+            "```\n"
+            "\n"
+            "More prose for Foo.\n"
+        )
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
+
+        skill_dir = tmp_path / plugin / "skills" / f"optimus-{plugin}"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        skill.write_text(skill_body)
+        return agents, skill
+
+    def test_summarize_marker_recognized_in_parse(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """parse_agents_md() returns (sections, summaries); summaries
+        contains an entry for the marked protocol."""
+        agents, _skill = self._setup_summarize_repo(tmp_path, monkeypatch)
+        sections, summaries = ip.parse_agents_md()
+        assert "Protocol: Foo" in sections
+        assert "Protocol: Foo" in summaries
+        assert "Foo summary" in summaries["Protocol: Foo"]
+        # Summary must NOT include the full body.
+        assert "echo full body" not in summaries["Protocol: Foo"]
+
+    def test_summarized_protocol_emits_stub_in_skill(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Default summarize mode: consumer SKILL.md gets the stub, not the
+        full body."""
+        _agents, skill = self._setup_summarize_repo(tmp_path, monkeypatch)
+        ip.inline_protocols()  # default summarize=True
+        out = skill.read_text()
+        # Stub heading present:
+        assert "### Protocol: Foo (summarized)" in out
+        # Summary line present:
+        assert "Foo summary" in out
+        # Full body bash MUST NOT propagate:
+        assert "echo full body line 1" not in out
+
+    def test_no_summarize_flag_emits_full_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """With summarize=False, summarize-marked protocols inline the full
+        body (legacy behavior, used by --no-summarize CLI flag)."""
+        _agents, skill = self._setup_summarize_repo(tmp_path, monkeypatch)
+        ip.inline_protocols(summarize=False)
+        out = skill.read_text()
+        # Stub MUST NOT appear:
+        assert "### Protocol: Foo (summarized)" not in out
+        # Full body MUST appear:
+        assert "echo full body line 1" in out
+        assert "More prose for Foo" in out
+
+    def test_stats_only_mode_does_not_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """--stats-only emits the table to stdout but doesn't modify any
+        SKILL.md files."""
+        _agents, skill = self._setup_summarize_repo(tmp_path, monkeypatch)
+        before = skill.read_text()
+        result = ip.inline_protocols(stats_only=True)
+        after = skill.read_text()
+        assert before == after, "stats-only must not write to SKILL.md"
+        # Stats payload shape:
+        assert isinstance(result, dict)
+        assert "per_skill" in result
+        assert "protocol_consumers" in result
+        assert "pre_summarize_total" in result
+        # Stdout has rendered table headers:
+        captured = capsys.readouterr()
+        assert "Per-skill inlining stats" in captured.out
+        assert "Duplication summary" in captured.out
+        assert "Estimated total inlined LOC" in captured.out
+
+    def test_summary_extraction_skips_referenced_by_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The summary parser must end at the next `**Referenced by:**` (or
+        any bold marker after a blank line), NOT include it as part of the
+        summary."""
+        _agents, _skill = self._setup_summarize_repo(tmp_path, monkeypatch)
+        _sections, summaries = ip.parse_agents_md()
+        summary = summaries["Protocol: Foo"]
+        assert "**Referenced by:**" not in summary, (
+            f"Summary leaked into Referenced-by block: {summary!r}"
+        )
+
+    def test_summarize_marker_without_summary_falls_back_to_full(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """Source-of-truth bug: marker present but no Summary subsection.
+        Inliner warns and falls back to full-body inlining."""
+        agents = tmp_path / "AGENTS.md"
+        agents.write_text(
+            "## Reusable Protocols\n\n"
+            "### Protocol: Bar\n\n"
+            f"{ip.SUMMARIZE_MARKER}\n\n"
+            "Body without a Summary subsection.\n"
+        )
+        monkeypatch.setattr(ip, "AGENTS_MD", agents)
+        monkeypatch.setattr(ip, "REPO_ROOT", tmp_path)
+        skill_dir = tmp_path / "barplug" / "skills" / "optimus-barplug"
+        skill_dir.mkdir(parents=True)
+        skill = skill_dir / "SKILL.md"
+        skill.write_text("see AGENTS.md Protocol: Bar.\n")
+
+        sections, summaries = ip.parse_agents_md()
+        assert "Protocol: Bar" in sections
+        # Summary missing -> protocol does NOT enter `summaries`.
+        assert "Protocol: Bar" not in summaries
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "no **Summary:** subsection" in captured.err
+
+        # And the inlined output uses the full body since the protocol
+        # doesn't enter `summaries`.
+        ip.inline_protocols()
+        out = skill.read_text()
+        assert "Body without a Summary subsection" in out
+        assert "(summarized)" not in out
+
+    def test_cli_flag_no_summarize_disables_summarize(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The argparse layer translates --no-summarize into summarize=False."""
+        args = ip._parse_args(["--no-summarize"])
+        assert args.no_summarize is True
+        assert args.stats_only is False
+
+    def test_cli_flag_stats_only_disables_writes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The argparse layer accepts --stats-only."""
+        args = ip._parse_args(["--stats-only"])
+        assert args.stats_only is True
+        assert args.no_summarize is False

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3089,7 +3089,7 @@ class TestSpecSelfHeal:
         finally:
             sys.path.pop(0)
 
-        agents_sections = inline_protocols.parse_agents_md()
+        agents_sections, _summaries = inline_protocols.parse_agents_md()
         violations = []
         for path in _all_skill_files():
             # Use the inliner's body-only extraction to skip the inlined block.
@@ -3235,3 +3235,54 @@ class TestWorktreeLocationConvention:
             if not pattern.search(body):
                 violations.append(f"{path.relative_to(REPO_ROOT)}: missing case-stmt traversal guard")
         assert violations == [], "\n".join(violations)
+
+
+# --- Phase 1 of issue #34: top-3 most-duplicated protocols carry the
+# `<!-- inline-mode: summarize -->` marker AND a `**Summary:**` subsection
+# in AGENTS.md. The inliner reads both at runtime; this test guards the
+# source-of-truth so the marker can't be dropped without flipping a test.
+
+class TestProtocolSummarizeMarker:
+    """Phase 1 of issue #34: Verify the 3 top-duplicated protocols carry
+    the <!-- inline-mode: summarize --> marker in AGENTS.md."""
+
+    SUMMARIZED_PROTOCOLS = [
+        "Resolve Main Worktree Path",
+        "Session State",
+        "Initialize .optimus Directory",
+    ]
+
+    def test_summarize_marker_present_for_top_protocols(self):
+        content = AGENTS_MD.read_text()
+        for proto in self.SUMMARIZED_PROTOCOLS:
+            heading = f"### Protocol: {proto}"
+            idx = content.find(heading)
+            assert idx >= 0, f"{heading} missing from AGENTS.md"
+            # Check the next 600 chars for the marker AND a Summary subsection.
+            window = content[idx: idx + 600]
+            assert "<!-- inline-mode: summarize -->" in window, (
+                f"{proto}: missing <!-- inline-mode: summarize --> marker "
+                "(must be placed immediately under the heading)"
+            )
+            assert "**Summary:**" in window, (
+                f"{proto}: missing **Summary:** subsection "
+                "(must follow the summarize marker)"
+            )
+
+    def test_summarize_marker_implies_marker_appears_first(self):
+        """Marker must precede any other prose in the protocol body so
+        parse_agents_md sees it before falling through to full-body
+        inlining heuristics."""
+        content = AGENTS_MD.read_text()
+        for proto in self.SUMMARIZED_PROTOCOLS:
+            heading = f"### Protocol: {proto}"
+            idx = content.find(heading)
+            window = content[idx: idx + 600]
+            # The marker MUST appear before the first `**Summary:**` (and
+            # also before the first `**Referenced by:**` if present).
+            marker_idx = window.find("<!-- inline-mode: summarize -->")
+            summary_idx = window.find("**Summary:**")
+            assert marker_idx < summary_idx, (
+                f"{proto}: marker must come before **Summary:** "
+                f"(marker={marker_idx}, summary={summary_idx})"
+            )

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1188,112 +1188,17 @@ each task. If any task appears twice in the chain, a cycle exists. Report ALL ta
 in the cycle so the user can fix it with `/optimus-tasks`.
 
 
-### Protocol: Resolve Main Worktree Path
+### Protocol: Resolve Main Worktree Path (summarized)
 
-**Referenced by:** all skills that read or write `.optimus/` operational files (state.json, stats.json, sessions, reports, logs, and checkpoint markers).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
 
-**Why:** `.optimus/` is gitignored. Git does NOT propagate ignored files across linked worktrees (`git worktree add` creates a sibling working tree but does not share gitignored files). When a skill runs from a linked worktree (the common case for `/optimus-build`, `/optimus-review`, `/optimus-done` which default to the task's worktree), reads and writes against `.optimus/state.json` resolve to the worktree's isolated copy. Updates never reach the main worktree. When the linked worktree is later removed (e.g., by `/optimus-done` cleanup), the writes are lost — silent data loss.
+**Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-**Recipe:**
+### Protocol: Initialize .optimus Directory (summarized)
 
-```bash
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-if [ -z "$MAIN_WORKTREE" ]; then
-  echo "ERROR: Cannot determine main worktree — not in a git repository." >&2
-  exit 1
-fi
-```
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Initialize .optimus Directory`.**
 
-The first `worktree` line in `git worktree list --porcelain` is always the main worktree (where the bare `.git/` directory or the repo's HEAD lives), regardless of where the command is run from.
-
-**Path resolution pattern:**
-
-After resolving `MAIN_WORKTREE`, every `.optimus/` path MUST be prefixed:
-
-```bash
-# RIGHT (works from any worktree):
-STATE_FILE="${MAIN_WORKTREE}/.optimus/state.json"
-SESSION_FILE="${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" \
-         "${MAIN_WORKTREE}/.optimus/reports" \
-         "${MAIN_WORKTREE}/.optimus/logs"
-
-# WRONG (resolves against PWD, breaks in linked worktrees):
-STATE_FILE=".optimus/state.json"
-SESSION_FILE=".optimus/sessions/session-${TASK_ID}.json"
-STATS_FILE=".optimus/stats.json"
-mkdir -p .optimus/sessions .optimus/reports .optimus/logs
-```
-
-**What does NOT need this protocol:**
-
-- `<tasksDir>/optimus-tasks.md` and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/` — versioned content, propagated by git across worktrees automatically.
-- `.optimus/config.json` — when **versioned** (legacy projects), it propagates via git; when **gitignored** (current default), it suffers the same isolation as state.json. **Treat `.optimus/config.json` as gitignored and resolve via `$MAIN_WORKTREE` for safety in current projects** — the cost is a single `git worktree list` call.
-- `.gitignore` itself — versioned, propagated via git.
-
-**Idempotency:** the resolution is read-only against git metadata; safe to call multiple times in the same skill execution. Cache `MAIN_WORKTREE` in a local variable rather than re-running `git worktree list` for each path.
-
-Skills reference this as: "Resolve main worktree — see AGENTS.md Protocol: Resolve Main Worktree Path."
-
-
-### Protocol: Initialize .optimus Directory
-
-**Referenced by:** import, tasks, report (export), quick-report, batch, pr-check, deep-review, coderabbit-review, all stage agents (1-4) for session files
-
-Before creating ANY file inside `.optimus/`, ensure the directory structure exists
-and that the entire `.optimus/` tree is gitignored (it is 100% operational/per-user).
-
-```bash
-# Requires Protocol: Resolve Main Worktree Path to have run first
-# (or resolve inline; see that protocol).
-MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-mkdir -p "${MAIN_WORKTREE}/.optimus/sessions" "${MAIN_WORKTREE}/.optimus/reports" "${MAIN_WORKTREE}/.optimus/logs"
-# Refuse symlinked .gitignore (defense against link-following file-write).
-# Hoisted ABOVE the operational-files write so the first append is also protected.
-if [ -L "${MAIN_WORKTREE}/.gitignore" ]; then
-  echo "ERROR: ${MAIN_WORKTREE}/.gitignore is a symlink — refusing to append (potential symlink attack)." >&2
-  exit 1
-fi
-if ! grep -q '^# optimus-operational-files' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-files\n.optimus/config.json\n.optimus/state.json\n.optimus/stats.json\n.optimus/sessions/\n.optimus/reports/\n.optimus/logs/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Linked worktrees managed by Optimus live at ${MAIN_WORKTREE}/.worktrees/
-# (see Protocol: Worktree Location). Add a separate marker so existing
-# projects whose .gitignore already carries the operational-files block
-# still get the worktree exclusion idempotently.
-if ! grep -q '^# optimus-operational-worktrees' "${MAIN_WORKTREE}/.gitignore" 2>/dev/null; then
-  printf '\n# optimus-operational-worktrees\n.worktrees/\n' >> "${MAIN_WORKTREE}/.gitignore"
-fi
-# Log retention (idempotent — fires once per init): age-based + count-cap prune.
-# Also duplicated in Protocol: Session State so stage agents (which call Session
-# State but not Initialize Directory) get pruning at every phase transition.
-# Both prune sites are no-ops on clean directories; running both is harmless.
-find "${MAIN_WORKTREE}/.optimus/logs" -type f -name '*.log' -mtime +30 -delete 2>/dev/null
-if [ -d "${MAIN_WORKTREE}/.optimus/logs" ]; then
-  ls -1t "${MAIN_WORKTREE}/.optimus/logs"/*.log 2>/dev/null | tail -n +501 \
-    | while IFS= read -r _log_to_rm; do rm -f -- "$_log_to_rm"; done
-fi
-```
-
-**Log retention** for `.optimus/logs/` runs at TWO sites for full coverage:
-- **Protocol: Initialize .optimus Directory** (this protocol) — fires when
-  admin/standalone skills (`import`, `tasks`, `report`, `quick-report`, `batch`,
-  `pr-check`, `deep-review`, `coderabbit-review`) initialize `.optimus/`.
-- **Protocol: Session State** — fires at every stage agent (`plan`, `build`,
-  `review`, `done`) phase transition.
-
-Both sites are idempotent (no-op on clean directories) and use the same prune
-logic (30-day age cap + 500-file count cap). Running both per session is a
-harmless cheap operation.
-
-Everything inside `.optimus/` is gitignored. The planning tree is versioned
-separately at `<tasksDir>/optimus-tasks.md` (and `<tasksDir>/tasks/`, `<tasksDir>/subtasks/`
-for Ring specs) — see the File Location section above.
-
-Skills reference this as: "Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory."
-
+**Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
 ### Protocol: Notification Hooks
 


### PR DESCRIPTION
Closes #34 (Phase 1 / incremental).

## Why a Phase 1?

Issue #34 proposed three architectural options. Investigation today found:

- **Option A (runtime resolver):** requires harness-side change in Claude Code AND Droid. Not controllable from this repo.
- **Option B (sibling SKILL.protocols.md):** same harness dependency.
- **Option C (separate shared-protocols plugin with deps):** Droid plugin.json schema has NO \`dependencies\` field today. Confirmed by grep across all 17 plugin.json files. Requires harness feature work.

This PR takes a **non-breaking, harness-independent path** that delivers measurable impact NOW and lays the foundation for Option C when the Droid feature lands.

## What it does

Introduces opt-in summarize mode to \`inline-protocols.py\`:

- Protocols in AGENTS.md tagged with \`<!-- inline-mode: summarize -->\` propagate as terse 5-line stubs in consumer SKILLs (was: full ~50-160 line body inlined into each consumer)
- Each summarize-marked protocol carries a \`**Summary:**\` block (~80 words) which becomes the stub content
- Full body stays in AGENTS.md as source of truth — agents read the stub and consult AGENTS.md when they need bash details

Applied to top-3 most-duplicated protocols:
- \`Protocol: Resolve Main Worktree Path\` (13 consumers)
- \`Protocol: Session State\` (3 explicit + 10 via foundational injection)
- \`Protocol: Initialize .optimus Directory\` (7 consumers)

## Stats (measured via new \`make inline-stats\`)

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| Inlined LOC across 15 SKILLs | 13,238 | 11,740 | **-1,498 (-11%)** |
| Total SKILL.md disk size | 24,020 | 22,614 | -1,406 (-5.9%) |
| Per-skill range (stage skills) | — | — | -47 to **-212 LOC** |
| Tests | 330 | **340** | +10 |

## What's added

- **\`AGENTS.md\` Editing Rules:** new \`Summarize mode\` rule documents the contract
- **\`inline-protocols.py\`:** \`parse_agents_md()\` now returns \`(sections, summaries)\`; \`inline_protocols()\` accepts \`summarize=True/False\` and \`stats_only=True/False\`; CLI flags \`--no-summarize\` and \`--stats-only\`
- **\`Makefile\`:** new \`make inline-stats\` target (no file writes — measurement only)
- **Tests:** \`TestSummarizeMode\` (8 tests in test_inline_protocols.py), \`TestProtocolSummarizeMarker\` (2 tests in test_skill_consistency.py)
- **README:** brief architecture note pointing at issue #34 + commands

## Stub format

Each summarized protocol now appears in consumer SKILLs as:

\`\`\`markdown
### Protocol: Resolve Main Worktree Path (summarized)

> **Summary inlined here. Full recipe at \`AGENTS.md → Protocol: Resolve Main Worktree Path\`.**

Resolve \`MAIN_WORKTREE\` once via \`git worktree list --porcelain | awk ...\` with \`\${MAIN_WORKTREE:?…}\` defensive guard. Use \`\${MAIN_WORKTREE}/.optimus/...\` for ALL \`.optimus/\` paths (gitignored, doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
\`\`\`

vs the previous ~58-line full body inlined into 13 SKILLs.

## Phase 2 candidates surfaced by stats

The new \`make inline-stats\` table identifies the next-best candidates for marking:

| Protocol | Consumers | Lines/copy | Total inlined |
|----------|-----------|-----------|--------------|
| Resolve Tasks Git Scope | 11 | 160 | **1,760** |
| State Management | 9 | 147 | **1,323** |
| Convergence Loop | 7 | ~120 | **~840** |
| Quiet Command Execution | 5 | ~70 | **~350** |

Phase 2 is a 1-line-marker-each PR (just add the marker + Summary in AGENTS.md). Easy increment.

## Phase 3+

Full Option C (shared-protocols plugin with deps) is tracked at #34. Awaits Droid \`dependencies\` field in plugin.json schema. The summarize-mode infrastructure here is a stepping stone — once Droid supports deps, the summarized protocols become natural candidates to migrate into the shared plugin.

## Test plan

- [x] \`make test\` — 340 passed
- [x] \`make lint\` — clean (ruff + py_compile + shellcheck)
- [x] \`make inline-stats\` — emits sensible table
- [x] \`python3 scripts/inline-protocols.py\` — idempotent (0 changes on second run)
- [x] Spot-check stage SKILLs: \`build/SKILL.md\` body shows summary stubs, NOT full bodies
- [ ] CI on this PR

## Reversibility

Run \`python3 scripts/inline-protocols.py --no-summarize\` to disable summarize mode and re-emit full bodies. Removing the markers from AGENTS.md restores pre-PR behavior naturally on next inline run.

## Stats

32 files changed, **+721 / −2,980** (net **−2,259 lines** of duplicated protocol prose removed from SKILLs).