### PR TITLE
feat(inliner): Phase 7 inline-protocol bloat reduction (issue #34)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -503,6 +503,10 @@ Two project-specific conventions on top of the spec:
 
 ### Valid Status Values (stored in state.json)
 
+<!-- inline-mode: summarize -->
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
+
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
 
@@ -797,6 +801,10 @@ and delegates the common logic to these protocols. This avoids duplicating the s
 in every SKILL.md.
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+
+<!-- inline-mode: summarize -->
+
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 **Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
 
@@ -2200,6 +2208,10 @@ Skills reference this as: "Invoke notification hooks — see AGENTS.md Protocol:
 
 ### Protocol: Ring Droid Requirement Check
 
+<!-- inline-mode: summarize -->
+
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
+
 **Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
 
 Before dispatching ring droids, verify the required droids are available. If any required
@@ -2387,6 +2399,10 @@ Resolve the full path to a task's Ring pre-dev spec and its subtasks directory:
 Skills reference this as: "Resolve TaskSpec — see AGENTS.md Protocol: TaskSpec Resolution."
 
 ### Protocol: Project Rules Discovery
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 **Referenced by:** stages 1-4, deep-review, coderabbit-review
 
@@ -2851,6 +2867,10 @@ version name (version names are case-sensitive to match the Versions table).
 Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Default Scope Resolution."
 
 ### Protocol: Active Version Guard
+
+<!-- inline-mode: summarize -->
+
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 **Referenced by:** all stage agents (1-4)
 

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -298,7 +298,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -311,15 +315,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Format Validation (summarized)
 
@@ -439,25 +434,10 @@ Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Prot
 
 **Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -582,7 +582,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -595,15 +599,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 
@@ -692,45 +687,11 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-### Protocol: Active Version Guard
+### Protocol: Active Version Guard (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Active Version Guard`.**
 
-After the task ID is confirmed and dependencies are validated, check if the task belongs
-to the `Ativa` version. If not, present options before proceeding.
-
-1. Read the task's **Version** column from `optimus-tasks.md`
-2. Read the **Versions** table and find the version with Status `Ativa`
-   - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
-3. **If the task's version matches the `Ativa` version** → proceed silently
-4. **If the task's version does NOT match the `Ativa` version** → present via `AskUser`:
-   ```
-   Task T-XXX is in version '<task_version>' (<version_status>),
-   but the active version is '<active_version>'.
-   To execute this task, it must be moved to the active version first.
-   ```
-   Options:
-   - **Move to active version and continue** — updates the Version column to the active version, commits, and proceeds
-   - **Cancel** — stops execution
-
-5. **If "Move to active version and continue":**
-   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
-   - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
-     separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
-     ```bash
-     tasks_git add "$TASKS_GIT_REL"
-     COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-     chmod 600 "$COMMIT_MSG_FILE"
-     printf '%s' "chore(tasks): move T-XXX to active version <active_version>" > "$COMMIT_MSG_FILE"
-     tasks_git commit -F "$COMMIT_MSG_FILE"
-     rm -f "$COMMIT_MSG_FILE"
-     ```
-   - Proceed with the stage
-
-6. **If "Cancel":** **STOP** — do not proceed with the stage
-
-Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
-
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution (summarized)
 
@@ -861,37 +822,11 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Push Commits (optional) (summarized)
 
@@ -905,45 +840,11 @@ Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Pr
 
 **Summary:** `_optimus_quiet_run <label> <command>` redirects stdout+stderr to `${MAIN_WORKTREE}/.optimus/logs/<ts>-<label>-<pid>.log`, emits a single `PASS`/`FAIL` line, and on failure dumps the last 50 lines (with `cat -v` to neutralize ANSI/OSC escape sequences). Uses `umask 0077` on the log file (output may contain credentials/stack traces). Exit code preserved so `if _optimus_quiet_run ...; then ... fi` works. Reserved exit codes: `2` = missing label/command; `3` = cannot create logs dir. Log retention (30-day age cap + 500-file count cap) is pruned at every Initialize Directory + Session State call. Use for verification commands only; never for output the agent must parse turn-by-turn. See full recipe in AGENTS.md.
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 ### Protocol: Session State (summarized)
 
@@ -975,25 +876,10 @@ Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring D
 
 **Summary:** When an Optimus stage skill (build, review, done) is invoked from the default branch (main/master) instead of from the task's linked worktree, automatically detect the correct workspace and navigate there before any mutation. Resolution order: (1) state.json `branch` field for the task; (2) match against `git worktree list` by branch ref; (3) fallback path-segment match by anchored kebab task-ID (`-t-NNN-`); (4) recovery: if branch exists but worktree is missing, create at `${MAIN_WORKTREE}/.worktrees/<branch-name>` per Protocol: Worktree Location. HARD BLOCK on default branch — refuses to mutate from main/master regardless of resolution outcome. See full recipe + Default Branch Refusal cross-reference in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -676,37 +676,11 @@ All cycle review skills follow this pattern:
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Push Commits (optional) (summarized)
 
@@ -720,44 +694,10 @@ Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Pr
 
 **Summary:** `_optimus_quiet_run <label> <command>` redirects stdout+stderr to `${MAIN_WORKTREE}/.optimus/logs/<ts>-<label>-<pid>.log`, emits a single `PASS`/`FAIL` line, and on failure dumps the last 50 lines (with `cat -v` to neutralize ANSI/OSC escape sequences). Uses `umask 0077` on the log file (output may contain credentials/stack traces). Exit code preserved so `if _optimus_quiet_run ...; then ... fi` works. Reserved exit codes: `2` = missing label/command; `3` = cannot create logs dir. Log retention (30-day age cap + 500-file count cap) is pruned at every Initialize Directory + Session State call. Use for verification commands only; never for output the agent must parse turn-by-turn. See full recipe in AGENTS.md.
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -254,7 +254,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -267,15 +271,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Format Validation (summarized)
 
@@ -395,25 +390,10 @@ Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Prot
 
 **Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus:import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus:import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/build.md
+++ b/commands/build.md
@@ -520,7 +520,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -533,15 +537,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 
@@ -630,45 +625,11 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-### Protocol: Active Version Guard
+### Protocol: Active Version Guard (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Active Version Guard`.**
 
-After the task ID is confirmed and dependencies are validated, check if the task belongs
-to the `Ativa` version. If not, present options before proceeding.
-
-1. Read the task's **Version** column from `optimus-tasks.md`
-2. Read the **Versions** table and find the version with Status `Ativa`
-   - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus:tasks` to set a version as Ativa before proceeding."
-3. **If the task's version matches the `Ativa` version** → proceed silently
-4. **If the task's version does NOT match the `Ativa` version** → present via `AskUser`:
-   ```
-   Task T-XXX is in version '<task_version>' (<version_status>),
-   but the active version is '<active_version>'.
-   To execute this task, it must be moved to the active version first.
-   ```
-   Options:
-   - **Move to active version and continue** — updates the Version column to the active version, commits, and proceeds
-   - **Cancel** — stops execution
-
-5. **If "Move to active version and continue":**
-   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
-   - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
-     separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
-     ```bash
-     tasks_git add "$TASKS_GIT_REL"
-     COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-     chmod 600 "$COMMIT_MSG_FILE"
-     printf '%s' "chore(tasks): move T-XXX to active version <active_version>" > "$COMMIT_MSG_FILE"
-     tasks_git commit -F "$COMMIT_MSG_FILE"
-     rm -f "$COMMIT_MSG_FILE"
-     ```
-   - Proceed with the stage
-
-6. **If "Cancel":** **STOP** — do not proceed with the stage
-
-Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
-
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution (summarized)
 
@@ -799,37 +760,11 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Push Commits (optional) (summarized)
 
@@ -843,45 +778,11 @@ Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Pr
 
 **Summary:** `_optimus_quiet_run <label> <command>` redirects stdout+stderr to `${MAIN_WORKTREE}/.optimus/logs/<ts>-<label>-<pid>.log`, emits a single `PASS`/`FAIL` line, and on failure dumps the last 50 lines (with `cat -v` to neutralize ANSI/OSC escape sequences). Uses `umask 0077` on the log file (output may contain credentials/stack traces). Exit code preserved so `if _optimus_quiet_run ...; then ... fi` works. Reserved exit codes: `2` = missing label/command; `3` = cannot create logs dir. Log retention (30-day age cap + 500-file count cap) is pruned at every Initialize Directory + Session State call. Use for verification commands only; never for output the agent must parse turn-by-turn. See full recipe in AGENTS.md.
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 ### Protocol: Session State (summarized)
 
@@ -913,25 +814,10 @@ Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring D
 
 **Summary:** When an Optimus stage skill (build, review, done) is invoked from the default branch (main/master) instead of from the task's linked worktree, automatically detect the correct workspace and navigate there before any mutation. Resolution order: (1) state.json `branch` field for the task; (2) match against `git worktree list` by branch ref; (3) fallback path-segment match by anchored kebab task-ID (`-t-NNN-`); (4) recovery: if branch exists but worktree is missing, create at `${MAIN_WORKTREE}/.worktrees/<branch-name>` per Protocol: Worktree Location. HARD BLOCK on default branch — refuses to mutate from main/master regardless of resolution outcome. See full recipe + Default Branch Refusal cross-reference in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus:import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus:import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -619,37 +619,11 @@ All cycle review skills follow this pattern:
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Push Commits (optional) (summarized)
 
@@ -663,44 +637,10 @@ Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Pr
 
 **Summary:** `_optimus_quiet_run <label> <command>` redirects stdout+stderr to `${MAIN_WORKTREE}/.optimus/logs/<ts>-<label>-<pid>.log`, emits a single `PASS`/`FAIL` line, and on failure dumps the last 50 lines (with `cat -v` to neutralize ANSI/OSC escape sequences). Uses `umask 0077` on the log file (output may contain credentials/stack traces). Exit code preserved so `if _optimus_quiet_run ...; then ... fi` works. Reserved exit codes: `2` = missing label/command; `3` = cannot create logs dir. Log retention (30-day age cap + 500-file count cap) is pruned at every Initialize Directory + Session State call. Use for verification commands only; never for output the agent must parse turn-by-turn. See full recipe in AGENTS.md.
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/deep-doc-review.md
+++ b/commands/deep-doc-review.md
@@ -318,44 +318,10 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -559,37 +559,11 @@ All cycle review skills follow this pattern:
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Quiet Command Execution (summarized)
 

--- a/commands/done.md
+++ b/commands/done.md
@@ -525,7 +525,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -538,15 +542,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Format Validation (summarized)
 
@@ -585,45 +580,11 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves `TASKS_DIR` (from `.optimus/config.json` `tasksDir` key, default `docs/pre-dev`) and `TASKS_FILE` (`<tasksDir>/optimus:tasks.md`), then detects whether tasksDir lives inside the project repo (`same-repo`) or a separate git repo (`separate-repo`). Sets `TASKS_REPO_ROOT`, `TASKS_GIT_REL`, `TASKS_DEFAULT_BRANCH`, and exposes a `tasks_git()` helper that wraps `git -C "$TASKS_DIR"` in separate-repo mode. Hard guards: reject `tasksDir` starting with `-` (git-option injection), require `python3` for separate-repo path computation, validate `TASKS_DEFAULT_BRANCH` against `^[a-zA-Z0-9._/-]+$`. Skills MUST use `tasks_git` (never raw `git`) on `$TASKS_FILE`. See full recipe in AGENTS.md.
 
-### Protocol: Active Version Guard
+### Protocol: Active Version Guard (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Active Version Guard`.**
 
-After the task ID is confirmed and dependencies are validated, check if the task belongs
-to the `Ativa` version. If not, present options before proceeding.
-
-1. Read the task's **Version** column from `optimus-tasks.md`
-2. Read the **Versions** table and find the version with Status `Ativa`
-   - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus:tasks` to set a version as Ativa before proceeding."
-3. **If the task's version matches the `Ativa` version** → proceed silently
-4. **If the task's version does NOT match the `Ativa` version** → present via `AskUser`:
-   ```
-   Task T-XXX is in version '<task_version>' (<version_status>),
-   but the active version is '<active_version>'.
-   To execute this task, it must be moved to the active version first.
-   ```
-   Options:
-   - **Move to active version and continue** — updates the Version column to the active version, commits, and proceeds
-   - **Cancel** — stops execution
-
-5. **If "Move to active version and continue":**
-   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
-   - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
-     separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
-     ```bash
-     tasks_git add "$TASKS_GIT_REL"
-     COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-     chmod 600 "$COMMIT_MSG_FILE"
-     printf '%s' "chore(tasks): move T-XXX to active version <active_version>" > "$COMMIT_MSG_FILE"
-     tasks_git commit -F "$COMMIT_MSG_FILE"
-     rm -f "$COMMIT_MSG_FILE"
-     ```
-   - Proceed with the stage
-
-6. **If "Cancel":** **STOP** — do not proceed with the stage
-
-Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
-
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution (summarized)
 
@@ -793,25 +754,10 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 
 **Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus:import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus:import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/import.md
+++ b/commands/import.md
@@ -465,7 +465,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -478,15 +482,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -881,7 +881,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -894,15 +898,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 
@@ -1025,45 +1020,11 @@ Every finding must present 2-3 options with this structure:
 - **Very high:** Architectural change, many files, extensive testing, risk of regressions
 
 
-### Protocol: Active Version Guard
+### Protocol: Active Version Guard (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Active Version Guard`.**
 
-After the task ID is confirmed and dependencies are validated, check if the task belongs
-to the `Ativa` version. If not, present options before proceeding.
-
-1. Read the task's **Version** column from `optimus-tasks.md`
-2. Read the **Versions** table and find the version with Status `Ativa`
-   - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus:tasks` to set a version as Ativa before proceeding."
-3. **If the task's version matches the `Ativa` version** → proceed silently
-4. **If the task's version does NOT match the `Ativa` version** → present via `AskUser`:
-   ```
-   Task T-XXX is in version '<task_version>' (<version_status>),
-   but the active version is '<active_version>'.
-   To execute this task, it must be moved to the active version first.
-   ```
-   Options:
-   - **Move to active version and continue** — updates the Version column to the active version, commits, and proceeds
-   - **Cancel** — stops execution
-
-5. **If "Move to active version and continue":**
-   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
-   - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
-     separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
-     ```bash
-     tasks_git add "$TASKS_GIT_REL"
-     COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-     chmod 600 "$COMMIT_MSG_FILE"
-     printf '%s' "chore(tasks): move T-XXX to active version <active_version>" > "$COMMIT_MSG_FILE"
-     tasks_git commit -F "$COMMIT_MSG_FILE"
-     rm -f "$COMMIT_MSG_FILE"
-     ```
-   - Proceed with the stage
-
-6. **If "Cancel":** **STOP** — do not proceed with the stage
-
-Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
-
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution (summarized)
 
@@ -1220,37 +1181,11 @@ Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Inc
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Push Commits (optional) (summarized)
 
@@ -1334,45 +1269,11 @@ Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-r
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 ### Protocol: Session State (summarized)
 
@@ -1480,25 +1381,10 @@ Optimus creates linked git worktrees during the task lifecycle:
 Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus:import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus:import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -1950,37 +1950,11 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Quiet Command Execution (summarized)
 

--- a/commands/quick-report.md
+++ b/commands/quick-report.md
@@ -246,7 +246,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -259,15 +263,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Protocol: Resolve Main Worktree Path (summarized)
 

--- a/commands/report.md
+++ b/commands/report.md
@@ -678,7 +678,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -691,15 +695,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Protocol: Resolve Main Worktree Path (summarized)
 

--- a/commands/resolve.md
+++ b/commands/resolve.md
@@ -282,25 +282,10 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves `TASKS_DIR` (from `.optimus/config.json` `tasksDir` key, default `docs/pre-dev`) and `TASKS_FILE` (`<tasksDir>/optimus:tasks.md`), then detects whether tasksDir lives inside the project repo (`same-repo`) or a separate git repo (`separate-repo`). Sets `TASKS_REPO_ROOT`, `TASKS_GIT_REL`, `TASKS_DEFAULT_BRANCH`, and exposes a `tasks_git()` helper that wraps `git -C "$TASKS_DIR"` in separate-repo mode. Hard guards: reject `tasksDir` starting with `-` (git-option injection), require `python3` for separate-repo path computation, validate `TASKS_DEFAULT_BRANCH` against `^[a-zA-Z0-9._/-]+$`. Skills MUST use `tasks_git` (never raw `git`) on `$TASKS_FILE`. See full recipe in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus:import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus:import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -823,25 +823,10 @@ Optimus creates linked git worktrees during the task lifecycle:
 Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus:import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus:import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/review.md
+++ b/commands/review.md
@@ -931,7 +931,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -944,15 +948,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 
@@ -1160,45 +1155,11 @@ required droids are not installed and a complex fix is needed, the skill MUST st
 inform the user which droids need to be installed.
 
 
-### Protocol: Active Version Guard
+### Protocol: Active Version Guard (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Active Version Guard`.**
 
-After the task ID is confirmed and dependencies are validated, check if the task belongs
-to the `Ativa` version. If not, present options before proceeding.
-
-1. Read the task's **Version** column from `optimus-tasks.md`
-2. Read the **Versions** table and find the version with Status `Ativa`
-   - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus:tasks` to set a version as Ativa before proceeding."
-3. **If the task's version matches the `Ativa` version** → proceed silently
-4. **If the task's version does NOT match the `Ativa` version** → present via `AskUser`:
-   ```
-   Task T-XXX is in version '<task_version>' (<version_status>),
-   but the active version is '<active_version>'.
-   To execute this task, it must be moved to the active version first.
-   ```
-   Options:
-   - **Move to active version and continue** — updates the Version column to the active version, commits, and proceeds
-   - **Cancel** — stops execution
-
-5. **If "Move to active version and continue":**
-   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
-   - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
-     separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
-     ```bash
-     tasks_git add "$TASKS_GIT_REL"
-     COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-     chmod 600 "$COMMIT_MSG_FILE"
-     printf '%s' "chore(tasks): move T-XXX to active version <active_version>" > "$COMMIT_MSG_FILE"
-     tasks_git commit -F "$COMMIT_MSG_FILE"
-     rm -f "$COMMIT_MSG_FILE"
-     ```
-   - Proceed with the stage
-
-6. **If "Cancel":** **STOP** — do not proceed with the stage
-
-Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
-
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution (summarized)
 
@@ -1365,37 +1326,11 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Push Commits (optional) (summarized)
 
@@ -1479,45 +1414,11 @@ applied fixes are correct and checks for any issues introduced by the fixes.
 Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
 
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 ### Protocol: Session State (summarized)
 
@@ -1549,25 +1450,10 @@ Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring D
 
 **Summary:** When an Optimus stage skill (build, review, done) is invoked from the default branch (main/master) instead of from the task's linked worktree, automatically detect the correct workspace and navigate there before any mutation. Resolution order: (1) state.json `branch` field for the task; (2) match against `git worktree list` by branch ref; (3) fallback path-segment match by anchored kebab task-ID (`-t-NNN-`); (4) recovery: if branch exists but worktree is missing, create at `${MAIN_WORKTREE}/.worktrees/<branch-name>` per Protocol: Worktree Location. HARD BLOCK on default branch — refuses to mutate from main/master regardless of resolution outcome. See full recipe + Default Branch Refusal cross-reference in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus:import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus:import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -981,7 +981,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -994,15 +998,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 
@@ -1086,25 +1081,10 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves the full path to a task's Ring pre-dev spec file by combining `<TASKS_DIR>` with the task's `TaskSpec` column from `optimus-tasks.md`. If `TaskSpec` is `-`, STOPs with a hint to run `/optimus:plan T-XXX`. HARD BLOCK on path traversal: resolves via `realpath -m` (or python3 `os.path.realpath` fallback) and rejects any result outside `$TASKS_DIR_ABS`. Also rejects symlinks (TOCTOU defence: realpath dereferences transparently, so a post-`-L` check guarantees no symlink in the final path). `TASKS_DIR` itself must be a valid git repo (enforced upstream by Resolve Tasks Git Scope) but is no longer required to live under `PROJECT_ROOT` — separate-repo scope is supported. Subtasks live at `<TASKS_DIR>/subtasks/T-NNN/`. See full recipe in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus:import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus:import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus:import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus:import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/deep-doc-review/skills/optimus-deep-doc-review/SKILL.md
+++ b/deep-doc-review/skills/optimus-deep-doc-review/SKILL.md
@@ -366,44 +366,10 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 **Summary:** Multi-round review pattern for plan, build, review, pr-check, coderabbit-review, deep-review, deep-doc-review. Round 1 is mandatory (the skill's primary dispatch). Rounds 2-5 are gated behind explicit `AskUser` prompts (entry gate before round 2, per-round gate before 3/4/5). Each gated round dispatches the SAME droid roster as round 1 in parallel via `Task` tool with zero prior context — agents read files fresh from disk. Convergence detection (zero new findings, strict `same file + ±5 lines + same category` matching) exits silently with status `CONVERGED` — never asks for another round. Hard limit at round 5. Exit statuses: `CONVERGED`, `USER_STOPPED`, `SKIPPED`, `HARD_LIMIT`, `DISPATCH_FAILED_ABORTED` (build has a single-slot carve-out). See full recipe in AGENTS.md.
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -610,37 +610,11 @@ All cycle review skills follow this pattern:
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Quiet Command Execution (summarized)
 

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -568,7 +568,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -581,15 +585,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Format Validation (summarized)
 
@@ -628,45 +623,11 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves `TASKS_DIR` (from `.optimus/config.json` `tasksDir` key, default `docs/pre-dev`) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then detects whether tasksDir lives inside the project repo (`same-repo`) or a separate git repo (`separate-repo`). Sets `TASKS_REPO_ROOT`, `TASKS_GIT_REL`, `TASKS_DEFAULT_BRANCH`, and exposes a `tasks_git()` helper that wraps `git -C "$TASKS_DIR"` in separate-repo mode. Hard guards: reject `tasksDir` starting with `-` (git-option injection), require `python3` for separate-repo path computation, validate `TASKS_DEFAULT_BRANCH` against `^[a-zA-Z0-9._/-]+$`. Skills MUST use `tasks_git` (never raw `git`) on `$TASKS_FILE`. See full recipe in AGENTS.md.
 
-### Protocol: Active Version Guard
+### Protocol: Active Version Guard (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Active Version Guard`.**
 
-After the task ID is confirmed and dependencies are validated, check if the task belongs
-to the `Ativa` version. If not, present options before proceeding.
-
-1. Read the task's **Version** column from `optimus-tasks.md`
-2. Read the **Versions** table and find the version with Status `Ativa`
-   - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
-3. **If the task's version matches the `Ativa` version** → proceed silently
-4. **If the task's version does NOT match the `Ativa` version** → present via `AskUser`:
-   ```
-   Task T-XXX is in version '<task_version>' (<version_status>),
-   but the active version is '<active_version>'.
-   To execute this task, it must be moved to the active version first.
-   ```
-   Options:
-   - **Move to active version and continue** — updates the Version column to the active version, commits, and proceeds
-   - **Cancel** — stops execution
-
-5. **If "Move to active version and continue":**
-   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
-   - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
-     separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
-     ```bash
-     tasks_git add "$TASKS_GIT_REL"
-     COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-     chmod 600 "$COMMIT_MSG_FILE"
-     printf '%s' "chore(tasks): move T-XXX to active version <active_version>" > "$COMMIT_MSG_FILE"
-     tasks_git commit -F "$COMMIT_MSG_FILE"
-     rm -f "$COMMIT_MSG_FILE"
-     ```
-   - Proceed with the stage
-
-6. **If "Cancel":** **STOP** — do not proceed with the stage
-
-Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
-
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution (summarized)
 
@@ -836,25 +797,10 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 
 **Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -513,7 +513,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -526,15 +530,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -942,7 +942,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -955,15 +959,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 
@@ -1086,45 +1081,11 @@ Every finding must present 2-3 options with this structure:
 - **Very high:** Architectural change, many files, extensive testing, risk of regressions
 
 
-### Protocol: Active Version Guard
+### Protocol: Active Version Guard (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Active Version Guard`.**
 
-After the task ID is confirmed and dependencies are validated, check if the task belongs
-to the `Ativa` version. If not, present options before proceeding.
-
-1. Read the task's **Version** column from `optimus-tasks.md`
-2. Read the **Versions** table and find the version with Status `Ativa`
-   - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
-3. **If the task's version matches the `Ativa` version** → proceed silently
-4. **If the task's version does NOT match the `Ativa` version** → present via `AskUser`:
-   ```
-   Task T-XXX is in version '<task_version>' (<version_status>),
-   but the active version is '<active_version>'.
-   To execute this task, it must be moved to the active version first.
-   ```
-   Options:
-   - **Move to active version and continue** — updates the Version column to the active version, commits, and proceeds
-   - **Cancel** — stops execution
-
-5. **If "Move to active version and continue":**
-   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
-   - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
-     separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
-     ```bash
-     tasks_git add "$TASKS_GIT_REL"
-     COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-     chmod 600 "$COMMIT_MSG_FILE"
-     printf '%s' "chore(tasks): move T-XXX to active version <active_version>" > "$COMMIT_MSG_FILE"
-     tasks_git commit -F "$COMMIT_MSG_FILE"
-     rm -f "$COMMIT_MSG_FILE"
-     ```
-   - Proceed with the stage
-
-6. **If "Cancel":** **STOP** — do not proceed with the stage
-
-Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
-
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution (summarized)
 
@@ -1281,37 +1242,11 @@ Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Inc
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Push Commits (optional) (summarized)
 
@@ -1395,45 +1330,11 @@ Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-r
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 ### Protocol: Session State (summarized)
 
@@ -1541,25 +1442,10 @@ Optimus creates linked git worktrees during the task lifecycle:
 Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -2022,37 +2022,11 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Quiet Command Execution (summarized)
 

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -284,7 +284,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -297,15 +301,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Protocol: Resolve Main Worktree Path (summarized)
 

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -723,7 +723,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -736,15 +740,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Protocol: Resolve Main Worktree Path (summarized)
 

--- a/resolve/skills/optimus-resolve/SKILL.md
+++ b/resolve/skills/optimus-resolve/SKILL.md
@@ -321,25 +321,10 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves `TASKS_DIR` (from `.optimus/config.json` `tasksDir` key, default `docs/pre-dev`) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then detects whether tasksDir lives inside the project repo (`same-repo`) or a separate git repo (`separate-repo`). Sets `TASKS_REPO_ROOT`, `TASKS_GIT_REL`, `TASKS_DEFAULT_BRANCH`, and exposes a `tasks_git()` helper that wraps `git -C "$TASKS_DIR"` in separate-repo mode. Hard guards: reject `tasksDir` starting with `-` (git-option injection), require `python3` for separate-repo path computation, validate `TASKS_DEFAULT_BRANCH` against `^[a-zA-Z0-9._/-]+$`. Skills MUST use `tasks_git` (never raw `git`) on `$TASKS_FILE`. See full recipe in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -882,25 +882,10 @@ Optimus creates linked git worktrees during the task lifecycle:
 Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -996,7 +996,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -1009,15 +1013,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 
@@ -1225,45 +1220,11 @@ required droids are not installed and a complex fix is needed, the skill MUST st
 inform the user which droids need to be installed.
 
 
-### Protocol: Active Version Guard
+### Protocol: Active Version Guard (summarized)
 
-**Referenced by:** all stage agents (1-4)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Active Version Guard`.**
 
-After the task ID is confirmed and dependencies are validated, check if the task belongs
-to the `Ativa` version. If not, present options before proceeding.
-
-1. Read the task's **Version** column from `optimus-tasks.md`
-2. Read the **Versions** table and find the version with Status `Ativa`
-   - **If no version has Status `Ativa`** → **STOP**: "No active version found in the Versions table. Run `/optimus-tasks` to set a version as Ativa before proceeding."
-3. **If the task's version matches the `Ativa` version** → proceed silently
-4. **If the task's version does NOT match the `Ativa` version** → present via `AskUser`:
-   ```
-   Task T-XXX is in version '<task_version>' (<version_status>),
-   but the active version is '<active_version>'.
-   To execute this task, it must be moved to the active version first.
-   ```
-   Options:
-   - **Move to active version and continue** — updates the Version column to the active version, commits, and proceeds
-   - **Cancel** — stops execution
-
-5. **If "Move to active version and continue":**
-   - Update the task's Version column in `optimus-tasks.md` to the `Ativa` version name
-   - Commit using `tasks_git` so the change lands in the correct repo (same-repo or
-     separate-repo, as resolved by Protocol: Resolve Tasks Git Scope):
-     ```bash
-     tasks_git add "$TASKS_GIT_REL"
-     COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }
-     chmod 600 "$COMMIT_MSG_FILE"
-     printf '%s' "chore(tasks): move T-XXX to active version <active_version>" > "$COMMIT_MSG_FILE"
-     tasks_git commit -F "$COMMIT_MSG_FILE"
-     rm -f "$COMMIT_MSG_FILE"
-     ```
-   - Proceed with the stage
-
-6. **If "Cancel":** **STOP** — do not proceed with the stage
-
-Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
-
+**Summary:** After task ID/deps confirmed, check the task's Version against the Versions table. If no version is `Ativa` → STOP. If task version matches `Ativa` → proceed silently. Otherwise present `AskUser` with two options: "Move to active version and continue" (updates Version column, commits via `tasks_git`) or "Cancel" (STOP). HARD BLOCK forces explicit version transition before mutating optimus-tasks.md. See full commit recipe in AGENTS.md.
 
 ### Protocol: All-Dependencies-Cancelled Resolution (summarized)
 
@@ -1430,37 +1391,11 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 **Summary:** Per-droid quality dimensions that review/pr-check/deep-review/coderabbit-review/plan/build skills MUST include in their agent prompts beyond the core review domain. Examples: code-reviewer adds resilience/concurrency/cognitive-complexity/error-handling checks; security-reviewer adds PII/error-response-leakage/rate-limiting/secrets; test-reviewer adds effectiveness/false-positive-risk/spec-traceability; nil-safety adds channel/map/slice safety; consequences adds backward-compat/migration-path/event-contract; dead-code adds zombie test infrastructure and stale feature flags; qa-analyst adds testability/operational-readiness; frontend adds UX states/accessibility/i18n; backend adds graceful-shutdown/context-propagation/structured-logging. Skills reference this when building specialist droid prompts so agents review uniformly. See full per-droid lists in AGENTS.md.
 
-### Protocol: Project Rules Discovery
+### Protocol: Project Rules Discovery (summarized)
 
-**Referenced by:** stages 1-4, deep-review, coderabbit-review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Project Rules Discovery`.**
 
-Every skill that reviews, validates, or generates code MUST search for project rules
-and AI instruction files before starting. Search for these files in order and read ALL
-that exist:
-
-```
-AGENTS.md                    # Primary agent instructions
-CLAUDE.md                    # Claude-specific rules
-DROIDS.md                    # Droid-specific rules
-.cursorrules                 # Cursor-specific rules
-PROJECT_RULES.md             # Coding standards (root or docs/)
-docs/PROJECT_RULES.md
-.editorconfig                # Editor formatting rules
-docs/coding-standards.md     # Explicit coding conventions
-docs/conventions.md
-.github/CONTRIBUTING.md      # Contribution guidelines
-CONTRIBUTING.md
-.eslintrc*                   # Linter configs (implicit rules)
-biome.json
-.golangci.yml
-.prettierrc*
-```
-
-If NONE exist, warn the user. If any are found, they become the source of truth
-for coding standards and must be passed to every dispatched sub-agent.
-
-Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Project Rules Discovery."
-
+**Summary:** Every reviewing/validating/generating skill MUST scan for project conventions before starting. Search the canonical list (AGENTS.md, CLAUDE.md, DROIDS.md, .cursorrules, PROJECT_RULES.md, .editorconfig, coding-standards.md, CONTRIBUTING.md, linter configs like .eslintrc/biome.json/.golangci.yml/.prettierrc) and read ALL that exist. If none exist, warn the user. Discovered files become the authoritative source of truth and MUST be passed to every dispatched sub-agent. See full file list in AGENTS.md.
 
 ### Protocol: Push Commits (optional) (summarized)
 
@@ -1544,45 +1479,11 @@ applied fixes are correct and checks for any issues introduced by the fixes.
 Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
 
 
-### Protocol: Ring Droid Requirement Check
+### Protocol: Ring Droid Requirement Check (summarized)
 
-**Referenced by:** review, deep-doc-review, coderabbit-review, plan, build
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Ring Droid Requirement Check`.**
 
-Before dispatching ring droids, verify the required droids are available. If any required
-droid is not installed, **STOP** and list missing droids.
-
-**Core review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-code-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-default-ring-test-reviewer`
-
-**Extended review droids** (required by review, pr-check, deep-review, coderabbit-review):
-- `ring-default-ring-nil-safety-reviewer`
-- `ring-default-ring-consequences-reviewer`
-- `ring-default-ring-dead-code-reviewer`
-
-**QA droids** (required by review, deep-review, build):
-- `ring-dev-team-qa-analyst`
-
-**Documentation droids** (required by deep-doc-review):
-- `ring-tw-team-docs-reviewer`
-- `ring-default-business-logic-reviewer`
-- `ring-default-code-reviewer`
-
-**Implementation droids** (required by build):
-- `ring-dev-team-backend-engineer-golang` (Go)
-- `ring-dev-team-backend-engineer-typescript` (TypeScript)
-- `ring-dev-team-frontend-engineer` (React/Next.js)
-
-**Spec validation droids** (required by plan):
-- `ring-default-business-logic-reviewer`
-- `ring-default-security-reviewer`
-- `ring-dev-team-qa-analyst`
-- `ring-default-code-reviewer`
-
-Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring Droid Requirement Check."
-
+**Summary:** Before dispatching, verify required ring droids are installed; if any missing, STOP and list them. Roster requirements vary by skill: Core review (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`, `ring-test-reviewer`); Extended review (`nil-safety-reviewer`, `consequences-reviewer`, `dead-code-reviewer`); QA (`qa-analyst`); Docs (`docs-reviewer`); Implementation (`backend-engineer-golang`/`-typescript`, `frontend-engineer`); Spec validation droids for plan. See full per-skill roster in AGENTS.md.
 
 ### Protocol: Session State (summarized)
 
@@ -1614,25 +1515,10 @@ Skills reference this as: "Verify ring droids — see AGENTS.md Protocol: Ring D
 
 **Summary:** When an Optimus stage skill (build, review, done) is invoked from the default branch (main/master) instead of from the task's linked worktree, automatically detect the correct workspace and navigate there before any mutation. Resolution order: (1) state.json `branch` field for the task; (2) match against `git worktree list` by branch ref; (3) fallback path-segment match by anchored kebab task-ID (`-t-NNN-`); (4) recovery: if branch exists but worktree is missing, create at `${MAIN_WORKTREE}/.worktrees/<branch-name>` per Protocol: Worktree Location. HARD BLOCK on default branch — refuses to mutate from main/master regardless of resolution outcome. See full recipe + Default Branch Refusal cross-reference in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3281,12 +3281,13 @@ class TestWorktreeLocationConvention:
 # source-of-truth so the marker can't be dropped without flipping a test.
 
 class TestProtocolSummarizeMarker:
-    """Phases 1+2+3+4+5 of issue #34: Verify the top-duplicated protocols carry
-    the <!-- inline-mode: summarize --> marker in AGENTS.md."""
+    """Phases 1+2+3+4+5+6+7 of issue #34: Verify the top-duplicated protocols
+    carry the <!-- inline-mode: summarize --> marker in AGENTS.md."""
 
     # Protocols carrying the standard `### Protocol: <name>` heading.
-    # File Location, Format Validation, and Finding Presentation are
-    # non-`Protocol:` H3 sections; tested separately via dedicated methods.
+    # File Location, Format Validation, Finding Presentation, and Valid
+    # Status Values are non-`Protocol:` H3 sections; tested separately via
+    # dedicated methods.
     SUMMARIZED_PROTOCOLS = [
         # Phase 1:
         "Resolve Main Worktree Path",
@@ -3312,6 +3313,11 @@ class TestProtocolSummarizeMarker:
         "Workspace Auto-Navigation (HARD BLOCK)",
         "Discover Review Droids",
         "Parse CodeRabbit Review Body",
+        # Phase 7:
+        "optimus-tasks.md Validation (HARD BLOCK)",
+        "Project Rules Discovery",
+        "Ring Droid Requirement Check",
+        "Active Version Guard",
     ]
 
     def test_summarize_marker_present_for_top_protocols(self):
@@ -3425,5 +3431,32 @@ class TestProtocolSummarizeMarker:
         )
         assert marker_idx < summary_idx, (
             "Finding Presentation: marker must come before **Summary:** "
+            f"(marker={marker_idx}, summary={summary_idx})"
+        )
+
+    def test_summarize_marker_present_for_valid_status_values_section(self):
+        """Phase 7: the `### Valid Status Values (stored in state.json)`
+        section (a non-`Protocol:` H3 nested under the Status section) also
+        carries the summarize marker. Same rationale as File Location, Format
+        Validation, and Finding Presentation — the inliner accepts any H2/H3
+        but the SUMMARIZED_PROTOCOLS list is keyed by `Protocol: <name>` form,
+        so this section is guarded explicitly."""
+        content = AGENTS_MD.read_text()
+        heading = "### Valid Status Values (stored in state.json)"
+        idx = content.find(heading)
+        assert idx >= 0, f"{heading} missing from AGENTS.md"
+        window = content[idx: idx + 1500]
+        marker_idx = window.find("<!-- inline-mode: summarize -->")
+        summary_idx = window.find("**Summary:**")
+        assert marker_idx >= 0, (
+            "Valid Status Values: missing <!-- inline-mode: summarize --> "
+            "marker (must be placed immediately under the heading)"
+        )
+        assert summary_idx >= 0, (
+            "Valid Status Values: missing **Summary:** subsection "
+            "(must follow the summarize marker)"
+        )
+        assert marker_idx < summary_idx, (
+            "Valid Status Values: marker must come before **Summary:** "
             f"(marker={marker_idx}, summary={summary_idx})"
         )

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -1033,7 +1033,11 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 Optimus splits its files into two trees:
 
-### Valid Status Values (stored in state.json)
+### Valid Status Values (stored in state.json) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Valid Status Values (stored in state.json)`.**
+
+**Summary:** state.json status values: `Pendente` (implicit, no entry), `Validando Spec` (plan), `Em Andamento` (build), `Validando Impl` (review), `DONE` (done), `Cancelado` (tasks/done). Administrative ops (Reopen, Advance, Demote, Cancel) require explicit user confirmation. See full table + transitions in AGENTS.md.
 
 Status lives in `.optimus/state.json`, NOT in optimus-tasks.md. A task with no entry in
 state.json is implicitly `Pendente`.
@@ -1046,15 +1050,6 @@ state.json is implicitly `Pendente`.
 | `Validando Impl` | review | Implementation being reviewed |
 | `DONE` | done | Completed |
 | `Cancelado` | tasks, done | Task abandoned, will not be implemented |
-
-**Administrative status operations** (managed by tasks, not by stage agents):
-- **Reopen:** `DONE` → `Pendente` (remove entry from state.json) or `Em Andamento` (if worktree exists) — when a bug is found after close. Also accepts `Cancelado` → `Pendente` — when a cancellation decision is reversed.
-- **Advance:** move forward one stage — when work was done manually outside the pipeline
-- **Demote:** move backward one stage — when rework is needed after review
-- **Cancel:** any non-terminal → `Cancelado` — task will not be implemented
-
-These operations require explicit user confirmation.
-
 
 ### Task Spec Resolution
 
@@ -1138,25 +1133,10 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves the full path to a task's Ring pre-dev spec file by combining `<TASKS_DIR>` with the task's `TaskSpec` column from `optimus-tasks.md`. If `TaskSpec` is `-`, STOPs with a hint to run `/optimus-plan T-XXX`. HARD BLOCK on path traversal: resolves via `realpath -m` (or python3 `os.path.realpath` fallback) and rejects any result outside `$TASKS_DIR_ABS`. Also rejects symlinks (TOCTOU defence: realpath dereferences transparently, so a post-`-L` check guarantees no symlink in the final path). `TASKS_DIR` itself must be a valid git repo (enforced upstream by Resolve Tasks Git Scope) but is no longer required to live under `PROJECT_ROOT` — separate-repo scope is supported. Subtasks live at `<TASKS_DIR>/subtasks/T-NNN/`. See full recipe in AGENTS.md.
 
-### Protocol: optimus-tasks.md Validation (HARD BLOCK)
+### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 
-**Referenced by:** all stage agents (1-4), tasks, batch. Note: resolve performs inline format validation in its own Step 4.2.
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: optimus-tasks.md Validation (HARD BLOCK)`.**
 
-Every stage agent MUST validate optimus-tasks.md before operating. The full validation rules are
-defined in the "Format Validation" section above (items 1-15). This protocol is the
-executable version:
-
-1. **Resolve paths and git scope:** Execute Protocol: Resolve Tasks Git Scope (below) to
-   resolve `TASKS_DIR`, `TASKS_FILE`, `TASKS_GIT_SCOPE`, and the `tasks_git` helper.
-2. **Find optimus-tasks.md:** Check if `TASKS_FILE` exists. If not found, **STOP** and suggest `/optimus-import`.
-3. **Validate format:** Execute all 15 validation checks from the "Format Validation" section. If the format marker is missing or any check fails, **STOP** and suggest `/optimus-import`.
-
-**All subsequent references to `optimus-tasks.md` in the skill use the resolved `TASKS_FILE` path.
-All references to Ring pre-dev artifacts use `TASKS_DIR` as the root** — never hardcoded paths.
-**All git operations on optimus-tasks.md use the `tasks_git` helper** (which handles both same-repo
-and separate-repo scopes).
-
-Skills reference this as: "Find and validate optimus-tasks.md (HARD BLOCK) — see AGENTS.md Protocol: optimus-tasks.md Validation."
-
+**Summary:** At Step 1.0.1 of every stage agent: (1) resolve paths via Protocol: Resolve Tasks Git Scope; (2) check `TASKS_FILE` exists, else STOP and suggest `/optimus-import`; (3) run all 15 Format Validation rules, else STOP and suggest `/optimus-import`. HARD BLOCK on any failure. All subsequent skill steps use the resolved `TASKS_FILE` and `tasks_git` helper. See full enumeration in AGENTS.md.
 
 <!-- INLINE-PROTOCOLS:END -->


### PR DESCRIPTION
## Summary

Phase 7 of the inline-protocol bloat reduction (issue #34). Phase 6 hypothesized that the remaining short protocols (body LOC < 50) would not yield net savings once you subtract the summary stub cost. **Measurement disproved that** — adding terse 3-5 line summaries for 5 candidates drops total inlined LOC from 3,228 (Phase 6 baseline) to 2,601 (**−627 LOC, −19%**).

Protocols marked summarize-mode this phase:

| Protocol | Consumers | Body LOC/copy | Total LOC | Heading type |
|---|---:|---:|---:|---|
| Valid Status Values (stored in state.json) | 9 | 22 | 198 | Non-Protocol H3 |
| Protocol: optimus-tasks.md Validation (HARD BLOCK) | 8 | 20 | 160 | Protocol H3 |
| Protocol: Project Rules Discovery | 6 | 31 | 186 | Protocol H3 |
| Protocol: Ring Droid Requirement Check | 5 | 39 | 195 | Protocol H3 |
| Protocol: Active Version Guard | 4 | 39 | 156 | Protocol H3 |

Summaries are deliberately terse (3-5 lines / ~50-80 words) — shorter than the 5-10 line / 80-120 word range from earlier phases — to maximize net savings on protocols with short bodies. All 5 protocols show positive marginal savings after stub overhead.

## Changes

- **AGENTS.md**: Add `<!-- inline-mode: summarize -->` + `**Summary:**` block under each of the 5 headings. Bodies preserved verbatim — bodies remain the source of truth.
- **scripts/test_skill_consistency.py**: Add 4 Protocol-form entries to `SUMMARIZED_PROTOCOLS`. Add targeted `test_summarize_marker_present_for_valid_status_values_section` for the non-Protocol H3 (matching the File Location / Format Validation / Finding Presentation pattern).
- **15 SKILL.md + 17 commands/**.md mirrors: regenerated by `inline-protocols.py` + `sync-claude-commands.py`. Net delta in skills: **−1,201 LOC** (bodies replaced by summary stubs).

## Test plan

- [x] `make inline-stats` baseline captured (3,228 LOC)
- [x] AGENTS.md edits applied (5 protocols)
- [x] `python3 scripts/inline-protocols.py` — 0 unmatched refs across 15 skills
- [x] `python3 scripts/sync-claude-commands.py` — regenerated mirrors
- [x] `make inline-stats` after — 2,601 LOC (−627 LOC, comfortably above 200 LOC decision threshold)
- [x] `make lint` — passes
- [x] `make test` — 344 passing (was 343; +1 new Phase 7 test)