### PR TITLE
feat(inliner): Phase 4 inline-protocol bloat reduction (issue #34) — natural pause

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -595,6 +595,10 @@ The `## Versions` section in optimus-tasks.md is **mandatory** and defines the a
 
 ### Format Validation
 
+<!-- inline-mode: summarize -->
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
+
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
 2. A `## Versions` section exists with a table containing columns: Version, Status, Description
@@ -2105,6 +2109,10 @@ Skills reference this as: "Check optimus-tasks.md divergence — see AGENTS.md P
 
 ### Protocol: Notification Hooks
 
+<!-- inline-mode: summarize -->
+
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
+
 **Referenced by:** all stage agents (1-4), tasks
 
 After writing a status change to state.json, invoke notification hooks if present.
@@ -2210,6 +2218,10 @@ droid is not installed, **STOP** and list missing droids.
 Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
 
 ### Protocol: Coverage Measurement
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 **Referenced by:** review, pr-check, coderabbit-review, deep-review, build
 
@@ -2921,6 +2933,11 @@ analysis, has its own opt-in convergence loop (Phase 7), and uses batch-apply (P
 but applies fixes directly rather than via ring droid TDD cycle.
 
 ### Finding Presentation (Unified Model)
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -321,7 +321,11 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -347,11 +351,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus-tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -620,7 +620,11 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -647,11 +651,6 @@ format validation and before task identification. If zero data rows: **STOP** an
 user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus-tasks`.
-
-
 ### Protocol: Resolve Tasks Git Scope (summarized)
 
 > **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Tasks Git Scope`.**
@@ -664,7 +663,12 @@ in the cycle so the user can fix it with `/optimus-tasks`.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -687,49 +691,6 @@ All cycle review skills follow this pattern:
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
-
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
 
 ### Protocol: Active Version Guard
 
@@ -818,79 +779,11 @@ Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: 
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Default Branch Refusal (HARD BLOCK)
 
@@ -1032,73 +925,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: PR Title Validation
 

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -617,7 +617,12 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -641,128 +646,17 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
-
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated) (summarized)
 
 > **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)`.**
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Initialize .optimus Directory (summarized)
 

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -277,7 +277,11 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus:tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus:import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -303,11 +307,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus:tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/commands/build.md
+++ b/commands/build.md
@@ -558,7 +558,11 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus:tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus:import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -585,11 +589,6 @@ format validation and before task identification. If zero data rows: **STOP** an
 user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus:tasks`.
-
-
 ### Protocol: Resolve Tasks Git Scope (summarized)
 
 > **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Tasks Git Scope`.**
@@ -602,7 +601,12 @@ in the cycle so the user can fix it with `/optimus:tasks`.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -625,49 +629,6 @@ All cycle review skills follow this pattern:
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
-
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
 
 ### Protocol: Active Version Guard
 
@@ -756,79 +717,11 @@ Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: 
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Default Branch Refusal (HARD BLOCK)
 
@@ -970,73 +863,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: PR Title Validation
 

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -560,7 +560,12 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -584,128 +589,17 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
-
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated) (summarized)
 
 > **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)`.**
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Initialize .optimus Directory (summarized)
 

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -500,7 +500,12 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -524,128 +529,17 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
-
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated) (summarized)
 
 > **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)`.**
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Discover Review Droids
 

--- a/commands/done.md
+++ b/commands/done.md
@@ -548,7 +548,11 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus:tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus:import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -574,11 +578,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus:tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 
@@ -865,73 +864,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: Resolve Main Worktree Path (summarized)
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -919,7 +919,11 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus:tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus:import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -945,11 +949,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus:tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 
@@ -1304,73 +1303,11 @@ times each stage ran on each task — useful for spotting spec churn and review 
 Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
 
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: Per-Droid Quality Checklists (summarized)
 

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -1802,7 +1802,12 @@ Every finding must present 2-3 options with this structure:
 - **Very high:** Architectural change, many files, extensive testing, risk of regressions
 
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -1825,49 +1830,6 @@ All cycle review skills follow this pattern:
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
-
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
 
 ### Fix Implementation (Complexity-Based Dispatch)
 
@@ -1925,79 +1887,11 @@ inform the user which droids need to be installed.
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Discover Review Droids
 

--- a/commands/resolve.md
+++ b/commands/resolve.md
@@ -245,7 +245,11 @@ Run `/optimus:report` to verify the dashboard looks correct.
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus:tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus:import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -271,11 +275,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus:tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -680,7 +680,11 @@ The agent MUST NOT use these excuses to skip or reorder steps:
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus:tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus:import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -706,11 +710,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus:tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -969,7 +969,11 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus:tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus:import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -995,11 +999,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus:tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 
@@ -1082,7 +1081,12 @@ Every finding must present 2-3 options with this structure:
 - **Very high:** Architectural change, many files, extensive testing, risk of regressions
 
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -1105,49 +1109,6 @@ All cycle review skills follow this pattern:
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
-
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
 
 ### Fix Implementation (Complexity-Based Dispatch)
 
@@ -1286,79 +1247,11 @@ Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: 
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Default Branch Refusal (HARD BLOCK)
 
@@ -1536,73 +1429,11 @@ times each stage ran on each task — useful for spotting spec churn and review 
 Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
 
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: PR Title Validation
 

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -1019,7 +1019,11 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus:tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus:import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -1046,11 +1050,6 @@ format validation and before task identification. If zero data rows: **STOP** an
 user: "No tasks found in optimus-tasks.md. Use `/optimus:tasks` to create a task or `/optimus:import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus:tasks`.
-
-
 ### Protocol: Resolve Main Worktree Path (summarized)
 
 > **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
@@ -1063,73 +1062,11 @@ in the cycle so the user can fix it with `/optimus:tasks`.
 
 **Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -551,7 +551,12 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -575,128 +580,17 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
-
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated) (summarized)
 
 > **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)`.**
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Discover Review Droids
 

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -591,7 +591,11 @@ state.json is implicitly `Pendente`.
 These operations require explicit user confirmation.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -617,11 +621,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus-tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 
@@ -908,73 +907,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: Resolve Main Worktree Path (summarized)
 

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -980,7 +980,11 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -1006,11 +1010,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus-tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 
@@ -1365,73 +1364,11 @@ times each stage ran on each task — useful for spotting spec churn and review 
 Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
 
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: Per-Droid Quality Checklists (summarized)
 

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -1874,7 +1874,12 @@ Every finding must present 2-3 options with this structure:
 - **Very high:** Architectural change, many files, extensive testing, risk of regressions
 
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -1897,49 +1902,6 @@ All cycle review skills follow this pattern:
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
-
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
 
 ### Fix Implementation (Complexity-Based Dispatch)
 
@@ -1997,79 +1959,11 @@ inform the user which droids need to be installed.
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Discover Review Droids
 

--- a/resolve/skills/optimus-resolve/SKILL.md
+++ b/resolve/skills/optimus-resolve/SKILL.md
@@ -284,7 +284,11 @@ Run `/optimus-report` to verify the dashboard looks correct.
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -310,11 +314,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus-tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -739,7 +739,11 @@ The agent MUST NOT use these excuses to skip or reorder steps:
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -765,11 +769,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus-tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -1034,7 +1034,11 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -1060,11 +1064,6 @@ format validation PASSES. Stage agents (1-4) MUST check for this condition immed
 format validation and before task identification. If zero data rows: **STOP** and inform the
 user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
-
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus-tasks`.
-
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 
@@ -1147,7 +1146,12 @@ Every finding must present 2-3 options with this structure:
 - **Very high:** Architectural change, many files, extensive testing, risk of regressions
 
 
-### Finding Presentation (Unified Model)
+### Finding Presentation (Unified Model) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Finding Presentation (Unified Model)`.**
+
+**Summary:** Common pattern for cycle review skills (plan, build, review, pr-check, deep-review, deep-doc-review, coderabbit-review): collect findings, dedup, group same-nature, present ONE-AT-A-TIME via AskUser with strict `[topic]/[option]` template, collect ALL decisions before applying ANY fixes. Mandatory: `(X/N)` progress prefix per finding; ALL findings presented (no auto-skip by severity); HARD BLOCK on "Tell me more" or free-text response — STOP and answer immediately, never defer to end of loop. Anti-rationalization defenses listed inline ("I'll address questions at end" — NO). Scope of structured template: finding-decision AskUsers in cycle review skills only; admin AskUsers MAY use prose. See full pattern + anti-rationalization examples in AGENTS.md.
+
 All cycle review skills follow this pattern:
 1. Collect findings from agents/tools
 2. Consolidate and deduplicate
@@ -1170,49 +1174,6 @@ All cycle review skills follow this pattern:
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
-
-   **AskUser template (MANDATORY — follow this exact structure for every finding):**
-   ```
-   1. [question] (X/N) SEVERITY — Finding title summary
-   [topic] (X/N) F#-Category
-   [option] Option A: recommended fix
-   [option] Option B: alternative approach
-   [option] Skip
-   [option] Tell me more
-   ```
-
-   **Scope of the structured AskUser template:**
-
-   The `[topic]/[option]` structured template applies ONLY to **AskUser calls that present
-   findings/decisions inside cycle review skills** (plan, build, review, pr-check,
-   deep-review, deep-doc-review, coderabbit-review). Each finding presentation must use
-   the template so the user gets consistent UX and the test suite can verify the contract.
-
-   Other AskUser calls — status confirmations, scope choosers, file-presence prompts,
-   admin operations like task creation/cancellation, resume reset confirmations, etc. —
-   MAY use prose. Authors should still aim for clarity and explicit option labels, but
-   the structured template is not required outside finding loops.
-
-   This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
-
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
-   with free text (a question, disagreement, or request for clarification):**
-   **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
-   Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
-   Provide a thorough answer with evidence (links, code references, best practice citations).
-   Only AFTER the user is satisfied, re-present the SAME finding's options and ask for
-   their decision again. This may go back and forth multiple times — that is expected.
-   **NEVER defer the response to the end of the findings loop.**
-
-   **Anti-rationalization (excuses the agent MUST NOT use to skip immediate response):**
-   - "I'll address all questions after presenting the remaining findings" — NO
-   - "Let me continue with the next finding and come back to this" — NO
-   - "I'll research this after the findings loop" — NO
-   - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
-
 
 ### Fix Implementation (Complexity-Based Dispatch)
 
@@ -1351,79 +1312,11 @@ Skills reference this as: "Check all-deps-cancelled — see AGENTS.md Protocol: 
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Coverage Measurement
+### Protocol: Coverage Measurement (summarized)
 
-**Referenced by:** review, pr-check, coderabbit-review, deep-review, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Coverage Measurement`.**
 
-Measure test coverage using Makefile targets with stack-specific fallbacks.
-
-**Run coverage quietly.** Coverage commands are the single biggest source of
-verbose output (N packages × per-file coverage lines). Wrap them with
-`_optimus_quiet_run` (see Protocol: Quiet Command Execution) so the full output
-lands on disk and only a PASS/FAIL line reaches the agent. Then read only the
-"total" summary line to extract the percentage.
-
-**Unit coverage command resolution order:**
-1. `make test-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -coverprofile=coverage-unit.out ./...` (wrapped) then `go tool cover -func=coverage-unit.out`
-   - Node: `npm test -- --coverage` (wrapped)
-   - Python: `pytest --cov=. --cov-report=term` (wrapped)
-
-If no unit coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Integration coverage command resolution order:**
-1. `make test-integration-coverage` (if Makefile target exists), run via `_optimus_quiet_run`
-2. Stack-specific fallback:
-   - Go: `go test -tags=integration -coverprofile=coverage-integration.out ./...` (wrapped) then `go tool cover -func=coverage-integration.out`
-   - Node: `npm run test:integration -- --coverage` (wrapped)
-   - Python: `pytest -m integration --cov=. --cov-report=term` (wrapped)
-
-If no integration coverage command is available, mark as **SKIP** — do not fail the verification.
-
-**Extracting the percentage (agent-visible output):** after the wrapped run, emit
-only the total line. Examples:
-
-```bash
-# Go
-_optimus_quiet_run "make-test-coverage" make test-coverage
-if [ -f coverage-unit.out ]; then
-  go tool cover -func=coverage-unit.out | awk '/^total:/ {print "Unit coverage: " $NF}'
-fi
-
-# Node (Istanbul JSON/text-summary)
-_optimus_quiet_run "npm-test-coverage" npm test -- --coverage
-if [ -f coverage/coverage-summary.json ]; then
-  jq -r '.total.lines.pct | "Unit coverage: \(.)%"' coverage/coverage-summary.json
-fi
-
-# Python (pytest-cov)
-_optimus_quiet_run "pytest-cov" pytest --cov=. --cov-report=term --cov-report=json:coverage.json
-if [ -f coverage.json ]; then
-  jq -r '.totals.percent_covered_display | "Unit coverage: \(.)%"' coverage.json
-fi
-```
-
-The agent sees ~2 lines total (PASS verdict + "Unit coverage: 87.4%"). The full
-per-file breakdown stays in `.optimus/logs/` and in the native coverage files.
-
-**Thresholds:**
-
-| Test Type | Threshold | Verdict if Below |
-|-----------|-----------|-----------------|
-| Unit tests | 85% | NEEDS_FIX / HIGH finding |
-| Integration tests | 70% | NEEDS_FIX / HIGH finding |
-
-**Coverage gap analysis:** When scanning for untested functions/methods (0% coverage),
-read the coverage output file (not the agent turn stdout) — either the native
-`coverage-*.out` / `coverage-summary.json` / `coverage.json` file, or the
-`.optimus/logs/<timestamp>-*-coverage-*.log` file produced by `_optimus_quiet_run`
-(the trailing `-<pid>` segment is part of every helper-produced log filename).
-Flag business-logic functions with 0% as HIGH, infrastructure/generated code with
-0% as SKIP.
-
-Skills reference this as: "Measure coverage — see AGENTS.md Protocol: Coverage Measurement."
-
+**Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
 ### Protocol: Default Branch Refusal (HARD BLOCK)
 
@@ -1601,73 +1494,11 @@ times each stage ran on each task — useful for spotting spec churn and review 
 Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
 
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: PR Title Validation
 

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3281,12 +3281,12 @@ class TestWorktreeLocationConvention:
 # source-of-truth so the marker can't be dropped without flipping a test.
 
 class TestProtocolSummarizeMarker:
-    """Phases 1+2+3 of issue #34: Verify the top-duplicated protocols carry
+    """Phases 1+2+3+4 of issue #34: Verify the top-duplicated protocols carry
     the <!-- inline-mode: summarize --> marker in AGENTS.md."""
 
     # Protocols carrying the standard `### Protocol: <name>` heading.
-    # File Location is a non-`Protocol:` H3 section; tested separately
-    # via test_summarize_marker_present_for_file_location_section.
+    # File Location, Format Validation, and Finding Presentation are
+    # non-`Protocol:` H3 sections; tested separately via dedicated methods.
     SUMMARIZED_PROTOCOLS = [
         # Phase 1:
         "Resolve Main Worktree Path",
@@ -3300,6 +3300,9 @@ class TestProtocolSummarizeMarker:
         # Phase 3:
         "Terminal Identification",
         "Per-Droid Quality Checklists",
+        # Phase 4:
+        "Coverage Measurement",
+        "Notification Hooks",
     ]
 
     def test_summarize_marker_present_for_top_protocols(self):
@@ -3361,5 +3364,57 @@ class TestProtocolSummarizeMarker:
         )
         assert marker_idx < summary_idx, (
             "File Location: marker must come before **Summary:** "
+            f"(marker={marker_idx}, summary={summary_idx})"
+        )
+
+    def test_summarize_marker_present_for_format_validation_section(self):
+        """Phase 4: the `### Format Validation` section (a non-`Protocol:` H3
+        nested under `## optimus-tasks.md Format Specification`) also carries
+        the summarize marker. Same rationale as File Location — the inliner
+        accepts any H2/H3 but the SUMMARIZED_PROTOCOLS list only enumerates
+        `Protocol: <name>` headings, so this section is guarded explicitly."""
+        content = AGENTS_MD.read_text()
+        heading = "### Format Validation"
+        idx = content.find(heading)
+        assert idx >= 0, f"{heading} missing from AGENTS.md"
+        window = content[idx: idx + 1500]
+        marker_idx = window.find("<!-- inline-mode: summarize -->")
+        summary_idx = window.find("**Summary:**")
+        assert marker_idx >= 0, (
+            "Format Validation: missing <!-- inline-mode: summarize --> marker "
+            "(must be placed immediately under the heading)"
+        )
+        assert summary_idx >= 0, (
+            "Format Validation: missing **Summary:** subsection "
+            "(must follow the summarize marker)"
+        )
+        assert marker_idx < summary_idx, (
+            "Format Validation: marker must come before **Summary:** "
+            f"(marker={marker_idx}, summary={summary_idx})"
+        )
+
+    def test_summarize_marker_present_for_finding_presentation_section(self):
+        """Phase 4: the `### Finding Presentation (Unified Model)` section (a
+        non-`Protocol:` H3) also carries the summarize marker. Same rationale
+        as File Location and Format Validation — the inliner accepts any H2/H3
+        but the SUMMARIZED_PROTOCOLS list is keyed by `Protocol: <name>` form,
+        so this section is guarded explicitly."""
+        content = AGENTS_MD.read_text()
+        heading = "### Finding Presentation (Unified Model)"
+        idx = content.find(heading)
+        assert idx >= 0, f"{heading} missing from AGENTS.md"
+        window = content[idx: idx + 1500]
+        marker_idx = window.find("<!-- inline-mode: summarize -->")
+        summary_idx = window.find("**Summary:**")
+        assert marker_idx >= 0, (
+            "Finding Presentation: missing <!-- inline-mode: summarize --> "
+            "marker (must be placed immediately under the heading)"
+        )
+        assert summary_idx >= 0, (
+            "Finding Presentation: missing **Summary:** subsection "
+            "(must follow the summarize marker)"
+        )
+        assert marker_idx < summary_idx, (
+            "Finding Presentation: marker must come before **Summary:** "
             f"(marker={marker_idx}, summary={summary_idx})"
         )

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1071,7 +1071,11 @@ The optimus-tasks.md table only tracks structural data (dependencies, versions, 
 — it does NOT duplicate content from Ring.
 
 
-### Format Validation
+### Format Validation (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Format Validation`.**
+
+**Summary:** 15-rule validation for `<tasksDir>/optimus-tasks.md` enforced at Step 1.0.1 of every stage agent (1-4): format marker `<!-- optimus:tasks-v1 -->` present; `## Versions` table with valid columns; all Version Status values valid (`Ativa`/`Próxima`/`Planejada`/`Backlog`/`Concluída`); exactly one `Ativa`, at most one `Próxima`; tasks table columns correct (Status/Branch live in state.json, NOT here); IDs match `T-NNN`; Tipo ∈ {Feature, Fix, Refactor, Chore, Docs, Test}; Priority ∈ {Alta, Media, Baixa}; Depends resolves to existing task rows; Version cells reference existing version rows; no duplicate IDs; no circular dependencies; no unescaped pipes; empty-table guard. HARD BLOCK on any failure — STOP and suggest `/optimus-import`. See full 15-item enumeration in AGENTS.md.
 
 Every stage agent (1-4) MUST validate the optimus-tasks.md format before operating:
 1. **First line** is `<!-- optimus:tasks-v1 -->` (format marker)
@@ -1098,11 +1102,6 @@ format validation and before task identification. If zero data rows: **STOP** an
 user: "No tasks found in optimus-tasks.md. Use `/optimus-tasks` to create a task or `/optimus-import`
 to import from Ring pre-dev." Do NOT proceed to task identification with an empty table.
 
-**NOTE:** For circular dependency detection (item 13), trace the full dependency chain for
-each task. If any task appears twice in the chain, a cycle exists. Report ALL tasks involved
-in the cycle so the user can fix it with `/optimus-tasks`.
-
-
 ### Protocol: Resolve Main Worktree Path (summarized)
 
 > **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Resolve Main Worktree Path`.**
@@ -1115,73 +1114,11 @@ in the cycle so the user can fix it with `/optimus-tasks`.
 
 **Summary:** Create `${MAIN_WORKTREE}/.optimus/{sessions,reports,logs}/` with `mkdir -p`. Add `# optimus-operational-files` and `# optimus-operational-worktrees` markers to `${MAIN_WORKTREE}/.gitignore` idempotently (grep-anchor before append). Refuse symlinked `.gitignore`. Auto-prune `.optimus/logs/` (30 days, 500 files). See full recipe in AGENTS.md.
 
-### Protocol: Notification Hooks
+### Protocol: Notification Hooks (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Notification Hooks`.**
 
-After writing a status change to state.json, invoke notification hooks if present.
-
-**IMPORTANT — Capture timing:** Read the current status from state.json and store it as
-`OLD_STATUS` BEFORE writing the new status. The sequence is:
-1. Read current status (with guard for missing/empty state.json):
-   ```bash
-   if [ -f "$STATE_FILE" ]; then
-     OLD_STATUS=$(jq -r --arg id "$TASK_ID" '.[$id].status // "Pendente"' "$STATE_FILE" 2>/dev/null)
-     [ -z "$OLD_STATUS" ] && OLD_STATUS="Pendente"
-   else
-     OLD_STATUS="Pendente"
-   fi
-   ```
-2. Write new status to state.json
-3. Invoke hooks with `OLD_STATUS` and new status
-
-**IMPORTANT:** Always quote all arguments and sanitize user-derived values to prevent
-shell injection. Hook scripts MUST NOT pass their arguments to `eval` or shell
-interpretation — treat all arguments as untrusted data.
-
-```bash
-# Sanitize: allow only safe characters. Does NOT allow `.` or `/` (which would
-# enable path-traversal if hook args flow into file paths).
-_optimus_sanitize() { printf '%s' "$1" | tr -cd '[:alnum:][:space:]-_:'; }
-
-# Resolve HOOKS_FILE with an explicit if-elif-else (instead of the fragile
-# `test && echo || (test && echo)` pattern).
-if [ -f ./tasks-hooks.sh ]; then
-  HOOKS_FILE="./tasks-hooks.sh"
-elif [ -f ./docs/tasks-hooks.sh ]; then
-  HOOKS_FILE="./docs/tasks-hooks.sh"
-else
-  HOOKS_FILE=""
-fi
-
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "$(_optimus_sanitize "$event")" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$old_status")" "$(_optimus_sanitize "$new_status")" 2>/dev/null &
-fi
-```
-
-Events and their parameter signatures:
-
-| Event | Parameters | Description |
-|-------|-----------|-------------|
-| `status-change` | `event task_id old_status new_status` | Any status transition |
-| `task-done` | `event task_id old_status "DONE"` | Task marked as done |
-| `task-cancelled` | `event task_id old_status "Cancelado"` | Task cancelled |
-| `task-blocked` | `event task_id current_status reason` | Dependency check failed (4 args — includes reason) |
-
-When a dependency check fails (provide defaults so hook payload is never malformed):
-```bash
-: "${dep_id:=unknown}"
-: "${dep_status:=unknown}"
-if [ -n "$HOOKS_FILE" ] && [ -x "$HOOKS_FILE" ]; then
-  "$HOOKS_FILE" "task-blocked" "$(_optimus_sanitize "$task_id")" "$(_optimus_sanitize "$current_status")" "$(_optimus_sanitize "blocked by $dep_id ($dep_status)")" 2>/dev/null &
-fi
-```
-
-Hooks run in background (`&`) and their failure does NOT block the pipeline.
-If `tasks-hooks.sh` does not exist, hooks are silently skipped.
-
-Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol: Notification Hooks."
-
+**Summary:** Optional hook system: stages emit events (`status-change`, `task-blocked`, `task-done`, `task-cancelled`) by invoking `<repo>/tasks-hooks.sh <event> <task_id> <args...>` (or `<repo>/docs/tasks-hooks.sh`) if the file exists and is executable. Hook receives sanitized args (alphanumeric + space + `-_:` only — does NOT allow `.` or `/` to prevent path-traversal if hook authors interpolate args into file paths). Argument shape: 4 args for `status-change`/`task-done`/`task-cancelled` (`event task_id old_status new_status`); 4 args for `task-blocked` (`event task_id current_status reason`). Hooks run in background (`&`) — failures NEVER block the pipeline. Capture `OLD_STATUS` BEFORE writing the new status. See full event signatures + sanitization recipe in AGENTS.md.
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 


### PR DESCRIPTION
Continues #34 incremental reduction. Phases 1-3 (#45, #46, #47) merged. **Phase 4 hits the natural pause point** — remaining protocols are niche or at-threshold.

## What changed

**4 final protocols marked:**

| Protocol | Consumers | LOC/copy | Saved |
|----------|-----------|----------|-------|
| Coverage Measurement | 5 | 73 | **~365** |
| Notification Hooks | 5 | 67 | **~335** |
| Finding Presentation (Unified Model) | 5 | 66 | **~330** |
| Format Validation | 8 | 31 | **~248** |
| **Phase 4 marginal observed** | | | **−848 LOC** |

## Cumulative impact (Phases 1-4 combined)

| Metric | Phase 1 | Phase 2 | Phase 3 | Phase 4 |
|--------|---------|---------|---------|---------|
| Inlined LOC | 11,740 | 7,537 | 5,740 | **5,209** |
| Marker count | 3 | 7 | 10 | **14** |
| pr-check/SKILL.md | — | 2,500 | 2,417 | **2,311** |
| review | — | — | 2,144 | **1,975** |
| build | — | — | 1,505 | **1,336** |

**Total reduction Phases 1-4:** −8,028 LOC (60% of the original 13,238 inlined LOC).

## Format Validation = non-Protocol heading (Phase 3 precedent)

Like \`File Location\` in Phase 3, \`Format Validation\` is \`### Format Validation\` (not \`### Protocol: X\`). Inliner's marker detection is line-based — works fine. Test infrastructure adds another targeted test (\`test_summarize_marker_present_for_format_validation_section\`).

\`Finding Presentation (Unified Model)\` is \`### Finding Presentation (Unified Model)\` — the parenthetical was tricky for the loop, so it gets the same targeted-test treatment.

## Test infrastructure

- \`SUMMARIZED_PROTOCOLS\` 9 → 11 entries (added Coverage Measurement, Notification Hooks)
- New \`test_summarize_marker_present_for_format_validation_section\`
- New \`test_summarize_marker_present_for_finding_presentation_section\`
- **No existing test required summarize-mode adaptation** — verified by audit. The 4 Phase 4 protocols had no full-body assertions in the test suite.

## Why pause here

Remaining unmarked candidates (sorted by total LOC saved if marked):

| Protocol | Consumers | LOC/copy | Total | Verdict |
|----------|-----------|----------|-------|---------|
| Push Commits (optional) | 4 | 79 | 316 | Borderline |
| Divergence Warning | 4 | 65 | 260 | Borderline |
| TaskSpec Resolution | 5 | 50 | 250 | At-threshold |
| All-Deps-Cancelled Resolution | 5 | 40 | 200 | At-threshold |
| Parse CodeRabbit Review Body | 2 | 133 | 266 | **Niche** (under threshold) |
| Workspace Auto-Navigation | 2 | 127 | 254 | **Niche** |
| Discover Review Droids | 2 | 119 | 238 | **Niche** |

A theoretical Phase 5 targeting the 4 borderline/at-threshold protocols would save ~600 LOC additional — <1/3 the impact of Phase 4. The 2-consumer protocols are tightly coupled to specific skill pairs by design (e.g., Parse CodeRabbit only consumed by pr-check + coderabbit-review) and would be poor summarize candidates.

**Recommendation: stop here.** Issue #34 stays open until full Option C (separate \`optimus-shared-protocols\` plugin with Droid \`dependencies\` field) — that's bottlenecked on harness feature support.

## Test plan

- [x] \`make test\` — 343 passed (+2 new)
- [x] \`make lint\` — clean
- [x] \`make inline-stats\` — sensible
- [x] \`python3 scripts/inline-protocols.py\` — 0 unmatched, idempotent
- [x] Spot-check pr-check/SKILL.md: 2,417 → 2,311
- [ ] CI on this PR

## Stats

24 files changed, **+275 / -1,899** (net **-1,624 lines** removed from SKILL.md + commands surface).