### PR TITLE
feat(inliner): Phase 8 inline-protocol bloat reduction (issue #34)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -770,6 +770,10 @@ If any gate fails, done stops immediately and status in state.json stays unchang
 
 ## Protocol: Dry-Run Mode
 
+<!-- inline-mode: summarize -->
+
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
+
 **Referenced by:** plan, build, review, done (all stage agents 1-4).
 
 All stage agents support **dry-run mode**. When the user includes "dry-run" or
@@ -1242,6 +1246,10 @@ Skills reference this as: "Run quietly — see AGENTS.md Protocol: Quiet Command
 
 ### Protocol: Increment Stage Stats
 
+<!-- inline-mode: summarize -->
+
+**Summary:** Plan and review increment per-task execution counters in `${MAIN_WORKTREE}/.optimus/stats.json` immediately after the status change (BEFORE analysis starts). Skip in dry-run mode. Recipe: read stats.json (start `{}` if missing); reset to `{}` if corrupted (`jq empty` fails) with WARNING; init task key `{ "plan_runs": 0, "review_runs": 0 }` if absent; increment matching counter; set `last_plan` / `last_review` to UTC ISO 8601; write back pretty-printed with sorted keys. stats.json is gitignored — no commit. See full recipe in AGENTS.md.
+
 **Referenced by:** plan, review
 
 After the status change in state.json (and BEFORE any analysis work begins), increment
@@ -1276,6 +1284,10 @@ times each stage ran on each task — useful for spotting spec churn and review 
 Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
 
 ### Protocol: Shell Safety Guidelines
+
+<!-- inline-mode: summarize -->
+
+**Summary:** All bash examples in AGENTS.md/SKILL.md are templates executed literally — follow these rules to prevent injection and silent failures: (1) always quote variables (`"$VAR"`); (2) check exit codes for critical commands; (3) never interpolate user-derived values directly into shell; (4) use `grep -F` for fixed-string matching of branch names/task IDs; (5) match task rows with anchored regex `grep -E '^\| T-NNN \|'`; (6) `command -v jq` before use; (7) `jq empty "$FILE"` before parse; (8) for commit messages with user content, write to `mktemp` file and use `git commit -F` (avoids all expansion). See full anti-pattern list + sanitization recipes in AGENTS.md.
 
 **Referenced by:** plan, batch
 
@@ -1717,6 +1729,10 @@ branch. See **Protocol: Default Branch Refusal** below.
 Skills reference this as: "Resolve workspace (HARD BLOCK) — see AGENTS.md Protocol: Workspace Auto-Navigation."
 
 ### Protocol: Default Branch Refusal (HARD BLOCK)
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Mutating stage skills (build, review, done) MUST refuse to run on the project's default branch (main/master). Defense-in-depth even after Workspace Auto-Navigation. Resolves DEFAULT_BRANCH via `git symbolic-ref refs/remotes/origin/HEAD` with main→master fallback; compares to `git branch --show-current`; STOP with explicit error message if equal. Invoke immediately after Workspace Auto-Navigation, before any state.json write, git commit, worktree mutation, or status transition. See full recipe in AGENTS.md.
 
 **Referenced by:** build, review, done
 
@@ -2435,6 +2451,10 @@ Skills reference this as: "Discover project rules — see AGENTS.md Protocol: Pr
 
 ### Protocol: Re-run Guard
 
+<!-- inline-mode: summarize -->
+
+**Summary:** Replaces the static "next step" suggestion in plan and review. Counts `total_findings` from this execution (grouped entries count as 1). If 0 → suggest next stage (build for plan, done for review). If >0 → `AskUser` offering "Re-run with clean context" (re-dispatches ALL agents with no memory of prior decisions — skipped findings will reappear) or "Advance to next stage". Re-run reset semantics (MANDATORY): reset `convergence_status` to `null`, `phase` to entry, overwrite `started_at`; preserve identity fields. Skip GitHub CLI/tasks validation/workspace/divergence checks; re-execute discovery + dispatch. No re-run limit. See full reset checklist in AGENTS.md.
+
 **Referenced by:** plan, review
 
 After the convergence loop exits and the final report/summary is presented, evaluate
@@ -2738,6 +2758,10 @@ Skills reference this as: "Read/write state.json — see AGENTS.md Protocol: Sta
 
 ### Protocol: Branch Name Derivation
 
+<!-- inline-mode: summarize -->
+
+**Summary:** Branch names derived deterministically from task structural data — NOT stored in optimus-tasks.md, only cached in state.json. Format: `<tipo-prefix>/<task-id-lowercase>-<keywords>`. Tipo→prefix: Feature→feat, Fix→fix, Refactor→refactor, Chore→chore, Docs→docs, Test→test. Keywords: 2-4 lowercase title words, articles/prepositions/generic verbs (implement/add/create/update) stripped. Sanitization: lowercase → non-alphanumeric to hyphens → collapse hyphens → strip leading/trailing → 100-char cap. Resolution order: state.json `branch` field → kebab-anchored search (`-t-003-` to avoid T-1/T-10 collision via `git branch --list "*${KEBAB#-}*"`) → derive from Tipo+ID+Title. See full sanitization + Tipo table + examples in AGENTS.md.
+
 **Referenced by:** plan, build, review, pr-check, done (workspace auto-navigation)
 
 Branch names are derived deterministically from the task's structural data in optimus-tasks.md.
@@ -2785,6 +2809,10 @@ Where:
 Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
 
 ### Protocol: Default Scope Resolution
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Read-only skills (report, quick-report) resolve a version scope filter (`ativa`, `upcoming`, `all`, or specific version name). Resolution order: (1) invocation argument wins, with `ask`/`menu` keywords forcing the prompt; (2) fall back to `defaultScope` in `${MAIN_WORKTREE}/.optimus/config.json` (validated against versions table — warn + reprompt if invalid); (3) `AskUser` with Ativa/Upcoming/All/Specific options; (4) offer to persist the choice to config.json (atomic jq write to tmp + mv). Scope names case-insensitive for keywords; case-preserved for version names. See full recipe in AGENTS.md.
 
 **Referenced by:** report, quick-report
 
@@ -2910,6 +2938,10 @@ to the `Ativa` version. If not, present options before proceeding.
 Skills reference this as: "Check active version guard — see AGENTS.md Protocol: Active Version Guard."
 
 ### Protocol: Worktree Location
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Linked worktrees created by plan / resume / Workspace Auto-Navigation / done-cleanup live at the canonical path `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by Initialize .optimus Directory + Session State protocols), project-rooted, resolved via Resolve Main Worktree Path so paths stay correct from any linked worktree. Branch names contain `/` (per Branch Name Derivation), creating intermediate `feat/`, `fix/` directories under `.worktrees/` automatically. Worktrees ALWAYS belong to the project repo, never the tasks repo (separate-repo `tasksDir` doesn't affect location). Recommend IDE exclusion (`.vscode/settings.json` `search.exclude`, IntelliJ Excluded). Backwards compat: legacy sibling paths still work via worktree metadata; no forced migration. See full convention + IDE config in AGENTS.md.
 
 **Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
 
@@ -3074,6 +3106,10 @@ exit?") preserves user authority while keeping the gate honest.
 
 ### Fix Implementation (Complexity-Based Dispatch)
 
+<!-- inline-mode: summarize -->
+
+**Summary:** Cycle review skills classify each approved fix before applying. **Simple** (single file, localized, exact code provided, obvious resolution: typo / missing nil guard / import / log line / dead code removal): orchestrator applies directly via Edit/MultiEdit, runs unit tests; on failure, reverts and escalates. **Complex** (multi-file, architectural impact, security-sensitive, schema/API/config changes, new tests needed, or unsure): dispatch ring droid. Code fixes use TDD cycle (RED-GREEN-REFACTOR) via `ring-dev-team-backend-engineer-golang`/`-typescript`, `ring-dev-team-frontend-engineer`, `ring-dev-team-qa-analyst`. Documentation fixes: `ring-tw-team-functional-writer`/`-api-writer`/`-docs-reviewer` (no TDD). When in doubt → dispatch. Ring droids are REQUIRED for complex fixes — STOP if missing. See full classification + dispatch templates in AGENTS.md.
+
 Fixes are classified by complexity. **Simple fixes** are applied directly by the
 orchestrator. **Complex fixes** (or fixes whose complexity cannot be determined) are
 delegated to specialist ring droids.
@@ -3149,6 +3185,11 @@ All skills that measure coverage MUST use these thresholds. If coverage profiles
 be generated (command fails or tool missing), report as SKIP — do not fail the verification.
 
 ### Deep Research Before Presenting (MANDATORY for cycle review skills)
+
+<!-- inline-mode: summarize -->
+
+**Summary:** Before presenting ANY finding, cycle review skills (plan, review, pr-check, coderabbit-review) MUST research silently across 12 dimensions: project patterns + similar cases, architectural decisions (AGENTS.md/TRD/ADRs), existing codebase precedent, current task focus, user/consumer use cases, UX impact, API best practices, engineering best practices (SOLID/DRY/observability), language idioms (`WebSearch`), correctness over convenience, production resilience (timeouts, retries, leaks), data integrity + privacy (LGPD/GDPR). Recommendation Option A MUST be evidence-backed (not generic). NOT optional — prevents false-positive findings. See full 12-item checklist in AGENTS.md.
+
 Applies to: plan, review, pr-check, coderabbit-review
 
 **BEFORE presenting any finding to the user, the agent MUST research it deeply.** This

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -379,48 +379,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Shell Safety Guidelines
+### Protocol: Shell Safety Guidelines (summarized)
 
-**Referenced by:** plan, batch
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Shell Safety Guidelines`.**
 
-All bash examples in AGENTS.md and SKILL.md files are templates that agents execute literally.
-Follow these rules to prevent injection and silent failures:
-
-1. **Always quote variables:** Use `"$VAR"` not `$VAR` — especially for paths, branch names, and user-derived values
-2. **Check exit codes for critical commands:**
-   ```bash
-   tasks_git add "$TASKS_GIT_REL"
-   COMMIT_MSG_FILE=$(mktemp)
-   printf '%s' "chore(tasks): $COMMIT_MSG" > "$COMMIT_MSG_FILE"
-   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-     echo "ERROR: git commit failed. Check pre-commit hooks or git config." >&2
-     rm -f "$COMMIT_MSG_FILE"
-     exit 1
-   fi
-   rm -f "$COMMIT_MSG_FILE"
-   ```
-3. **Never interpolate user-derived values directly into shell commands** — task titles,
-   branch names, and other user input may contain shell metacharacters
-4. **Use `grep -F` for fixed string matching** — never pass branch names or task IDs
-   as regex patterns to `grep` without `-F`
-5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in optimus-tasks.md — plain `grep "T-NNN"`
-   matches titles and dependency columns too
-6. **Validate tool availability** before use: `command -v jq >/dev/null 2>&1` before running `jq`
-7. **Validate JSON files** before parsing: `jq empty "$FILE" 2>/dev/null` before reading keys
-8. **Sanitize user-derived values in commit messages** — task titles and descriptions may
-   contain shell metacharacters (backticks, `$(...)`, double quotes). **Mandatory pattern:**
-   write the commit message to a temporary file and use `git commit -F`:
-   ```bash
-   COMMIT_MSG_FILE=$(mktemp)
-   printf '%s' "chore(tasks): $OPERATION" > "$COMMIT_MSG_FILE"
-   git commit -F "$COMMIT_MSG_FILE"
-   rm -f "$COMMIT_MSG_FILE"
-   ```
-   This avoids all shell expansion issues. If using `-m` directly, sanitize with:
-   `SAFE_VALUE=$(printf '%s' "$VALUE" | tr -d '`$')` before interpolation.
-
-Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines."
-
+**Summary:** All bash examples in AGENTS.md/SKILL.md are templates executed literally — follow these rules to prevent injection and silent failures: (1) always quote variables (`"$VAR"`); (2) check exit codes for critical commands; (3) never interpolate user-derived values directly into shell; (4) use `grep -F` for fixed-string matching of branch names/task IDs; (5) match task rows with anchored regex `grep -E '^\| T-NNN \|'`; (6) `command -v jq` before use; (7) `jq empty "$FILE"` before parse; (8) for commit messages with user content, write to `mktemp` file and use `git commit -F` (avoids all expansion). See full anti-pattern list + sanitization recipes in AGENTS.md.
 
 ### Protocol: State Management (summarized)
 

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -711,39 +711,11 @@ All cycle review skills follow this pattern:
 
 **Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
-### Protocol: Default Branch Refusal (HARD BLOCK)
+### Protocol: Default Branch Refusal (HARD BLOCK) (summarized)
 
-**Referenced by:** build, review, done
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Branch Refusal (HARD BLOCK)`.**
 
-**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
-in edge cases (user cancels the AskUser prompt, silent failure, future skill that
-forgets to invoke the protocol). A second, unconditional refusal at the start of any
-mutating stage prevents accidental commits, worktree removals, or status writes on
-the default branch.
-
-```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-if [ -z "$DEFAULT_BRANCH" ]; then
-  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
-    DEFAULT_BRANCH="main"
-  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
-    DEFAULT_BRANCH="master"
-  fi
-fi
-CURRENT=$(git branch --show-current 2>/dev/null)
-if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
-  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
-  exit 1
-fi
-```
-
-**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
-the skill performs any state.json write, git commit, git worktree mutation, or
-status transition.
-
-Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
-
+**Summary:** Mutating stage skills (build, review, done) MUST refuse to run on the project's default branch (main/master). Defense-in-depth even after Workspace Auto-Navigation. Resolves DEFAULT_BRANCH via `git symbolic-ref refs/remotes/origin/HEAD` with main→master fallback; compares to `git branch --show-current`; STOP with explicit error message if equal. Invoke immediately after Workspace Auto-Navigation, before any state.json write, git commit, worktree mutation, or status transition. See full recipe in AGENTS.md.
 
 ### Protocol: Divergence Warning (summarized)
 
@@ -751,31 +723,11 @@ Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see 
 
 **Summary:** Detects when `optimus-tasks.md` has diverged between the current branch and the tasks repo's default branch. Uses `tasks_git` so it works in both same-repo and separate-repo scopes. Throttles `tasks_git fetch` via a 5-minute cache marker at `${MAIN_WORKTREE}/.optimus/.last-tasks-fetch` (defense-in-depth: validates marker contents are numeric before arithmetic to survive corrupted marker files under `set -euo pipefail`). Compares against `origin/$TASKS_DEFAULT_BRANCH` via `tasks_git diff` limited to `$TASKS_GIT_REL`. On non-empty diff, warns via `AskUser` with options to **Sync now** (merge `origin/<default>`) or **Continue without syncing**. NOT a HARD BLOCK — divergence is a soft warning. Skipped silently when `TASKS_DEFAULT_BRANCH` is unresolved. See full recipe in AGENTS.md.
 
-## Protocol: Dry-Run Mode
+### Protocol: Dry-Run Mode (summarized)
 
-**Referenced by:** plan, build, review, done (all stage agents 1-4).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Dry-Run Mode`.**
 
-All stage agents support **dry-run mode**. When the user includes "dry-run" or
-"preview" in their invocation (e.g., "dry-run spec T-003", "preview review T-012"),
-the agent MUST:
-
-1. **Run all analysis/validation phases normally** — agent dispatch, findings, etc.
-2. **Do NOT change task status** — skip the status update step in state.json.
-3. **Do NOT commit or push anything** — no git operations that modify state.
-4. **Do NOT create workspaces** — skip branch/worktree creation (stage-1 only).
-5. **Do NOT apply fixes** — skip batch-apply phases.
-6. **Do NOT increment stage stats** — skip the Increment Stage Stats protocol.
-7. **Do NOT write session files** — session state is for crash recovery of real
-   executions, not previews.
-8. **Skip convergence rounds 2+** — round 1 (primary review pass) is sufficient
-   for preview; do NOT enter the convergence loop.
-9. **Present results as informational** — phrase the summary as "what would happen"
-   without implying any side effects occurred.
-
-Stage agents may add stage-specific dry-run notes (e.g., which phase numbers
-to skip), but MUST NOT relax any of the rules above. The point of dry-run is
-to give the user a reliable preview with zero state mutation.
-
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -335,48 +335,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Shell Safety Guidelines
+### Protocol: Shell Safety Guidelines (summarized)
 
-**Referenced by:** plan, batch
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Shell Safety Guidelines`.**
 
-All bash examples in AGENTS.md and SKILL.md files are templates that agents execute literally.
-Follow these rules to prevent injection and silent failures:
-
-1. **Always quote variables:** Use `"$VAR"` not `$VAR` — especially for paths, branch names, and user-derived values
-2. **Check exit codes for critical commands:**
-   ```bash
-   tasks_git add "$TASKS_GIT_REL"
-   COMMIT_MSG_FILE=$(mktemp)
-   printf '%s' "chore(tasks): $COMMIT_MSG" > "$COMMIT_MSG_FILE"
-   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-     echo "ERROR: git commit failed. Check pre-commit hooks or git config." >&2
-     rm -f "$COMMIT_MSG_FILE"
-     exit 1
-   fi
-   rm -f "$COMMIT_MSG_FILE"
-   ```
-3. **Never interpolate user-derived values directly into shell commands** — task titles,
-   branch names, and other user input may contain shell metacharacters
-4. **Use `grep -F` for fixed string matching** — never pass branch names or task IDs
-   as regex patterns to `grep` without `-F`
-5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in optimus-tasks.md — plain `grep "T-NNN"`
-   matches titles and dependency columns too
-6. **Validate tool availability** before use: `command -v jq >/dev/null 2>&1` before running `jq`
-7. **Validate JSON files** before parsing: `jq empty "$FILE" 2>/dev/null` before reading keys
-8. **Sanitize user-derived values in commit messages** — task titles and descriptions may
-   contain shell metacharacters (backticks, `$(...)`, double quotes). **Mandatory pattern:**
-   write the commit message to a temporary file and use `git commit -F`:
-   ```bash
-   COMMIT_MSG_FILE=$(mktemp)
-   printf '%s' "chore(tasks): $OPERATION" > "$COMMIT_MSG_FILE"
-   git commit -F "$COMMIT_MSG_FILE"
-   rm -f "$COMMIT_MSG_FILE"
-   ```
-   This avoids all shell expansion issues. If using `-m` directly, sanitize with:
-   `SAFE_VALUE=$(printf '%s' "$VALUE" | tr -d '`$')` before interpolation.
-
-Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines."
-
+**Summary:** All bash examples in AGENTS.md/SKILL.md are templates executed literally — follow these rules to prevent injection and silent failures: (1) always quote variables (`"$VAR"`); (2) check exit codes for critical commands; (3) never interpolate user-derived values directly into shell; (4) use `grep -F` for fixed-string matching of branch names/task IDs; (5) match task rows with anchored regex `grep -E '^\| T-NNN \|'`; (6) `command -v jq` before use; (7) `jq empty "$FILE"` before parse; (8) for commit messages with user content, write to `mktemp` file and use `git commit -F` (avoids all expansion). See full anti-pattern list + sanitization recipes in AGENTS.md.
 
 ### Protocol: State Management (summarized)
 

--- a/commands/build.md
+++ b/commands/build.md
@@ -649,39 +649,11 @@ All cycle review skills follow this pattern:
 
 **Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
-### Protocol: Default Branch Refusal (HARD BLOCK)
+### Protocol: Default Branch Refusal (HARD BLOCK) (summarized)
 
-**Referenced by:** build, review, done
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Branch Refusal (HARD BLOCK)`.**
 
-**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
-in edge cases (user cancels the AskUser prompt, silent failure, future skill that
-forgets to invoke the protocol). A second, unconditional refusal at the start of any
-mutating stage prevents accidental commits, worktree removals, or status writes on
-the default branch.
-
-```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-if [ -z "$DEFAULT_BRANCH" ]; then
-  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
-    DEFAULT_BRANCH="main"
-  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
-    DEFAULT_BRANCH="master"
-  fi
-fi
-CURRENT=$(git branch --show-current 2>/dev/null)
-if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
-  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
-  exit 1
-fi
-```
-
-**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
-the skill performs any state.json write, git commit, git worktree mutation, or
-status transition.
-
-Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
-
+**Summary:** Mutating stage skills (build, review, done) MUST refuse to run on the project's default branch (main/master). Defense-in-depth even after Workspace Auto-Navigation. Resolves DEFAULT_BRANCH via `git symbolic-ref refs/remotes/origin/HEAD` with main→master fallback; compares to `git branch --show-current`; STOP with explicit error message if equal. Invoke immediately after Workspace Auto-Navigation, before any state.json write, git commit, worktree mutation, or status transition. See full recipe in AGENTS.md.
 
 ### Protocol: Divergence Warning (summarized)
 
@@ -689,31 +661,11 @@ Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see 
 
 **Summary:** Detects when `optimus-tasks.md` has diverged between the current branch and the tasks repo's default branch. Uses `tasks_git` so it works in both same-repo and separate-repo scopes. Throttles `tasks_git fetch` via a 5-minute cache marker at `${MAIN_WORKTREE}/.optimus/.last-tasks-fetch` (defense-in-depth: validates marker contents are numeric before arithmetic to survive corrupted marker files under `set -euo pipefail`). Compares against `origin/$TASKS_DEFAULT_BRANCH` via `tasks_git diff` limited to `$TASKS_GIT_REL`. On non-empty diff, warns via `AskUser` with options to **Sync now** (merge `origin/<default>`) or **Continue without syncing**. NOT a HARD BLOCK — divergence is a soft warning. Skipped silently when `TASKS_DEFAULT_BRANCH` is unresolved. See full recipe in AGENTS.md.
 
-## Protocol: Dry-Run Mode
+### Protocol: Dry-Run Mode (summarized)
 
-**Referenced by:** plan, build, review, done (all stage agents 1-4).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Dry-Run Mode`.**
 
-All stage agents support **dry-run mode**. When the user includes "dry-run" or
-"preview" in their invocation (e.g., "dry-run spec T-003", "preview review T-012"),
-the agent MUST:
-
-1. **Run all analysis/validation phases normally** — agent dispatch, findings, etc.
-2. **Do NOT change task status** — skip the status update step in state.json.
-3. **Do NOT commit or push anything** — no git operations that modify state.
-4. **Do NOT create workspaces** — skip branch/worktree creation (stage-1 only).
-5. **Do NOT apply fixes** — skip batch-apply phases.
-6. **Do NOT increment stage stats** — skip the Increment Stage Stats protocol.
-7. **Do NOT write session files** — session state is for crash recovery of real
-   executions, not previews.
-8. **Skip convergence rounds 2+** — round 1 (primary review pass) is sufficient
-   for preview; do NOT enter the convergence loop.
-9. **Present results as informational** — phrase the summary as "what would happen"
-   without implying any side effects occurred.
-
-Stage agents may add stage-specific dry-run notes (e.g., which phase numbers
-to skip), but MUST NOT relax any of the rules above. The point of dry-run is
-to give the user a reliable preview with zero state mutation.
-
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 

--- a/commands/done.md
+++ b/commands/done.md
@@ -592,39 +592,11 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** When every dependency in a task's `Depends:` column has status `Cancelado`, emit a multi-option resolution message AFTER the per-dep status check loop populates the `DEP_STATUSES` array. Recipe: iterate `DEP_STATUSES`, set `ALL_CANCELLED=true` if every entry equals `Cancelado`; when `ALL_CANCELLED=true` AND the array is non-empty, print three options to stderr — (a) remove all dependencies, (b) replace with alternative task IDs, (c) cancel the task itself — each with the corresponding `/optimus:tasks` invocation, then `exit 1`. If the array is empty or any dep is non-Cancelado, fall through to per-dep error. Variable contract: `DEP_STATUSES` is the canonical name; adapt if existing skill code uses another. See full recipe in AGENTS.md.
 
-### Protocol: Default Branch Refusal (HARD BLOCK)
+### Protocol: Default Branch Refusal (HARD BLOCK) (summarized)
 
-**Referenced by:** build, review, done
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Branch Refusal (HARD BLOCK)`.**
 
-**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
-in edge cases (user cancels the AskUser prompt, silent failure, future skill that
-forgets to invoke the protocol). A second, unconditional refusal at the start of any
-mutating stage prevents accidental commits, worktree removals, or status writes on
-the default branch.
-
-```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-if [ -z "$DEFAULT_BRANCH" ]; then
-  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
-    DEFAULT_BRANCH="main"
-  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
-    DEFAULT_BRANCH="master"
-  fi
-fi
-CURRENT=$(git branch --show-current 2>/dev/null)
-if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
-  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
-  exit 1
-fi
-```
-
-**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
-the skill performs any state.json write, git commit, git worktree mutation, or
-status transition.
-
-Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
-
+**Summary:** Mutating stage skills (build, review, done) MUST refuse to run on the project's default branch (main/master). Defense-in-depth even after Workspace Auto-Navigation. Resolves DEFAULT_BRANCH via `git symbolic-ref refs/remotes/origin/HEAD` with main→master fallback; compares to `git branch --show-current`; STOP with explicit error message if equal. Invoke immediately after Workspace Auto-Navigation, before any state.json write, git commit, worktree mutation, or status transition. See full recipe in AGENTS.md.
 
 ### Protocol: Default Branch Resolution
 
@@ -690,31 +662,11 @@ Skills reference this as: "Resolve default branch — see AGENTS.md Protocol: De
 
 **Summary:** Detects when `optimus-tasks.md` has diverged between the current branch and the tasks repo's default branch. Uses `tasks_git` so it works in both same-repo and separate-repo scopes. Throttles `tasks_git fetch` via a 5-minute cache marker at `${MAIN_WORKTREE}/.optimus/.last-tasks-fetch` (defense-in-depth: validates marker contents are numeric before arithmetic to survive corrupted marker files under `set -euo pipefail`). Compares against `origin/$TASKS_DEFAULT_BRANCH` via `tasks_git diff` limited to `$TASKS_GIT_REL`. On non-empty diff, warns via `AskUser` with options to **Sync now** (merge `origin/<default>`) or **Continue without syncing**. NOT a HARD BLOCK — divergence is a soft warning. Skipped silently when `TASKS_DEFAULT_BRANCH` is unresolved. See full recipe in AGENTS.md.
 
-## Protocol: Dry-Run Mode
+### Protocol: Dry-Run Mode (summarized)
 
-**Referenced by:** plan, build, review, done (all stage agents 1-4).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Dry-Run Mode`.**
 
-All stage agents support **dry-run mode**. When the user includes "dry-run" or
-"preview" in their invocation (e.g., "dry-run spec T-003", "preview review T-012"),
-the agent MUST:
-
-1. **Run all analysis/validation phases normally** — agent dispatch, findings, etc.
-2. **Do NOT change task status** — skip the status update step in state.json.
-3. **Do NOT commit or push anything** — no git operations that modify state.
-4. **Do NOT create workspaces** — skip branch/worktree creation (stage-1 only).
-5. **Do NOT apply fixes** — skip batch-apply phases.
-6. **Do NOT increment stage stats** — skip the Increment Stage Stats protocol.
-7. **Do NOT write session files** — session state is for crash recovery of real
-   executions, not previews.
-8. **Skip convergence rounds 2+** — round 1 (primary review pass) is sufficient
-   for preview; do NOT enter the convergence loop.
-9. **Present results as informational** — phrase the summary as "what would happen"
-   without implying any side effects occurred.
-
-Stage agents may add stage-specific dry-run notes (e.g., which phase numbers
-to skip), but MUST NOT relax any of the rules above. The point of dry-run is
-to give the user a reliable preview with zero state mutation.
-
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -951,48 +951,13 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves `TASKS_DIR` (from `.optimus/config.json` `tasksDir` key, default `docs/pre-dev`) and `TASKS_FILE` (`<tasksDir>/optimus:tasks.md`), then detects whether tasksDir lives inside the project repo (`same-repo`) or a separate git repo (`separate-repo`). Sets `TASKS_REPO_ROOT`, `TASKS_GIT_REL`, `TASKS_DEFAULT_BRANCH`, and exposes a `tasks_git()` helper that wraps `git -C "$TASKS_DIR"` in separate-repo mode. Hard guards: reject `tasksDir` starting with `-` (git-option injection), require `python3` for separate-repo path computation, validate `TASKS_DEFAULT_BRANCH` against `^[a-zA-Z0-9._/-]+$`. Skills MUST use `tasks_git` (never raw `git`) on `$TASKS_FILE`. See full recipe in AGENTS.md.
 
-### Deep Research Before Presenting (MANDATORY for cycle review skills)
+### Deep Research Before Presenting (MANDATORY for cycle review skills) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Deep Research Before Presenting (MANDATORY for cycle review skills)`.**
+
+**Summary:** Before presenting ANY finding, cycle review skills (plan, review, pr-check, coderabbit-review) MUST research silently across 12 dimensions: project patterns + similar cases, architectural decisions (AGENTS.md/TRD/ADRs), existing codebase precedent, current task focus, user/consumer use cases, UX impact, API best practices, engineering best practices (SOLID/DRY/observability), language idioms (`WebSearch`), correctness over convenience, production resilience (timeouts, retries, leaks), data integrity + privacy (LGPD/GDPR). Recommendation Option A MUST be evidence-backed (not generic). NOT optional — prevents false-positive findings. See full 12-item checklist in AGENTS.md.
+
 Applies to: plan, review, pr-check, coderabbit-review
-
-**BEFORE presenting any finding to the user, the agent MUST research it deeply.** This
-research is done SILENTLY — do not show the research process. Present only the conclusions.
-
-**Research checklist (ALL items, every finding):**
-
-1. **Project patterns:** Read the affected file(s) fully. Check how similar cases are handled
-   elsewhere in the codebase. Identify existing conventions the finding might violate or follow.
-2. **Architectural decisions:** Review project rules (AGENTS.md, PROJECT_RULES.md, etc.) and
-   architecture docs (TRD, ADRs). Understand WHY the project is structured this way before
-   suggesting changes.
-3. **Existing codebase:** Search for precedent. If the codebase already does the same thing
-   in 10 other places without issue, that context changes the finding's weight.
-4. **Current task focus:** Is this finding within the scope of the task being worked on?
-   Tangential findings should be flagged as such (not dismissed, but contextualized).
-5. **User/consumer use cases:** Who consumes this code — end users, other services, internal
-   modules? How does the finding affect them? Trace the impact to real user scenarios.
-6. **UX impact:** For user-facing changes, evaluate usability, accessibility, error messaging,
-   and workflows. Would the user notice? Would it block their work?
-7. **API best practices:** For API changes, check REST conventions, error handling patterns,
-   idempotency, status codes, pagination, versioning, and backward compatibility.
-8. **Engineering best practices:** SOLID principles, DRY, separation of concerns, error
-   handling, resilience patterns, observability, testability.
-9. **Language-specific best practices:** Use `WebSearch` to research idioms and conventions
-   for the specific language (Go, TypeScript, Python, etc.). Check official style guides,
-   common linter rules, and community-accepted patterns.
-10. **Correctness over convenience:** Always recommend the correct approach, regardless of
-    effort. The easy option may be presented as an alternative, but Option A must be what
-    the agent believes is right based on all the research above.
-11. **Production resilience:** Would this code survive production conditions? Consider:
-    timeouts on external calls, retry with backoff, circuit breakers, graceful degradation,
-    resource cleanup (connections, handles, goroutines), graceful shutdown, and behavior
-    under load (N+1 queries, unbounded queries, connection pool exhaustion).
-12. **Data integrity and privacy:** Are transaction boundaries correct? Could partial writes
-    occur? Is PII properly handled (not logged, masked in responses)? LGPD/GDPR compliance?
-
-**After research, form the recommendation:** Option A MUST be the approach the agent
-believes is correct based on the research. It must be backed by evidence (project patterns,
-best practice references, official documentation), not just a generic suggestion.
-
 
 ### Finding Option Format (MANDATORY for cycle review skills)
 
@@ -1032,54 +997,11 @@ Every finding must present 2-3 options with this structure:
 
 **Summary:** When every dependency in a task's `Depends:` column has status `Cancelado`, emit a multi-option resolution message AFTER the per-dep status check loop populates the `DEP_STATUSES` array. Recipe: iterate `DEP_STATUSES`, set `ALL_CANCELLED=true` if every entry equals `Cancelado`; when `ALL_CANCELLED=true` AND the array is non-empty, print three options to stderr — (a) remove all dependencies, (b) replace with alternative task IDs, (c) cancel the task itself — each with the corresponding `/optimus:tasks` invocation, then `exit 1`. If the array is empty or any dep is non-Cancelado, fall through to per-dep error. Variable contract: `DEP_STATUSES` is the canonical name; adapt if existing skill code uses another. See full recipe in AGENTS.md.
 
-### Protocol: Branch Name Derivation
+### Protocol: Branch Name Derivation (summarized)
 
-**Referenced by:** plan, build, review, pr-check, done (workspace auto-navigation)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Branch Name Derivation`.**
 
-Branch names are derived deterministically from the task's structural data in optimus-tasks.md.
-They are NOT stored in optimus-tasks.md — they are stored in state.json for quick reference
-and can always be re-derived.
-
-**Derivation rule:**
-
-```
-<tipo-prefix>/<task-id-lowercase>-<keywords>
-```
-
-Where:
-- `<tipo-prefix>` is mapped from the Tipo column: Feature→`feat`, Fix→`fix`,
-  Refactor→`refactor`, Chore→`chore`, Docs→`docs`, Test→`test`
-- `<task-id-lowercase>` is the task ID in lowercase (e.g., `t-003`)
-- `<keywords>` are 2-4 lowercase words from the Title, stripping articles,
-  prepositions, and generic words (implement, add, create, update)
-
-**Sanitization (applied to keywords before constructing branch name):**
-1. Convert to lowercase
-2. Replace non-alphanumeric characters (except hyphens) with hyphens
-3. Collapse consecutive hyphens to a single hyphen
-4. Remove leading/trailing hyphens from each keyword
-5. Truncate the full branch name to 100 characters
-
-**Examples:**
-- T-003 "User Auth JWT" (Feature) → `feat/t-003-user-auth-jwt`
-- T-007 "Duplicate Login" (Fix) → `fix/t-007-duplicate-login`
-- T-012 "Extract Middleware" (Refactor) → `refactor/t-012-extract-middleware`
-- T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
-
-**Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest, source-of-truth).
-2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
-   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
-   ```bash
-   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
-   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
-   git worktree list --porcelain 2>/dev/null \
-     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
-   ```
-3. Derive from Tipo + ID + Title (always works).
-
-Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
-
+**Summary:** Branch names derived deterministically from task structural data — NOT stored in optimus-tasks.md, only cached in state.json. Format: `<tipo-prefix>/<task-id-lowercase>-<keywords>`. Tipo→prefix: Feature→feat, Fix→fix, Refactor→refactor, Chore→chore, Docs→docs, Test→test. Keywords: 2-4 lowercase title words, articles/prepositions/generic verbs (implement/add/create/update) stripped. Sanitization: lowercase → non-alphanumeric to hyphens → collapse hyphens → strip leading/trailing → 100-char cap. Resolution order: state.json `branch` field → kebab-anchored search (`-t-003-` to avoid T-1/T-10 collision via `git branch --list "*${KEBAB#-}*"`) → derive from Tipo+ID+Title. See full sanitization + Tipo table + examples in AGENTS.md.
 
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated) (summarized)
 
@@ -1093,31 +1015,11 @@ Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch
 
 **Summary:** Detects when `optimus-tasks.md` has diverged between the current branch and the tasks repo's default branch. Uses `tasks_git` so it works in both same-repo and separate-repo scopes. Throttles `tasks_git fetch` via a 5-minute cache marker at `${MAIN_WORKTREE}/.optimus/.last-tasks-fetch` (defense-in-depth: validates marker contents are numeric before arithmetic to survive corrupted marker files under `set -euo pipefail`). Compares against `origin/$TASKS_DEFAULT_BRANCH` via `tasks_git diff` limited to `$TASKS_GIT_REL`. On non-empty diff, warns via `AskUser` with options to **Sync now** (merge `origin/<default>`) or **Continue without syncing**. NOT a HARD BLOCK — divergence is a soft warning. Skipped silently when `TASKS_DEFAULT_BRANCH` is unresolved. See full recipe in AGENTS.md.
 
-## Protocol: Dry-Run Mode
+### Protocol: Dry-Run Mode (summarized)
 
-**Referenced by:** plan, build, review, done (all stage agents 1-4).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Dry-Run Mode`.**
 
-All stage agents support **dry-run mode**. When the user includes "dry-run" or
-"preview" in their invocation (e.g., "dry-run spec T-003", "preview review T-012"),
-the agent MUST:
-
-1. **Run all analysis/validation phases normally** — agent dispatch, findings, etc.
-2. **Do NOT change task status** — skip the status update step in state.json.
-3. **Do NOT commit or push anything** — no git operations that modify state.
-4. **Do NOT create workspaces** — skip branch/worktree creation (stage-1 only).
-5. **Do NOT apply fixes** — skip batch-apply phases.
-6. **Do NOT increment stage stats** — skip the Increment Stage Stats protocol.
-7. **Do NOT write session files** — session state is for crash recovery of real
-   executions, not previews.
-8. **Skip convergence rounds 2+** — round 1 (primary review pass) is sufficient
-   for preview; do NOT enter the convergence loop.
-9. **Present results as informational** — phrase the summary as "what would happen"
-   without implying any side effects occurred.
-
-Stage agents may add stage-specific dry-run notes (e.g., which phase numbers
-to skip), but MUST NOT relax any of the rules above. The point of dry-run is
-to give the user a reliable preview with zero state mutation.
-
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 
@@ -1133,41 +1035,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Increment Stage Stats
+### Protocol: Increment Stage Stats (summarized)
 
-**Referenced by:** plan, review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Increment Stage Stats`.**
 
-After the status change in state.json (and BEFORE any analysis work begins), increment
-the execution counter for the current stage in `.optimus/stats.json`. This tracks how many
-times each stage ran on each task — useful for spotting spec churn and review cycles.
-
-**NOTE:** Only increment when NOT in dry-run mode.
-
-1. Read `.optimus/stats.json`. If the file does not exist, start with an empty object `{}`.
-   If the file exists but is corrupted, reset it:
-   ```bash
-   # Requires Protocol: Resolve Main Worktree Path to have run first
-   # (or resolve inline; see that protocol).
-   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-   STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-   if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
-     echo "WARNING: stats.json is corrupted. Resetting counters."
-     echo '{}' > "$STATS_FILE"
-   fi
-   ```
-2. If the task ID key does not exist, initialize it:
-   ```json
-   { "plan_runs": 0, "review_runs": 0 }
-   ```
-3. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
-4. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
-5. Write the updated JSON back to `.optimus/stats.json` (pretty-printed, sorted keys).
-
-**NOTE:** stats.json is gitignored — no commit needed.
-
-Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
-
+**Summary:** Plan and review increment per-task execution counters in `${MAIN_WORKTREE}/.optimus/stats.json` immediately after the status change (BEFORE analysis starts). Skip in dry-run mode. Recipe: read stats.json (start `{}` if missing); reset to `{}` if corrupted (`jq empty` fails) with WARNING; init task key `{ "plan_runs": 0, "review_runs": 0 }` if absent; increment matching counter; set `last_plan` / `last_review` to UTC ISO 8601; write back pretty-printed with sorted keys. stats.json is gitignored — no commit. See full recipe in AGENTS.md.
 
 ### Protocol: Notification Hooks (summarized)
 
@@ -1193,75 +1065,11 @@ Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Inc
 
 **Summary:** Optional commit-push pattern for stage skills (plan, build, review, coderabbit-review). After committing locally, offer to push via `AskUser`. Step 1: detect upstream with `git rev-parse --abbrev-ref @{u}` — if missing, all local commits are unpushed and `git push -u origin <branch>` sets upstream; if present, count unpushed via `git log @{u}..HEAD`. Step 2: in `separate-repo` tasks scope, repeat the same upstream/unpushed dance against the tasks repo via `tasks_git`. After successful push, if the current repo is the Optimus plugin repo, run `droid plugin update` for each installed optimus skill so agents pick up the latest version. See full recipe in AGENTS.md.
 
-### Protocol: Re-run Guard
+### Protocol: Re-run Guard (summarized)
 
-**Referenced by:** plan, review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Re-run Guard`.**
 
-After the convergence loop exits and the final report/summary is presented, evaluate
-whether to suggest advancement or offer a re-run. This protocol replaces the static
-"Next step suggestion" in plan and review.
-
-**Logic:**
-
-1. Count `total_findings` produced during this execution (all findings from round 1 AND
-   any convergence rounds that were dispatched — note: with opt-in gating, the user may
-   have skipped them all, in which case only round 1 contributes — from all agents and
-   static analysis, regardless of whether they were fixed or skipped by the user). If
-   findings were grouped (per Finding Presentation item 3), count grouped entries, not
-   individual occurrences.
-2. **If `total_findings == 0`:** The analysis is clean. Suggest the next stage:
-   - plan: "Spec validation clean — 0 findings. Next step: run `/optimus:build` to implement this task."
-   - review: "Implementation review clean — 0 findings. Next step: run `/optimus:done` to close this task."
-3. **If `total_findings > 0`:** Ask via `AskUser`:
-   ```
-   Validation found N findings (X fixed, Y skipped).
-   Re-running dispatches ALL review agents again with clean context (no memory of
-   previous findings — findings you previously skipped will reappear for review).
-   This will consume similar tokens to the initial run. Workspace and status are preserved.
-   ```
-   Options:
-   - **Re-run with clean context** — re-analyze from scratch
-   - **Advance to next stage** — proceed despite findings
-
-4. **If "Re-run with clean context":**
-   - Increment stage stats (new execution)
-   - **Skip:** GitHub CLI check, optimus-tasks.md validation, task identification, session state
-     check, status validation/change, workspace creation, divergence check
-   - **Re-execute:** project structure discovery, document loading, static analysis,
-     coverage profiling, agent dispatch (ALL agents), finding presentation, fix application,
-     convergence loop entry gate (and any rounds the user opts into)
-   - **Session file:** After re-run starts, the session protocol (Protocol: Session State)
-     resumes normal operation — update the session file at each phase transition as usual.
-     This ensures crash recovery during a re-run resumes from the correct phase.
-   - After the re-run completes, apply this protocol again (evaluate findings count)
-   - There is no limit on re-runs — the user controls when to stop
-
-   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
-   context", the orchestrator MUST:
-
-   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
-      or another terminal state at the previous run's end).
-   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
-      that performs work, NOT the load-only phases).
-   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
-   4. Preserve `task_id`, `task_branch`, and any other identity fields.
-   5. After reset, normal `Protocol: Session State` updates resume.
-
-   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
-   short-circuit the re-run's loop, producing a phantom "no findings" result.
-
-5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
-
-**NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
-were resolved. If the user skipped findings in a previous run, they will reappear on
-re-run (clean context has no memory of previous decisions). This is by design.
-
-**NOTE:** Re-run analyzes the current codebase state, including any fixes applied and
-committed during the previous run. It does NOT revert commits. This validates that
-applied fixes are correct and checks for any issues introduced by the fixes.
-
-Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
-
+**Summary:** Replaces the static "next step" suggestion in plan and review. Counts `total_findings` from this execution (grouped entries count as 1). If 0 → suggest next stage (build for plan, done for review). If >0 → `AskUser` offering "Re-run with clean context" (re-dispatches ALL agents with no memory of prior decisions — skipped findings will reappear) or "Advance to next stage". Re-run reset semantics (MANDATORY): reset `convergence_status` to `null`, `phase` to entry, overwrite `started_at`; preserve identity fields. Skip GitHub CLI/tasks validation/workspace/divergence checks; re-execute discovery + dispatch. No re-run limit. See full reset checklist in AGENTS.md.
 
 ### Protocol: Resolve Main Worktree Path (summarized)
 
@@ -1281,48 +1089,11 @@ Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-r
 
 **Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
-### Protocol: Shell Safety Guidelines
+### Protocol: Shell Safety Guidelines (summarized)
 
-**Referenced by:** plan, batch
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Shell Safety Guidelines`.**
 
-All bash examples in AGENTS.md and SKILL.md files are templates that agents execute literally.
-Follow these rules to prevent injection and silent failures:
-
-1. **Always quote variables:** Use `"$VAR"` not `$VAR` — especially for paths, branch names, and user-derived values
-2. **Check exit codes for critical commands:**
-   ```bash
-   tasks_git add "$TASKS_GIT_REL"
-   COMMIT_MSG_FILE=$(mktemp)
-   printf '%s' "chore(tasks): $COMMIT_MSG" > "$COMMIT_MSG_FILE"
-   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-     echo "ERROR: git commit failed. Check pre-commit hooks or git config." >&2
-     rm -f "$COMMIT_MSG_FILE"
-     exit 1
-   fi
-   rm -f "$COMMIT_MSG_FILE"
-   ```
-3. **Never interpolate user-derived values directly into shell commands** — task titles,
-   branch names, and other user input may contain shell metacharacters
-4. **Use `grep -F` for fixed string matching** — never pass branch names or task IDs
-   as regex patterns to `grep` without `-F`
-5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in optimus-tasks.md — plain `grep "T-NNN"`
-   matches titles and dependency columns too
-6. **Validate tool availability** before use: `command -v jq >/dev/null 2>&1` before running `jq`
-7. **Validate JSON files** before parsing: `jq empty "$FILE" 2>/dev/null` before reading keys
-8. **Sanitize user-derived values in commit messages** — task titles and descriptions may
-   contain shell metacharacters (backticks, `$(...)`, double quotes). **Mandatory pattern:**
-   write the commit message to a temporary file and use `git commit -F`:
-   ```bash
-   COMMIT_MSG_FILE=$(mktemp)
-   printf '%s' "chore(tasks): $OPERATION" > "$COMMIT_MSG_FILE"
-   git commit -F "$COMMIT_MSG_FILE"
-   rm -f "$COMMIT_MSG_FILE"
-   ```
-   This avoids all shell expansion issues. If using `-m` directly, sanitize with:
-   `SAFE_VALUE=$(printf '%s' "$VALUE" | tr -d '`$')` before interpolation.
-
-Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines."
-
+**Summary:** All bash examples in AGENTS.md/SKILL.md are templates executed literally — follow these rules to prevent injection and silent failures: (1) always quote variables (`"$VAR"`); (2) check exit codes for critical commands; (3) never interpolate user-derived values directly into shell; (4) use `grep -F` for fixed-string matching of branch names/task IDs; (5) match task rows with anchored regex `grep -E '^\| T-NNN \|'`; (6) `command -v jq` before use; (7) `jq empty "$FILE"` before parse; (8) for commit messages with user content, write to `mktemp` file and use `git commit -F` (avoids all expansion). See full anti-pattern list + sanitization recipes in AGENTS.md.
 
 ### Protocol: State Management (summarized)
 
@@ -1342,44 +1113,11 @@ Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Prot
 
 **Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
 
-### Protocol: Worktree Location
+### Protocol: Worktree Location (summarized)
 
-**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Worktree Location`.**
 
-Optimus creates linked git worktrees during the task lifecycle:
-
-- `/optimus:plan` creates a worktree when a task starts (Step 1.0.5).
-- `/optimus:resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
-- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
-
-**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
-
-**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
-
-**Why nested under the project repo:**
-
-| Concern | Resolution |
-|---|---|
-| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
-| Cleanup lifecycle | Removing the project directory also removes worktrees |
-| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
-| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
-| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
-
-**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
-
-- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
-- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
-
-**Backwards compatibility:**
-
-- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
-- New worktrees from `/optimus:plan` and `resume`'s recovery land in `.worktrees/`.
-- No forced migration.
-- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
-
-Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
-
+**Summary:** Linked worktrees created by plan / resume / Workspace Auto-Navigation / done-cleanup live at the canonical path `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by Initialize .optimus Directory + Session State protocols), project-rooted, resolved via Resolve Main Worktree Path so paths stay correct from any linked worktree. Branch names contain `/` (per Branch Name Derivation), creating intermediate `feat/`, `fix/` directories under `.worktrees/` automatically. Worktrees ALWAYS belong to the project repo, never the tasks repo (separate-repo `tasksDir` doesn't affect location). Recommend IDE exclusion (`.vscode/settings.json` `search.exclude`, IntelliJ Excluded). Backwards compat: legacy sibling paths still work via worktree metadata; no forced migration. See full convention + IDE config in AGENTS.md.
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -1733,48 +1733,13 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Deep Research Before Presenting (MANDATORY for cycle review skills)
+### Deep Research Before Presenting (MANDATORY for cycle review skills) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Deep Research Before Presenting (MANDATORY for cycle review skills)`.**
+
+**Summary:** Before presenting ANY finding, cycle review skills (plan, review, pr-check, coderabbit-review) MUST research silently across 12 dimensions: project patterns + similar cases, architectural decisions (AGENTS.md/TRD/ADRs), existing codebase precedent, current task focus, user/consumer use cases, UX impact, API best practices, engineering best practices (SOLID/DRY/observability), language idioms (`WebSearch`), correctness over convenience, production resilience (timeouts, retries, leaks), data integrity + privacy (LGPD/GDPR). Recommendation Option A MUST be evidence-backed (not generic). NOT optional — prevents false-positive findings. See full 12-item checklist in AGENTS.md.
+
 Applies to: plan, review, pr-check, coderabbit-review
-
-**BEFORE presenting any finding to the user, the agent MUST research it deeply.** This
-research is done SILENTLY — do not show the research process. Present only the conclusions.
-
-**Research checklist (ALL items, every finding):**
-
-1. **Project patterns:** Read the affected file(s) fully. Check how similar cases are handled
-   elsewhere in the codebase. Identify existing conventions the finding might violate or follow.
-2. **Architectural decisions:** Review project rules (AGENTS.md, PROJECT_RULES.md, etc.) and
-   architecture docs (TRD, ADRs). Understand WHY the project is structured this way before
-   suggesting changes.
-3. **Existing codebase:** Search for precedent. If the codebase already does the same thing
-   in 10 other places without issue, that context changes the finding's weight.
-4. **Current task focus:** Is this finding within the scope of the task being worked on?
-   Tangential findings should be flagged as such (not dismissed, but contextualized).
-5. **User/consumer use cases:** Who consumes this code — end users, other services, internal
-   modules? How does the finding affect them? Trace the impact to real user scenarios.
-6. **UX impact:** For user-facing changes, evaluate usability, accessibility, error messaging,
-   and workflows. Would the user notice? Would it block their work?
-7. **API best practices:** For API changes, check REST conventions, error handling patterns,
-   idempotency, status codes, pagination, versioning, and backward compatibility.
-8. **Engineering best practices:** SOLID principles, DRY, separation of concerns, error
-   handling, resilience patterns, observability, testability.
-9. **Language-specific best practices:** Use `WebSearch` to research idioms and conventions
-   for the specific language (Go, TypeScript, Python, etc.). Check official style guides,
-   common linter rules, and community-accepted patterns.
-10. **Correctness over convenience:** Always recommend the correct approach, regardless of
-    effort. The easy option may be presented as an alternative, but Option A must be what
-    the agent believes is right based on all the research above.
-11. **Production resilience:** Would this code survive production conditions? Consider:
-    timeouts on external calls, retry with backoff, circuit breakers, graceful degradation,
-    resource cleanup (connections, handles, goroutines), graceful shutdown, and behavior
-    under load (N+1 queries, unbounded queries, connection pool exhaustion).
-12. **Data integrity and privacy:** Are transaction boundaries correct? Could partial writes
-    occur? Is PII properly handled (not logged, masked in responses)? LGPD/GDPR compliance?
-
-**After research, form the recommendation:** Option A MUST be the approach the agent
-believes is correct based on the research. It must be backed by evidence (project patterns,
-best practice references, official documentation), not just a generic suggestion.
-
 
 ### Finding Option Format (MANDATORY for cycle review skills)
 
@@ -1831,7 +1796,11 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-### Fix Implementation (Complexity-Based Dispatch)
+### Fix Implementation (Complexity-Based Dispatch) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Fix Implementation (Complexity-Based Dispatch)`.**
+
+**Summary:** Cycle review skills classify each approved fix before applying. **Simple** (single file, localized, exact code provided, obvious resolution: typo / missing nil guard / import / log line / dead code removal): orchestrator applies directly via Edit/MultiEdit, runs unit tests; on failure, reverts and escalates. **Complex** (multi-file, architectural impact, security-sensitive, schema/API/config changes, new tests needed, or unsure): dispatch ring droid. Code fixes use TDD cycle (RED-GREEN-REFACTOR) via `ring-dev-team-backend-engineer-golang`/`-typescript`, `ring-dev-team-frontend-engineer`, `ring-dev-team-qa-analyst`. Documentation fixes: `ring-tw-team-functional-writer`/`-api-writer`/`-docs-reviewer` (no TDD). When in doubt → dispatch. Ring droids are REQUIRED for complex fixes — STOP if missing. See full classification + dispatch templates in AGENTS.md.
 
 Fixes are classified by complexity. **Simple fixes** are applied directly by the
 orchestrator. **Complex fixes** (or fixes whose complexity cannot be determined) are
@@ -1840,46 +1809,6 @@ delegated to specialist ring droids.
 #### Complexity Classification
 
 For each approved fix, assess complexity BEFORE applying:
-
-**Simple fix (apply directly):**
-- The review agent already provided the exact code change needed
-- Single file, localized change (few lines)
-- Obvious resolution: typo, missing error check, wrong variable name, missing nil guard,
-  import fix, formatting, adding a log line, renaming, removing dead code
-- No new logic, no architectural impact, no new test scenarios needed
-
-**Complex fix (dispatch ring droid):**
-- Multiple files affected
-- Requires understanding broader codebase context or architectural decisions
-- New functionality, significant refactoring, or new integration points
-- Requires new test scenarios (not just updating existing ones)
-- Security-sensitive changes (auth, crypto, input validation)
-- Database schema, API contract, or config changes
-- The orchestrator is unsure how to fix it
-
-**When in doubt → dispatch ring droid.** If you cannot confidently classify a fix as
-simple, treat it as complex.
-
-#### Direct Fix (simple findings)
-
-The orchestrator applies the fix directly using Edit/MultiEdit tools. After applying:
-1. Run unit tests to verify no regression
-2. If tests fail, revert and escalate to ring droid dispatch
-
-#### Ring Droid Dispatch (complex findings)
-
-**Code fixes** → dispatch ring backend/frontend/QA droids with **TDD cycle** (RED-GREEN-REFACTOR):
-- `ring-dev-team-backend-engineer-golang` (Go), `ring-dev-team-backend-engineer-typescript` (TS),
-  `ring-dev-team-frontend-engineer` (React/Next.js), `ring-dev-team-qa-analyst` (tests)
-
-**Documentation fixes** → dispatch ring documentation droids **without TDD** (no tests for docs):
-- `ring-tw-team-functional-writer` (guides), `ring-tw-team-api-writer` (API docs),
-  `ring-tw-team-docs-reviewer` (quality fixes)
-
-**Ring droids are REQUIRED for complex fixes** — there is no alternative dispatch mechanism. If the
-required droids are not installed and a complex fix is needed, the skill MUST stop and
-inform the user which droids need to be installed.
-
 
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated) (summarized)
 

--- a/commands/quick-report.md
+++ b/commands/quick-report.md
@@ -270,88 +270,11 @@ state.json is implicitly `Pendente`.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Protocol: Default Scope Resolution
+### Protocol: Default Scope Resolution (summarized)
 
-**Referenced by:** report, quick-report
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Scope Resolution`.**
 
-Both `report` and `quick-report` support a version scope filter (`ativa`, `upcoming`,
-`all`, or a specific version name). Resolve the effective scope in this order:
-
-1. **Invocation wins.** If the user specified a scope in the invocation (e.g.,
-   "quick report all", "report v2", "report upcoming"), use that scope directly.
-   Skip steps 2-3.
-
-   **Force-ask keywords:** If the invocation contains `ask` or `menu`
-   (e.g., "quick report ask", "report menu"), skip step 2 and go straight to step 3
-   (the AskUser prompt). This lets the user override the saved default for a single run
-   and optionally overwrite it.
-
-2. **Config fallback.** If `.optimus/config.json` has a `defaultScope` key, use it:
-   ```bash
-   CONFIG_FILE="${MAIN_WORKTREE}/.optimus/config.json"
-   if [ -f "$CONFIG_FILE" ] && jq -e '.defaultScope' "$CONFIG_FILE" >/dev/null 2>&1; then
-     SCOPE=$(jq -r '.defaultScope' "$CONFIG_FILE")
-   fi
-   ```
-   **Validation:** `SCOPE` must be `ativa`, `upcoming`, `all`, or match a version name in
-   the `## Versions` table of `optimus-tasks.md`. If invalid (empty, unknown keyword, or a version
-   name that no longer exists), warn the user and fall through to step 3.
-   ```
-   WARNING: .optimus/config.json has defaultScope="<value>" but it is not valid
-   (must be ativa/upcoming/all or an existing version name). Falling back to prompt.
-   ```
-
-3. **Ask user.** Present the standard AskUser prompt:
-   ```
-   Which version scope do you want to see?
-   ```
-   Options:
-   - **Ativa** — only tasks from the active version (`<active_version_name>`)
-   - **Upcoming** — active + planned (Ativa, Próxima, Planejada — excludes Backlog and Concluída)
-   - **All** — all tasks across all versions
-   - **Specific version** — pick one version by name (follow-up AskUser lists versions)
-
-4. **Offer to persist (only when step 3 ran).** After the user picks a scope in step 3,
-   ask a follow-up via AskUser:
-   ```
-   Save "<chosen_scope>" as the default in .optimus/config.json?
-   You can still override per-invocation (e.g., "quick report all") or
-   use "quick report ask" to be prompted again.
-   ```
-   Options:
-   - **Save as default** — write `defaultScope` to `.optimus/config.json`
-   - **Just this time** — do not persist
-
-5. **Persist the scope (if user chose to save):**
-   ```bash
-   # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-   CONFIG_FILE="${MAIN_WORKTREE}/.optimus/config.json"
-   if [ ! -f "$CONFIG_FILE" ]; then
-     echo '{}' > "$CONFIG_FILE"
-   fi
-   if jq --arg s "$SCOPE" '.defaultScope = $s' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp"; then
-     if jq empty "${CONFIG_FILE}.tmp" 2>/dev/null; then
-       mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
-     else
-       rm -f "${CONFIG_FILE}.tmp"
-       echo "ERROR: jq produced invalid JSON — config.json unchanged"
-     fi
-   else
-     rm -f "${CONFIG_FILE}.tmp"
-     echo "ERROR: jq failed to update config.json"
-   fi
-   ```
-   **NOTE:** `config.json` is gitignored (per-user preference). The saved `defaultScope`
-   affects only the local environment — each user can choose their own default. These
-   skills are read-only for code/tasks — writing to `config.json` is the single allowed
-   side-effect, and only when the user explicitly agrees.
-
-**NOTE:** Scope names are case-insensitive for user input. Normalize to lowercase for
-`ativa`/`upcoming`/`all`, but preserve the original casing when the scope is a specific
-version name (version names are case-sensitive to match the Versions table).
-
-Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Default Scope Resolution."
-
+**Summary:** Read-only skills (report, quick-report) resolve a version scope filter (`ativa`, `upcoming`, `all`, or specific version name). Resolution order: (1) invocation argument wins, with `ask`/`menu` keywords forcing the prompt; (2) fall back to `defaultScope` in `${MAIN_WORKTREE}/.optimus/config.json` (validated against versions table — warn + reprompt if invalid); (3) `AskUser` with Ativa/Upcoming/All/Specific options; (4) offer to persist the choice to config.json (atomic jq write to tmp + mv). Scope names case-insensitive for keywords; case-preserved for version names. See full recipe in AGENTS.md.
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/commands/report.md
+++ b/commands/report.md
@@ -702,88 +702,11 @@ state.json is implicitly `Pendente`.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Protocol: Default Scope Resolution
+### Protocol: Default Scope Resolution (summarized)
 
-**Referenced by:** report, quick-report
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Scope Resolution`.**
 
-Both `report` and `quick-report` support a version scope filter (`ativa`, `upcoming`,
-`all`, or a specific version name). Resolve the effective scope in this order:
-
-1. **Invocation wins.** If the user specified a scope in the invocation (e.g.,
-   "quick report all", "report v2", "report upcoming"), use that scope directly.
-   Skip steps 2-3.
-
-   **Force-ask keywords:** If the invocation contains `ask` or `menu`
-   (e.g., "quick report ask", "report menu"), skip step 2 and go straight to step 3
-   (the AskUser prompt). This lets the user override the saved default for a single run
-   and optionally overwrite it.
-
-2. **Config fallback.** If `.optimus/config.json` has a `defaultScope` key, use it:
-   ```bash
-   CONFIG_FILE="${MAIN_WORKTREE}/.optimus/config.json"
-   if [ -f "$CONFIG_FILE" ] && jq -e '.defaultScope' "$CONFIG_FILE" >/dev/null 2>&1; then
-     SCOPE=$(jq -r '.defaultScope' "$CONFIG_FILE")
-   fi
-   ```
-   **Validation:** `SCOPE` must be `ativa`, `upcoming`, `all`, or match a version name in
-   the `## Versions` table of `optimus-tasks.md`. If invalid (empty, unknown keyword, or a version
-   name that no longer exists), warn the user and fall through to step 3.
-   ```
-   WARNING: .optimus/config.json has defaultScope="<value>" but it is not valid
-   (must be ativa/upcoming/all or an existing version name). Falling back to prompt.
-   ```
-
-3. **Ask user.** Present the standard AskUser prompt:
-   ```
-   Which version scope do you want to see?
-   ```
-   Options:
-   - **Ativa** — only tasks from the active version (`<active_version_name>`)
-   - **Upcoming** — active + planned (Ativa, Próxima, Planejada — excludes Backlog and Concluída)
-   - **All** — all tasks across all versions
-   - **Specific version** — pick one version by name (follow-up AskUser lists versions)
-
-4. **Offer to persist (only when step 3 ran).** After the user picks a scope in step 3,
-   ask a follow-up via AskUser:
-   ```
-   Save "<chosen_scope>" as the default in .optimus/config.json?
-   You can still override per-invocation (e.g., "quick report all") or
-   use "quick report ask" to be prompted again.
-   ```
-   Options:
-   - **Save as default** — write `defaultScope` to `.optimus/config.json`
-   - **Just this time** — do not persist
-
-5. **Persist the scope (if user chose to save):**
-   ```bash
-   # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-   CONFIG_FILE="${MAIN_WORKTREE}/.optimus/config.json"
-   if [ ! -f "$CONFIG_FILE" ]; then
-     echo '{}' > "$CONFIG_FILE"
-   fi
-   if jq --arg s "$SCOPE" '.defaultScope = $s' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp"; then
-     if jq empty "${CONFIG_FILE}.tmp" 2>/dev/null; then
-       mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
-     else
-       rm -f "${CONFIG_FILE}.tmp"
-       echo "ERROR: jq produced invalid JSON — config.json unchanged"
-     fi
-   else
-     rm -f "${CONFIG_FILE}.tmp"
-     echo "ERROR: jq failed to update config.json"
-   fi
-   ```
-   **NOTE:** `config.json` is gitignored (per-user preference). The saved `defaultScope`
-   affects only the local environment — each user can choose their own default. These
-   skills are read-only for code/tasks — writing to `config.json` is the single allowed
-   side-effect, and only when the user explicitly agrees.
-
-**NOTE:** Scope names are case-insensitive for user input. Normalize to lowercase for
-`ativa`/`upcoming`/`all`, but preserve the original casing when the scope is a specific
-version name (version names are case-sensitive to match the Versions table).
-
-Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Default Scope Resolution."
-
+**Summary:** Read-only skills (report, quick-report) resolve a version scope filter (`ativa`, `upcoming`, `all`, or specific version name). Resolution order: (1) invocation argument wins, with `ask`/`menu` keywords forcing the prompt; (2) fall back to `defaultScope` in `${MAIN_WORKTREE}/.optimus/config.json` (validated against versions table — warn + reprompt if invalid); (3) `AskUser` with Ativa/Upcoming/All/Specific options; (4) offer to persist the choice to config.json (atomic jq write to tmp + mv). Scope names case-insensitive for keywords; case-preserved for version names. See full recipe in AGENTS.md.
 
 ### Protocol: Initialize .optimus Directory (summarized)
 

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -717,54 +717,11 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves `TASKS_DIR` (from `.optimus/config.json` `tasksDir` key, default `docs/pre-dev`) and `TASKS_FILE` (`<tasksDir>/optimus:tasks.md`), then detects whether tasksDir lives inside the project repo (`same-repo`) or a separate git repo (`separate-repo`). Sets `TASKS_REPO_ROOT`, `TASKS_GIT_REL`, `TASKS_DEFAULT_BRANCH`, and exposes a `tasks_git()` helper that wraps `git -C "$TASKS_DIR"` in separate-repo mode. Hard guards: reject `tasksDir` starting with `-` (git-option injection), require `python3` for separate-repo path computation, validate `TASKS_DEFAULT_BRANCH` against `^[a-zA-Z0-9._/-]+$`. Skills MUST use `tasks_git` (never raw `git`) on `$TASKS_FILE`. See full recipe in AGENTS.md.
 
-### Protocol: Branch Name Derivation
+### Protocol: Branch Name Derivation (summarized)
 
-**Referenced by:** plan, build, review, pr-check, done (workspace auto-navigation)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Branch Name Derivation`.**
 
-Branch names are derived deterministically from the task's structural data in optimus-tasks.md.
-They are NOT stored in optimus-tasks.md — they are stored in state.json for quick reference
-and can always be re-derived.
-
-**Derivation rule:**
-
-```
-<tipo-prefix>/<task-id-lowercase>-<keywords>
-```
-
-Where:
-- `<tipo-prefix>` is mapped from the Tipo column: Feature→`feat`, Fix→`fix`,
-  Refactor→`refactor`, Chore→`chore`, Docs→`docs`, Test→`test`
-- `<task-id-lowercase>` is the task ID in lowercase (e.g., `t-003`)
-- `<keywords>` are 2-4 lowercase words from the Title, stripping articles,
-  prepositions, and generic words (implement, add, create, update)
-
-**Sanitization (applied to keywords before constructing branch name):**
-1. Convert to lowercase
-2. Replace non-alphanumeric characters (except hyphens) with hyphens
-3. Collapse consecutive hyphens to a single hyphen
-4. Remove leading/trailing hyphens from each keyword
-5. Truncate the full branch name to 100 characters
-
-**Examples:**
-- T-003 "User Auth JWT" (Feature) → `feat/t-003-user-auth-jwt`
-- T-007 "Duplicate Login" (Fix) → `fix/t-007-duplicate-login`
-- T-012 "Extract Middleware" (Refactor) → `refactor/t-012-extract-middleware`
-- T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
-
-**Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest, source-of-truth).
-2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
-   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
-   ```bash
-   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
-   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
-   git worktree list --porcelain 2>/dev/null \
-     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
-   ```
-3. Derive from Tipo + ID + Title (always works).
-
-Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
-
+**Summary:** Branch names derived deterministically from task structural data — NOT stored in optimus-tasks.md, only cached in state.json. Format: `<tipo-prefix>/<task-id-lowercase>-<keywords>`. Tipo→prefix: Feature→feat, Fix→fix, Refactor→refactor, Chore→chore, Docs→docs, Test→test. Keywords: 2-4 lowercase title words, articles/prepositions/generic verbs (implement/add/create/update) stripped. Sanitization: lowercase → non-alphanumeric to hyphens → collapse hyphens → strip leading/trailing → 100-char cap. Resolution order: state.json `branch` field → kebab-anchored search (`-t-003-` to avoid T-1/T-10 collision via `git branch --list "*${KEBAB#-}*"`) → derive from Tipo+ID+Title. See full sanitization + Tipo table + examples in AGENTS.md.
 
 ### Protocol: Initialize .optimus Directory (summarized)
 
@@ -784,44 +741,11 @@ Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch
 
 **Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
 
-### Protocol: Worktree Location
+### Protocol: Worktree Location (summarized)
 
-**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Worktree Location`.**
 
-Optimus creates linked git worktrees during the task lifecycle:
-
-- `/optimus:plan` creates a worktree when a task starts (Step 1.0.5).
-- `/optimus:resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
-- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
-
-**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
-
-**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
-
-**Why nested under the project repo:**
-
-| Concern | Resolution |
-|---|---|
-| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
-| Cleanup lifecycle | Removing the project directory also removes worktrees |
-| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
-| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
-| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
-
-**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
-
-- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
-- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
-
-**Backwards compatibility:**
-
-- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
-- New worktrees from `/optimus:plan` and `resume`'s recovery land in `.worktrees/`.
-- No forced migration.
-- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
-
-Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
-
+**Summary:** Linked worktrees created by plan / resume / Workspace Auto-Navigation / done-cleanup live at the canonical path `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by Initialize .optimus Directory + Session State protocols), project-rooted, resolved via Resolve Main Worktree Path so paths stay correct from any linked worktree. Branch names contain `/` (per Branch Name Derivation), creating intermediate `feat/`, `fix/` directories under `.worktrees/` automatically. Worktrees ALWAYS belong to the project repo, never the tasks repo (separate-repo `tasksDir` doesn't affect location). Recommend IDE exclusion (`.vscode/settings.json` `search.exclude`, IntelliJ Excluded). Backwards compat: legacy sibling paths still work via worktree metadata; no forced migration. See full convention + IDE config in AGENTS.md.
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1007,48 +1007,13 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Deep Research Before Presenting (MANDATORY for cycle review skills)
+### Deep Research Before Presenting (MANDATORY for cycle review skills) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Deep Research Before Presenting (MANDATORY for cycle review skills)`.**
+
+**Summary:** Before presenting ANY finding, cycle review skills (plan, review, pr-check, coderabbit-review) MUST research silently across 12 dimensions: project patterns + similar cases, architectural decisions (AGENTS.md/TRD/ADRs), existing codebase precedent, current task focus, user/consumer use cases, UX impact, API best practices, engineering best practices (SOLID/DRY/observability), language idioms (`WebSearch`), correctness over convenience, production resilience (timeouts, retries, leaks), data integrity + privacy (LGPD/GDPR). Recommendation Option A MUST be evidence-backed (not generic). NOT optional — prevents false-positive findings. See full 12-item checklist in AGENTS.md.
+
 Applies to: plan, review, pr-check, coderabbit-review
-
-**BEFORE presenting any finding to the user, the agent MUST research it deeply.** This
-research is done SILENTLY — do not show the research process. Present only the conclusions.
-
-**Research checklist (ALL items, every finding):**
-
-1. **Project patterns:** Read the affected file(s) fully. Check how similar cases are handled
-   elsewhere in the codebase. Identify existing conventions the finding might violate or follow.
-2. **Architectural decisions:** Review project rules (AGENTS.md, PROJECT_RULES.md, etc.) and
-   architecture docs (TRD, ADRs). Understand WHY the project is structured this way before
-   suggesting changes.
-3. **Existing codebase:** Search for precedent. If the codebase already does the same thing
-   in 10 other places without issue, that context changes the finding's weight.
-4. **Current task focus:** Is this finding within the scope of the task being worked on?
-   Tangential findings should be flagged as such (not dismissed, but contextualized).
-5. **User/consumer use cases:** Who consumes this code — end users, other services, internal
-   modules? How does the finding affect them? Trace the impact to real user scenarios.
-6. **UX impact:** For user-facing changes, evaluate usability, accessibility, error messaging,
-   and workflows. Would the user notice? Would it block their work?
-7. **API best practices:** For API changes, check REST conventions, error handling patterns,
-   idempotency, status codes, pagination, versioning, and backward compatibility.
-8. **Engineering best practices:** SOLID principles, DRY, separation of concerns, error
-   handling, resilience patterns, observability, testability.
-9. **Language-specific best practices:** Use `WebSearch` to research idioms and conventions
-   for the specific language (Go, TypeScript, Python, etc.). Check official style guides,
-   common linter rules, and community-accepted patterns.
-10. **Correctness over convenience:** Always recommend the correct approach, regardless of
-    effort. The easy option may be presented as an alternative, but Option A must be what
-    the agent believes is right based on all the research above.
-11. **Production resilience:** Would this code survive production conditions? Consider:
-    timeouts on external calls, retry with backoff, circuit breakers, graceful degradation,
-    resource cleanup (connections, handles, goroutines), graceful shutdown, and behavior
-    under load (N+1 queries, unbounded queries, connection pool exhaustion).
-12. **Data integrity and privacy:** Are transaction boundaries correct? Could partial writes
-    occur? Is PII properly handled (not logged, masked in responses)? LGPD/GDPR compliance?
-
-**After research, form the recommendation:** Option A MUST be the approach the agent
-believes is correct based on the research. It must be backed by evidence (project patterns,
-best practice references, official documentation), not just a generic suggestion.
-
 
 ### Finding Option Format (MANDATORY for cycle review skills)
 
@@ -1105,7 +1070,11 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-### Fix Implementation (Complexity-Based Dispatch)
+### Fix Implementation (Complexity-Based Dispatch) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Fix Implementation (Complexity-Based Dispatch)`.**
+
+**Summary:** Cycle review skills classify each approved fix before applying. **Simple** (single file, localized, exact code provided, obvious resolution: typo / missing nil guard / import / log line / dead code removal): orchestrator applies directly via Edit/MultiEdit, runs unit tests; on failure, reverts and escalates. **Complex** (multi-file, architectural impact, security-sensitive, schema/API/config changes, new tests needed, or unsure): dispatch ring droid. Code fixes use TDD cycle (RED-GREEN-REFACTOR) via `ring-dev-team-backend-engineer-golang`/`-typescript`, `ring-dev-team-frontend-engineer`, `ring-dev-team-qa-analyst`. Documentation fixes: `ring-tw-team-functional-writer`/`-api-writer`/`-docs-reviewer` (no TDD). When in doubt → dispatch. Ring droids are REQUIRED for complex fixes — STOP if missing. See full classification + dispatch templates in AGENTS.md.
 
 Fixes are classified by complexity. **Simple fixes** are applied directly by the
 orchestrator. **Complex fixes** (or fixes whose complexity cannot be determined) are
@@ -1114,46 +1083,6 @@ delegated to specialist ring droids.
 #### Complexity Classification
 
 For each approved fix, assess complexity BEFORE applying:
-
-**Simple fix (apply directly):**
-- The review agent already provided the exact code change needed
-- Single file, localized change (few lines)
-- Obvious resolution: typo, missing error check, wrong variable name, missing nil guard,
-  import fix, formatting, adding a log line, renaming, removing dead code
-- No new logic, no architectural impact, no new test scenarios needed
-
-**Complex fix (dispatch ring droid):**
-- Multiple files affected
-- Requires understanding broader codebase context or architectural decisions
-- New functionality, significant refactoring, or new integration points
-- Requires new test scenarios (not just updating existing ones)
-- Security-sensitive changes (auth, crypto, input validation)
-- Database schema, API contract, or config changes
-- The orchestrator is unsure how to fix it
-
-**When in doubt → dispatch ring droid.** If you cannot confidently classify a fix as
-simple, treat it as complex.
-
-#### Direct Fix (simple findings)
-
-The orchestrator applies the fix directly using Edit/MultiEdit tools. After applying:
-1. Run unit tests to verify no regression
-2. If tests fail, revert and escalate to ring droid dispatch
-
-#### Ring Droid Dispatch (complex findings)
-
-**Code fixes** → dispatch ring backend/frontend/QA droids with **TDD cycle** (RED-GREEN-REFACTOR):
-- `ring-dev-team-backend-engineer-golang` (Go), `ring-dev-team-backend-engineer-typescript` (TS),
-  `ring-dev-team-frontend-engineer` (React/Next.js), `ring-dev-team-qa-analyst` (tests)
-
-**Documentation fixes** → dispatch ring documentation droids **without TDD** (no tests for docs):
-- `ring-tw-team-functional-writer` (guides), `ring-tw-team-api-writer` (API docs),
-  `ring-tw-team-docs-reviewer` (quality fixes)
-
-**Ring droids are REQUIRED for complex fixes** — there is no alternative dispatch mechanism. If the
-required droids are not installed and a complex fix is needed, the skill MUST stop and
-inform the user which droids need to be installed.
-
 
 ### Protocol: Active Version Guard (summarized)
 
@@ -1179,39 +1108,11 @@ inform the user which droids need to be installed.
 
 **Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
-### Protocol: Default Branch Refusal (HARD BLOCK)
+### Protocol: Default Branch Refusal (HARD BLOCK) (summarized)
 
-**Referenced by:** build, review, done
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Branch Refusal (HARD BLOCK)`.**
 
-**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
-in edge cases (user cancels the AskUser prompt, silent failure, future skill that
-forgets to invoke the protocol). A second, unconditional refusal at the start of any
-mutating stage prevents accidental commits, worktree removals, or status writes on
-the default branch.
-
-```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-if [ -z "$DEFAULT_BRANCH" ]; then
-  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
-    DEFAULT_BRANCH="main"
-  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
-    DEFAULT_BRANCH="master"
-  fi
-fi
-CURRENT=$(git branch --show-current 2>/dev/null)
-if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
-  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
-  exit 1
-fi
-```
-
-**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
-the skill performs any state.json write, git commit, git worktree mutation, or
-status transition.
-
-Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
-
+**Summary:** Mutating stage skills (build, review, done) MUST refuse to run on the project's default branch (main/master). Defense-in-depth even after Workspace Auto-Navigation. Resolves DEFAULT_BRANCH via `git symbolic-ref refs/remotes/origin/HEAD` with main→master fallback; compares to `git branch --show-current`; STOP with explicit error message if equal. Invoke immediately after Workspace Auto-Navigation, before any state.json write, git commit, worktree mutation, or status transition. See full recipe in AGENTS.md.
 
 ### Protocol: Divergence Warning (summarized)
 
@@ -1219,31 +1120,11 @@ Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see 
 
 **Summary:** Detects when `optimus-tasks.md` has diverged between the current branch and the tasks repo's default branch. Uses `tasks_git` so it works in both same-repo and separate-repo scopes. Throttles `tasks_git fetch` via a 5-minute cache marker at `${MAIN_WORKTREE}/.optimus/.last-tasks-fetch` (defense-in-depth: validates marker contents are numeric before arithmetic to survive corrupted marker files under `set -euo pipefail`). Compares against `origin/$TASKS_DEFAULT_BRANCH` via `tasks_git diff` limited to `$TASKS_GIT_REL`. On non-empty diff, warns via `AskUser` with options to **Sync now** (merge `origin/<default>`) or **Continue without syncing**. NOT a HARD BLOCK — divergence is a soft warning. Skipped silently when `TASKS_DEFAULT_BRANCH` is unresolved. See full recipe in AGENTS.md.
 
-## Protocol: Dry-Run Mode
+### Protocol: Dry-Run Mode (summarized)
 
-**Referenced by:** plan, build, review, done (all stage agents 1-4).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Dry-Run Mode`.**
 
-All stage agents support **dry-run mode**. When the user includes "dry-run" or
-"preview" in their invocation (e.g., "dry-run spec T-003", "preview review T-012"),
-the agent MUST:
-
-1. **Run all analysis/validation phases normally** — agent dispatch, findings, etc.
-2. **Do NOT change task status** — skip the status update step in state.json.
-3. **Do NOT commit or push anything** — no git operations that modify state.
-4. **Do NOT create workspaces** — skip branch/worktree creation (stage-1 only).
-5. **Do NOT apply fixes** — skip batch-apply phases.
-6. **Do NOT increment stage stats** — skip the Increment Stage Stats protocol.
-7. **Do NOT write session files** — session state is for crash recovery of real
-   executions, not previews.
-8. **Skip convergence rounds 2+** — round 1 (primary review pass) is sufficient
-   for preview; do NOT enter the convergence loop.
-9. **Present results as informational** — phrase the summary as "what would happen"
-   without implying any side effects occurred.
-
-Stage agents may add stage-specific dry-run notes (e.g., which phase numbers
-to skip), but MUST NOT relax any of the rules above. The point of dry-run is
-to give the user a reliable preview with zero state mutation.
-
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 
@@ -1259,41 +1140,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Increment Stage Stats
+### Protocol: Increment Stage Stats (summarized)
 
-**Referenced by:** plan, review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Increment Stage Stats`.**
 
-After the status change in state.json (and BEFORE any analysis work begins), increment
-the execution counter for the current stage in `.optimus/stats.json`. This tracks how many
-times each stage ran on each task — useful for spotting spec churn and review cycles.
-
-**NOTE:** Only increment when NOT in dry-run mode.
-
-1. Read `.optimus/stats.json`. If the file does not exist, start with an empty object `{}`.
-   If the file exists but is corrupted, reset it:
-   ```bash
-   # Requires Protocol: Resolve Main Worktree Path to have run first
-   # (or resolve inline; see that protocol).
-   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-   STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-   if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
-     echo "WARNING: stats.json is corrupted. Resetting counters."
-     echo '{}' > "$STATS_FILE"
-   fi
-   ```
-2. If the task ID key does not exist, initialize it:
-   ```json
-   { "plan_runs": 0, "review_runs": 0 }
-   ```
-3. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
-4. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
-5. Write the updated JSON back to `.optimus/stats.json` (pretty-printed, sorted keys).
-
-**NOTE:** stats.json is gitignored — no commit needed.
-
-Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
-
+**Summary:** Plan and review increment per-task execution counters in `${MAIN_WORKTREE}/.optimus/stats.json` immediately after the status change (BEFORE analysis starts). Skip in dry-run mode. Recipe: read stats.json (start `{}` if missing); reset to `{}` if corrupted (`jq empty` fails) with WARNING; init task key `{ "plan_runs": 0, "review_runs": 0 }` if absent; increment matching counter; set `last_plan` / `last_review` to UTC ISO 8601; write back pretty-printed with sorted keys. stats.json is gitignored — no commit. See full recipe in AGENTS.md.
 
 ### Protocol: Notification Hooks (summarized)
 
@@ -1344,75 +1195,11 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 **Summary:** `_optimus_quiet_run <label> <command>` redirects stdout+stderr to `${MAIN_WORKTREE}/.optimus/logs/<ts>-<label>-<pid>.log`, emits a single `PASS`/`FAIL` line, and on failure dumps the last 50 lines (with `cat -v` to neutralize ANSI/OSC escape sequences). Uses `umask 0077` on the log file (output may contain credentials/stack traces). Exit code preserved so `if _optimus_quiet_run ...; then ... fi` works. Reserved exit codes: `2` = missing label/command; `3` = cannot create logs dir. Log retention (30-day age cap + 500-file count cap) is pruned at every Initialize Directory + Session State call. Use for verification commands only; never for output the agent must parse turn-by-turn. See full recipe in AGENTS.md.
 
-### Protocol: Re-run Guard
+### Protocol: Re-run Guard (summarized)
 
-**Referenced by:** plan, review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Re-run Guard`.**
 
-After the convergence loop exits and the final report/summary is presented, evaluate
-whether to suggest advancement or offer a re-run. This protocol replaces the static
-"Next step suggestion" in plan and review.
-
-**Logic:**
-
-1. Count `total_findings` produced during this execution (all findings from round 1 AND
-   any convergence rounds that were dispatched — note: with opt-in gating, the user may
-   have skipped them all, in which case only round 1 contributes — from all agents and
-   static analysis, regardless of whether they were fixed or skipped by the user). If
-   findings were grouped (per Finding Presentation item 3), count grouped entries, not
-   individual occurrences.
-2. **If `total_findings == 0`:** The analysis is clean. Suggest the next stage:
-   - plan: "Spec validation clean — 0 findings. Next step: run `/optimus:build` to implement this task."
-   - review: "Implementation review clean — 0 findings. Next step: run `/optimus:done` to close this task."
-3. **If `total_findings > 0`:** Ask via `AskUser`:
-   ```
-   Validation found N findings (X fixed, Y skipped).
-   Re-running dispatches ALL review agents again with clean context (no memory of
-   previous findings — findings you previously skipped will reappear for review).
-   This will consume similar tokens to the initial run. Workspace and status are preserved.
-   ```
-   Options:
-   - **Re-run with clean context** — re-analyze from scratch
-   - **Advance to next stage** — proceed despite findings
-
-4. **If "Re-run with clean context":**
-   - Increment stage stats (new execution)
-   - **Skip:** GitHub CLI check, optimus-tasks.md validation, task identification, session state
-     check, status validation/change, workspace creation, divergence check
-   - **Re-execute:** project structure discovery, document loading, static analysis,
-     coverage profiling, agent dispatch (ALL agents), finding presentation, fix application,
-     convergence loop entry gate (and any rounds the user opts into)
-   - **Session file:** After re-run starts, the session protocol (Protocol: Session State)
-     resumes normal operation — update the session file at each phase transition as usual.
-     This ensures crash recovery during a re-run resumes from the correct phase.
-   - After the re-run completes, apply this protocol again (evaluate findings count)
-   - There is no limit on re-runs — the user controls when to stop
-
-   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
-   context", the orchestrator MUST:
-
-   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
-      or another terminal state at the previous run's end).
-   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
-      that performs work, NOT the load-only phases).
-   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
-   4. Preserve `task_id`, `task_branch`, and any other identity fields.
-   5. After reset, normal `Protocol: Session State` updates resume.
-
-   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
-   short-circuit the re-run's loop, producing a phantom "no findings" result.
-
-5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
-
-**NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
-were resolved. If the user skipped findings in a previous run, they will reappear on
-re-run (clean context has no memory of previous decisions). This is by design.
-
-**NOTE:** Re-run analyzes the current codebase state, including any fixes applied and
-committed during the previous run. It does NOT revert commits. This validates that
-applied fixes are correct and checks for any issues introduced by the fixes.
-
-Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
-
+**Summary:** Replaces the static "next step" suggestion in plan and review. Counts `total_findings` from this execution (grouped entries count as 1). If 0 → suggest next stage (build for plan, done for review). If >0 → `AskUser` offering "Re-run with clean context" (re-dispatches ALL agents with no memory of prior decisions — skipped findings will reappear) or "Advance to next stage". Re-run reset semantics (MANDATORY): reset `convergence_status` to `null`, `phase` to entry, overwrite `started_at`; preserve identity fields. Skip GitHub CLI/tasks validation/workspace/divergence checks; re-execute discovery + dispatch. No re-run limit. See full reset checklist in AGENTS.md.
 
 ### Protocol: Ring Droid Requirement Check (summarized)
 

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -635,39 +635,11 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** When every dependency in a task's `Depends:` column has status `Cancelado`, emit a multi-option resolution message AFTER the per-dep status check loop populates the `DEP_STATUSES` array. Recipe: iterate `DEP_STATUSES`, set `ALL_CANCELLED=true` if every entry equals `Cancelado`; when `ALL_CANCELLED=true` AND the array is non-empty, print three options to stderr — (a) remove all dependencies, (b) replace with alternative task IDs, (c) cancel the task itself — each with the corresponding `/optimus-tasks` invocation, then `exit 1`. If the array is empty or any dep is non-Cancelado, fall through to per-dep error. Variable contract: `DEP_STATUSES` is the canonical name; adapt if existing skill code uses another. See full recipe in AGENTS.md.
 
-### Protocol: Default Branch Refusal (HARD BLOCK)
+### Protocol: Default Branch Refusal (HARD BLOCK) (summarized)
 
-**Referenced by:** build, review, done
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Branch Refusal (HARD BLOCK)`.**
 
-**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
-in edge cases (user cancels the AskUser prompt, silent failure, future skill that
-forgets to invoke the protocol). A second, unconditional refusal at the start of any
-mutating stage prevents accidental commits, worktree removals, or status writes on
-the default branch.
-
-```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-if [ -z "$DEFAULT_BRANCH" ]; then
-  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
-    DEFAULT_BRANCH="main"
-  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
-    DEFAULT_BRANCH="master"
-  fi
-fi
-CURRENT=$(git branch --show-current 2>/dev/null)
-if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
-  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
-  exit 1
-fi
-```
-
-**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
-the skill performs any state.json write, git commit, git worktree mutation, or
-status transition.
-
-Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
-
+**Summary:** Mutating stage skills (build, review, done) MUST refuse to run on the project's default branch (main/master). Defense-in-depth even after Workspace Auto-Navigation. Resolves DEFAULT_BRANCH via `git symbolic-ref refs/remotes/origin/HEAD` with main→master fallback; compares to `git branch --show-current`; STOP with explicit error message if equal. Invoke immediately after Workspace Auto-Navigation, before any state.json write, git commit, worktree mutation, or status transition. See full recipe in AGENTS.md.
 
 ### Protocol: Default Branch Resolution
 
@@ -733,31 +705,11 @@ Skills reference this as: "Resolve default branch — see AGENTS.md Protocol: De
 
 **Summary:** Detects when `optimus-tasks.md` has diverged between the current branch and the tasks repo's default branch. Uses `tasks_git` so it works in both same-repo and separate-repo scopes. Throttles `tasks_git fetch` via a 5-minute cache marker at `${MAIN_WORKTREE}/.optimus/.last-tasks-fetch` (defense-in-depth: validates marker contents are numeric before arithmetic to survive corrupted marker files under `set -euo pipefail`). Compares against `origin/$TASKS_DEFAULT_BRANCH` via `tasks_git diff` limited to `$TASKS_GIT_REL`. On non-empty diff, warns via `AskUser` with options to **Sync now** (merge `origin/<default>`) or **Continue without syncing**. NOT a HARD BLOCK — divergence is a soft warning. Skipped silently when `TASKS_DEFAULT_BRANCH` is unresolved. See full recipe in AGENTS.md.
 
-## Protocol: Dry-Run Mode
+### Protocol: Dry-Run Mode (summarized)
 
-**Referenced by:** plan, build, review, done (all stage agents 1-4).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Dry-Run Mode`.**
 
-All stage agents support **dry-run mode**. When the user includes "dry-run" or
-"preview" in their invocation (e.g., "dry-run spec T-003", "preview review T-012"),
-the agent MUST:
-
-1. **Run all analysis/validation phases normally** — agent dispatch, findings, etc.
-2. **Do NOT change task status** — skip the status update step in state.json.
-3. **Do NOT commit or push anything** — no git operations that modify state.
-4. **Do NOT create workspaces** — skip branch/worktree creation (stage-1 only).
-5. **Do NOT apply fixes** — skip batch-apply phases.
-6. **Do NOT increment stage stats** — skip the Increment Stage Stats protocol.
-7. **Do NOT write session files** — session state is for crash recovery of real
-   executions, not previews.
-8. **Skip convergence rounds 2+** — round 1 (primary review pass) is sufficient
-   for preview; do NOT enter the convergence loop.
-9. **Present results as informational** — phrase the summary as "what would happen"
-   without implying any side effects occurred.
-
-Stage agents may add stage-specific dry-run notes (e.g., which phase numbers
-to skip), but MUST NOT relax any of the rules above. The point of dry-run is
-to give the user a reliable preview with zero state mutation.
-
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -1012,48 +1012,13 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves `TASKS_DIR` (from `.optimus/config.json` `tasksDir` key, default `docs/pre-dev`) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then detects whether tasksDir lives inside the project repo (`same-repo`) or a separate git repo (`separate-repo`). Sets `TASKS_REPO_ROOT`, `TASKS_GIT_REL`, `TASKS_DEFAULT_BRANCH`, and exposes a `tasks_git()` helper that wraps `git -C "$TASKS_DIR"` in separate-repo mode. Hard guards: reject `tasksDir` starting with `-` (git-option injection), require `python3` for separate-repo path computation, validate `TASKS_DEFAULT_BRANCH` against `^[a-zA-Z0-9._/-]+$`. Skills MUST use `tasks_git` (never raw `git`) on `$TASKS_FILE`. See full recipe in AGENTS.md.
 
-### Deep Research Before Presenting (MANDATORY for cycle review skills)
+### Deep Research Before Presenting (MANDATORY for cycle review skills) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Deep Research Before Presenting (MANDATORY for cycle review skills)`.**
+
+**Summary:** Before presenting ANY finding, cycle review skills (plan, review, pr-check, coderabbit-review) MUST research silently across 12 dimensions: project patterns + similar cases, architectural decisions (AGENTS.md/TRD/ADRs), existing codebase precedent, current task focus, user/consumer use cases, UX impact, API best practices, engineering best practices (SOLID/DRY/observability), language idioms (`WebSearch`), correctness over convenience, production resilience (timeouts, retries, leaks), data integrity + privacy (LGPD/GDPR). Recommendation Option A MUST be evidence-backed (not generic). NOT optional — prevents false-positive findings. See full 12-item checklist in AGENTS.md.
+
 Applies to: plan, review, pr-check, coderabbit-review
-
-**BEFORE presenting any finding to the user, the agent MUST research it deeply.** This
-research is done SILENTLY — do not show the research process. Present only the conclusions.
-
-**Research checklist (ALL items, every finding):**
-
-1. **Project patterns:** Read the affected file(s) fully. Check how similar cases are handled
-   elsewhere in the codebase. Identify existing conventions the finding might violate or follow.
-2. **Architectural decisions:** Review project rules (AGENTS.md, PROJECT_RULES.md, etc.) and
-   architecture docs (TRD, ADRs). Understand WHY the project is structured this way before
-   suggesting changes.
-3. **Existing codebase:** Search for precedent. If the codebase already does the same thing
-   in 10 other places without issue, that context changes the finding's weight.
-4. **Current task focus:** Is this finding within the scope of the task being worked on?
-   Tangential findings should be flagged as such (not dismissed, but contextualized).
-5. **User/consumer use cases:** Who consumes this code — end users, other services, internal
-   modules? How does the finding affect them? Trace the impact to real user scenarios.
-6. **UX impact:** For user-facing changes, evaluate usability, accessibility, error messaging,
-   and workflows. Would the user notice? Would it block their work?
-7. **API best practices:** For API changes, check REST conventions, error handling patterns,
-   idempotency, status codes, pagination, versioning, and backward compatibility.
-8. **Engineering best practices:** SOLID principles, DRY, separation of concerns, error
-   handling, resilience patterns, observability, testability.
-9. **Language-specific best practices:** Use `WebSearch` to research idioms and conventions
-   for the specific language (Go, TypeScript, Python, etc.). Check official style guides,
-   common linter rules, and community-accepted patterns.
-10. **Correctness over convenience:** Always recommend the correct approach, regardless of
-    effort. The easy option may be presented as an alternative, but Option A must be what
-    the agent believes is right based on all the research above.
-11. **Production resilience:** Would this code survive production conditions? Consider:
-    timeouts on external calls, retry with backoff, circuit breakers, graceful degradation,
-    resource cleanup (connections, handles, goroutines), graceful shutdown, and behavior
-    under load (N+1 queries, unbounded queries, connection pool exhaustion).
-12. **Data integrity and privacy:** Are transaction boundaries correct? Could partial writes
-    occur? Is PII properly handled (not logged, masked in responses)? LGPD/GDPR compliance?
-
-**After research, form the recommendation:** Option A MUST be the approach the agent
-believes is correct based on the research. It must be backed by evidence (project patterns,
-best practice references, official documentation), not just a generic suggestion.
-
 
 ### Finding Option Format (MANDATORY for cycle review skills)
 
@@ -1093,54 +1058,11 @@ Every finding must present 2-3 options with this structure:
 
 **Summary:** When every dependency in a task's `Depends:` column has status `Cancelado`, emit a multi-option resolution message AFTER the per-dep status check loop populates the `DEP_STATUSES` array. Recipe: iterate `DEP_STATUSES`, set `ALL_CANCELLED=true` if every entry equals `Cancelado`; when `ALL_CANCELLED=true` AND the array is non-empty, print three options to stderr — (a) remove all dependencies, (b) replace with alternative task IDs, (c) cancel the task itself — each with the corresponding `/optimus-tasks` invocation, then `exit 1`. If the array is empty or any dep is non-Cancelado, fall through to per-dep error. Variable contract: `DEP_STATUSES` is the canonical name; adapt if existing skill code uses another. See full recipe in AGENTS.md.
 
-### Protocol: Branch Name Derivation
+### Protocol: Branch Name Derivation (summarized)
 
-**Referenced by:** plan, build, review, pr-check, done (workspace auto-navigation)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Branch Name Derivation`.**
 
-Branch names are derived deterministically from the task's structural data in optimus-tasks.md.
-They are NOT stored in optimus-tasks.md — they are stored in state.json for quick reference
-and can always be re-derived.
-
-**Derivation rule:**
-
-```
-<tipo-prefix>/<task-id-lowercase>-<keywords>
-```
-
-Where:
-- `<tipo-prefix>` is mapped from the Tipo column: Feature→`feat`, Fix→`fix`,
-  Refactor→`refactor`, Chore→`chore`, Docs→`docs`, Test→`test`
-- `<task-id-lowercase>` is the task ID in lowercase (e.g., `t-003`)
-- `<keywords>` are 2-4 lowercase words from the Title, stripping articles,
-  prepositions, and generic words (implement, add, create, update)
-
-**Sanitization (applied to keywords before constructing branch name):**
-1. Convert to lowercase
-2. Replace non-alphanumeric characters (except hyphens) with hyphens
-3. Collapse consecutive hyphens to a single hyphen
-4. Remove leading/trailing hyphens from each keyword
-5. Truncate the full branch name to 100 characters
-
-**Examples:**
-- T-003 "User Auth JWT" (Feature) → `feat/t-003-user-auth-jwt`
-- T-007 "Duplicate Login" (Fix) → `fix/t-007-duplicate-login`
-- T-012 "Extract Middleware" (Refactor) → `refactor/t-012-extract-middleware`
-- T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
-
-**Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest, source-of-truth).
-2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
-   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
-   ```bash
-   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
-   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
-   git worktree list --porcelain 2>/dev/null \
-     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
-   ```
-3. Derive from Tipo + ID + Title (always works).
-
-Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
-
+**Summary:** Branch names derived deterministically from task structural data — NOT stored in optimus-tasks.md, only cached in state.json. Format: `<tipo-prefix>/<task-id-lowercase>-<keywords>`. Tipo→prefix: Feature→feat, Fix→fix, Refactor→refactor, Chore→chore, Docs→docs, Test→test. Keywords: 2-4 lowercase title words, articles/prepositions/generic verbs (implement/add/create/update) stripped. Sanitization: lowercase → non-alphanumeric to hyphens → collapse hyphens → strip leading/trailing → 100-char cap. Resolution order: state.json `branch` field → kebab-anchored search (`-t-003-` to avoid T-1/T-10 collision via `git branch --list "*${KEBAB#-}*"`) → derive from Tipo+ID+Title. See full sanitization + Tipo table + examples in AGENTS.md.
 
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated) (summarized)
 
@@ -1154,31 +1076,11 @@ Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch
 
 **Summary:** Detects when `optimus-tasks.md` has diverged between the current branch and the tasks repo's default branch. Uses `tasks_git` so it works in both same-repo and separate-repo scopes. Throttles `tasks_git fetch` via a 5-minute cache marker at `${MAIN_WORKTREE}/.optimus/.last-tasks-fetch` (defense-in-depth: validates marker contents are numeric before arithmetic to survive corrupted marker files under `set -euo pipefail`). Compares against `origin/$TASKS_DEFAULT_BRANCH` via `tasks_git diff` limited to `$TASKS_GIT_REL`. On non-empty diff, warns via `AskUser` with options to **Sync now** (merge `origin/<default>`) or **Continue without syncing**. NOT a HARD BLOCK — divergence is a soft warning. Skipped silently when `TASKS_DEFAULT_BRANCH` is unresolved. See full recipe in AGENTS.md.
 
-## Protocol: Dry-Run Mode
+### Protocol: Dry-Run Mode (summarized)
 
-**Referenced by:** plan, build, review, done (all stage agents 1-4).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Dry-Run Mode`.**
 
-All stage agents support **dry-run mode**. When the user includes "dry-run" or
-"preview" in their invocation (e.g., "dry-run spec T-003", "preview review T-012"),
-the agent MUST:
-
-1. **Run all analysis/validation phases normally** — agent dispatch, findings, etc.
-2. **Do NOT change task status** — skip the status update step in state.json.
-3. **Do NOT commit or push anything** — no git operations that modify state.
-4. **Do NOT create workspaces** — skip branch/worktree creation (stage-1 only).
-5. **Do NOT apply fixes** — skip batch-apply phases.
-6. **Do NOT increment stage stats** — skip the Increment Stage Stats protocol.
-7. **Do NOT write session files** — session state is for crash recovery of real
-   executions, not previews.
-8. **Skip convergence rounds 2+** — round 1 (primary review pass) is sufficient
-   for preview; do NOT enter the convergence loop.
-9. **Present results as informational** — phrase the summary as "what would happen"
-   without implying any side effects occurred.
-
-Stage agents may add stage-specific dry-run notes (e.g., which phase numbers
-to skip), but MUST NOT relax any of the rules above. The point of dry-run is
-to give the user a reliable preview with zero state mutation.
-
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 
@@ -1194,41 +1096,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Increment Stage Stats
+### Protocol: Increment Stage Stats (summarized)
 
-**Referenced by:** plan, review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Increment Stage Stats`.**
 
-After the status change in state.json (and BEFORE any analysis work begins), increment
-the execution counter for the current stage in `.optimus/stats.json`. This tracks how many
-times each stage ran on each task — useful for spotting spec churn and review cycles.
-
-**NOTE:** Only increment when NOT in dry-run mode.
-
-1. Read `.optimus/stats.json`. If the file does not exist, start with an empty object `{}`.
-   If the file exists but is corrupted, reset it:
-   ```bash
-   # Requires Protocol: Resolve Main Worktree Path to have run first
-   # (or resolve inline; see that protocol).
-   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-   STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-   if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
-     echo "WARNING: stats.json is corrupted. Resetting counters."
-     echo '{}' > "$STATS_FILE"
-   fi
-   ```
-2. If the task ID key does not exist, initialize it:
-   ```json
-   { "plan_runs": 0, "review_runs": 0 }
-   ```
-3. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
-4. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
-5. Write the updated JSON back to `.optimus/stats.json` (pretty-printed, sorted keys).
-
-**NOTE:** stats.json is gitignored — no commit needed.
-
-Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
-
+**Summary:** Plan and review increment per-task execution counters in `${MAIN_WORKTREE}/.optimus/stats.json` immediately after the status change (BEFORE analysis starts). Skip in dry-run mode. Recipe: read stats.json (start `{}` if missing); reset to `{}` if corrupted (`jq empty` fails) with WARNING; init task key `{ "plan_runs": 0, "review_runs": 0 }` if absent; increment matching counter; set `last_plan` / `last_review` to UTC ISO 8601; write back pretty-printed with sorted keys. stats.json is gitignored — no commit. See full recipe in AGENTS.md.
 
 ### Protocol: Notification Hooks (summarized)
 
@@ -1254,75 +1126,11 @@ Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Inc
 
 **Summary:** Optional commit-push pattern for stage skills (plan, build, review, coderabbit-review). After committing locally, offer to push via `AskUser`. Step 1: detect upstream with `git rev-parse --abbrev-ref @{u}` — if missing, all local commits are unpushed and `git push -u origin <branch>` sets upstream; if present, count unpushed via `git log @{u}..HEAD`. Step 2: in `separate-repo` tasks scope, repeat the same upstream/unpushed dance against the tasks repo via `tasks_git`. After successful push, if the current repo is the Optimus plugin repo, run `droid plugin update` for each installed optimus skill so agents pick up the latest version. See full recipe in AGENTS.md.
 
-### Protocol: Re-run Guard
+### Protocol: Re-run Guard (summarized)
 
-**Referenced by:** plan, review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Re-run Guard`.**
 
-After the convergence loop exits and the final report/summary is presented, evaluate
-whether to suggest advancement or offer a re-run. This protocol replaces the static
-"Next step suggestion" in plan and review.
-
-**Logic:**
-
-1. Count `total_findings` produced during this execution (all findings from round 1 AND
-   any convergence rounds that were dispatched — note: with opt-in gating, the user may
-   have skipped them all, in which case only round 1 contributes — from all agents and
-   static analysis, regardless of whether they were fixed or skipped by the user). If
-   findings were grouped (per Finding Presentation item 3), count grouped entries, not
-   individual occurrences.
-2. **If `total_findings == 0`:** The analysis is clean. Suggest the next stage:
-   - plan: "Spec validation clean — 0 findings. Next step: run `/optimus-build` to implement this task."
-   - review: "Implementation review clean — 0 findings. Next step: run `/optimus-done` to close this task."
-3. **If `total_findings > 0`:** Ask via `AskUser`:
-   ```
-   Validation found N findings (X fixed, Y skipped).
-   Re-running dispatches ALL review agents again with clean context (no memory of
-   previous findings — findings you previously skipped will reappear for review).
-   This will consume similar tokens to the initial run. Workspace and status are preserved.
-   ```
-   Options:
-   - **Re-run with clean context** — re-analyze from scratch
-   - **Advance to next stage** — proceed despite findings
-
-4. **If "Re-run with clean context":**
-   - Increment stage stats (new execution)
-   - **Skip:** GitHub CLI check, optimus-tasks.md validation, task identification, session state
-     check, status validation/change, workspace creation, divergence check
-   - **Re-execute:** project structure discovery, document loading, static analysis,
-     coverage profiling, agent dispatch (ALL agents), finding presentation, fix application,
-     convergence loop entry gate (and any rounds the user opts into)
-   - **Session file:** After re-run starts, the session protocol (Protocol: Session State)
-     resumes normal operation — update the session file at each phase transition as usual.
-     This ensures crash recovery during a re-run resumes from the correct phase.
-   - After the re-run completes, apply this protocol again (evaluate findings count)
-   - There is no limit on re-runs — the user controls when to stop
-
-   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
-   context", the orchestrator MUST:
-
-   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
-      or another terminal state at the previous run's end).
-   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
-      that performs work, NOT the load-only phases).
-   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
-   4. Preserve `task_id`, `task_branch`, and any other identity fields.
-   5. After reset, normal `Protocol: Session State` updates resume.
-
-   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
-   short-circuit the re-run's loop, producing a phantom "no findings" result.
-
-5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
-
-**NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
-were resolved. If the user skipped findings in a previous run, they will reappear on
-re-run (clean context has no memory of previous decisions). This is by design.
-
-**NOTE:** Re-run analyzes the current codebase state, including any fixes applied and
-committed during the previous run. It does NOT revert commits. This validates that
-applied fixes are correct and checks for any issues introduced by the fixes.
-
-Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
-
+**Summary:** Replaces the static "next step" suggestion in plan and review. Counts `total_findings` from this execution (grouped entries count as 1). If 0 → suggest next stage (build for plan, done for review). If >0 → `AskUser` offering "Re-run with clean context" (re-dispatches ALL agents with no memory of prior decisions — skipped findings will reappear) or "Advance to next stage". Re-run reset semantics (MANDATORY): reset `convergence_status` to `null`, `phase` to entry, overwrite `started_at`; preserve identity fields. Skip GitHub CLI/tasks validation/workspace/divergence checks; re-execute discovery + dispatch. No re-run limit. See full reset checklist in AGENTS.md.
 
 ### Protocol: Resolve Main Worktree Path (summarized)
 
@@ -1342,48 +1150,11 @@ Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-r
 
 **Summary:** Session lifecycle state at `${MAIN_WORKTREE}/.optimus/sessions/session-${TASK_ID}.json` tracks `task_id`, `branch`, `phase`, `convergence_status`, `started_at`. Update at every phase transition. Initialize `.optimus/` directory + auto-prune `.optimus/logs/` (30-day, 500-file cap) on transition. See full recipe in AGENTS.md.
 
-### Protocol: Shell Safety Guidelines
+### Protocol: Shell Safety Guidelines (summarized)
 
-**Referenced by:** plan, batch
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Shell Safety Guidelines`.**
 
-All bash examples in AGENTS.md and SKILL.md files are templates that agents execute literally.
-Follow these rules to prevent injection and silent failures:
-
-1. **Always quote variables:** Use `"$VAR"` not `$VAR` — especially for paths, branch names, and user-derived values
-2. **Check exit codes for critical commands:**
-   ```bash
-   tasks_git add "$TASKS_GIT_REL"
-   COMMIT_MSG_FILE=$(mktemp)
-   printf '%s' "chore(tasks): $COMMIT_MSG" > "$COMMIT_MSG_FILE"
-   if ! tasks_git commit -F "$COMMIT_MSG_FILE"; then
-     echo "ERROR: git commit failed. Check pre-commit hooks or git config." >&2
-     rm -f "$COMMIT_MSG_FILE"
-     exit 1
-   fi
-   rm -f "$COMMIT_MSG_FILE"
-   ```
-3. **Never interpolate user-derived values directly into shell commands** — task titles,
-   branch names, and other user input may contain shell metacharacters
-4. **Use `grep -F` for fixed string matching** — never pass branch names or task IDs
-   as regex patterns to `grep` without `-F`
-5. **Use `grep -E '^\| T-NNN \|'`** to match task rows in optimus-tasks.md — plain `grep "T-NNN"`
-   matches titles and dependency columns too
-6. **Validate tool availability** before use: `command -v jq >/dev/null 2>&1` before running `jq`
-7. **Validate JSON files** before parsing: `jq empty "$FILE" 2>/dev/null` before reading keys
-8. **Sanitize user-derived values in commit messages** — task titles and descriptions may
-   contain shell metacharacters (backticks, `$(...)`, double quotes). **Mandatory pattern:**
-   write the commit message to a temporary file and use `git commit -F`:
-   ```bash
-   COMMIT_MSG_FILE=$(mktemp)
-   printf '%s' "chore(tasks): $OPERATION" > "$COMMIT_MSG_FILE"
-   git commit -F "$COMMIT_MSG_FILE"
-   rm -f "$COMMIT_MSG_FILE"
-   ```
-   This avoids all shell expansion issues. If using `-m` directly, sanitize with:
-   `SAFE_VALUE=$(printf '%s' "$VALUE" | tr -d '`$')` before interpolation.
-
-Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines."
-
+**Summary:** All bash examples in AGENTS.md/SKILL.md are templates executed literally — follow these rules to prevent injection and silent failures: (1) always quote variables (`"$VAR"`); (2) check exit codes for critical commands; (3) never interpolate user-derived values directly into shell; (4) use `grep -F` for fixed-string matching of branch names/task IDs; (5) match task rows with anchored regex `grep -E '^\| T-NNN \|'`; (6) `command -v jq` before use; (7) `jq empty "$FILE"` before parse; (8) for commit messages with user content, write to `mktemp` file and use `git commit -F` (avoids all expansion). See full anti-pattern list + sanitization recipes in AGENTS.md.
 
 ### Protocol: State Management (summarized)
 
@@ -1403,44 +1174,11 @@ Skills reference this as: "Follow shell safety guidelines — see AGENTS.md Prot
 
 **Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
 
-### Protocol: Worktree Location
+### Protocol: Worktree Location (summarized)
 
-**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Worktree Location`.**
 
-Optimus creates linked git worktrees during the task lifecycle:
-
-- `/optimus-plan` creates a worktree when a task starts (Step 1.0.5).
-- `/optimus-resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
-- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
-
-**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
-
-**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
-
-**Why nested under the project repo:**
-
-| Concern | Resolution |
-|---|---|
-| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
-| Cleanup lifecycle | Removing the project directory also removes worktrees |
-| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
-| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
-| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
-
-**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
-
-- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
-- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
-
-**Backwards compatibility:**
-
-- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
-- New worktrees from `/optimus-plan` and `resume`'s recovery land in `.worktrees/`.
-- No forced migration.
-- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
-
-Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
-
+**Summary:** Linked worktrees created by plan / resume / Workspace Auto-Navigation / done-cleanup live at the canonical path `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by Initialize .optimus Directory + Session State protocols), project-rooted, resolved via Resolve Main Worktree Path so paths stay correct from any linked worktree. Branch names contain `/` (per Branch Name Derivation), creating intermediate `feat/`, `fix/` directories under `.worktrees/` automatically. Worktrees ALWAYS belong to the project repo, never the tasks repo (separate-repo `tasksDir` doesn't affect location). Recommend IDE exclusion (`.vscode/settings.json` `search.exclude`, IntelliJ Excluded). Backwards compat: legacy sibling paths still work via worktree metadata; no forced migration. See full convention + IDE config in AGENTS.md.
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -1805,48 +1805,13 @@ extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Deep Research Before Presenting (MANDATORY for cycle review skills)
+### Deep Research Before Presenting (MANDATORY for cycle review skills) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Deep Research Before Presenting (MANDATORY for cycle review skills)`.**
+
+**Summary:** Before presenting ANY finding, cycle review skills (plan, review, pr-check, coderabbit-review) MUST research silently across 12 dimensions: project patterns + similar cases, architectural decisions (AGENTS.md/TRD/ADRs), existing codebase precedent, current task focus, user/consumer use cases, UX impact, API best practices, engineering best practices (SOLID/DRY/observability), language idioms (`WebSearch`), correctness over convenience, production resilience (timeouts, retries, leaks), data integrity + privacy (LGPD/GDPR). Recommendation Option A MUST be evidence-backed (not generic). NOT optional — prevents false-positive findings. See full 12-item checklist in AGENTS.md.
+
 Applies to: plan, review, pr-check, coderabbit-review
-
-**BEFORE presenting any finding to the user, the agent MUST research it deeply.** This
-research is done SILENTLY — do not show the research process. Present only the conclusions.
-
-**Research checklist (ALL items, every finding):**
-
-1. **Project patterns:** Read the affected file(s) fully. Check how similar cases are handled
-   elsewhere in the codebase. Identify existing conventions the finding might violate or follow.
-2. **Architectural decisions:** Review project rules (AGENTS.md, PROJECT_RULES.md, etc.) and
-   architecture docs (TRD, ADRs). Understand WHY the project is structured this way before
-   suggesting changes.
-3. **Existing codebase:** Search for precedent. If the codebase already does the same thing
-   in 10 other places without issue, that context changes the finding's weight.
-4. **Current task focus:** Is this finding within the scope of the task being worked on?
-   Tangential findings should be flagged as such (not dismissed, but contextualized).
-5. **User/consumer use cases:** Who consumes this code — end users, other services, internal
-   modules? How does the finding affect them? Trace the impact to real user scenarios.
-6. **UX impact:** For user-facing changes, evaluate usability, accessibility, error messaging,
-   and workflows. Would the user notice? Would it block their work?
-7. **API best practices:** For API changes, check REST conventions, error handling patterns,
-   idempotency, status codes, pagination, versioning, and backward compatibility.
-8. **Engineering best practices:** SOLID principles, DRY, separation of concerns, error
-   handling, resilience patterns, observability, testability.
-9. **Language-specific best practices:** Use `WebSearch` to research idioms and conventions
-   for the specific language (Go, TypeScript, Python, etc.). Check official style guides,
-   common linter rules, and community-accepted patterns.
-10. **Correctness over convenience:** Always recommend the correct approach, regardless of
-    effort. The easy option may be presented as an alternative, but Option A must be what
-    the agent believes is right based on all the research above.
-11. **Production resilience:** Would this code survive production conditions? Consider:
-    timeouts on external calls, retry with backoff, circuit breakers, graceful degradation,
-    resource cleanup (connections, handles, goroutines), graceful shutdown, and behavior
-    under load (N+1 queries, unbounded queries, connection pool exhaustion).
-12. **Data integrity and privacy:** Are transaction boundaries correct? Could partial writes
-    occur? Is PII properly handled (not logged, masked in responses)? LGPD/GDPR compliance?
-
-**After research, form the recommendation:** Option A MUST be the approach the agent
-believes is correct based on the research. It must be backed by evidence (project patterns,
-best practice references, official documentation), not just a generic suggestion.
-
 
 ### Finding Option Format (MANDATORY for cycle review skills)
 
@@ -1903,7 +1868,11 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-### Fix Implementation (Complexity-Based Dispatch)
+### Fix Implementation (Complexity-Based Dispatch) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Fix Implementation (Complexity-Based Dispatch)`.**
+
+**Summary:** Cycle review skills classify each approved fix before applying. **Simple** (single file, localized, exact code provided, obvious resolution: typo / missing nil guard / import / log line / dead code removal): orchestrator applies directly via Edit/MultiEdit, runs unit tests; on failure, reverts and escalates. **Complex** (multi-file, architectural impact, security-sensitive, schema/API/config changes, new tests needed, or unsure): dispatch ring droid. Code fixes use TDD cycle (RED-GREEN-REFACTOR) via `ring-dev-team-backend-engineer-golang`/`-typescript`, `ring-dev-team-frontend-engineer`, `ring-dev-team-qa-analyst`. Documentation fixes: `ring-tw-team-functional-writer`/`-api-writer`/`-docs-reviewer` (no TDD). When in doubt → dispatch. Ring droids are REQUIRED for complex fixes — STOP if missing. See full classification + dispatch templates in AGENTS.md.
 
 Fixes are classified by complexity. **Simple fixes** are applied directly by the
 orchestrator. **Complex fixes** (or fixes whose complexity cannot be determined) are
@@ -1912,46 +1881,6 @@ delegated to specialist ring droids.
 #### Complexity Classification
 
 For each approved fix, assess complexity BEFORE applying:
-
-**Simple fix (apply directly):**
-- The review agent already provided the exact code change needed
-- Single file, localized change (few lines)
-- Obvious resolution: typo, missing error check, wrong variable name, missing nil guard,
-  import fix, formatting, adding a log line, renaming, removing dead code
-- No new logic, no architectural impact, no new test scenarios needed
-
-**Complex fix (dispatch ring droid):**
-- Multiple files affected
-- Requires understanding broader codebase context or architectural decisions
-- New functionality, significant refactoring, or new integration points
-- Requires new test scenarios (not just updating existing ones)
-- Security-sensitive changes (auth, crypto, input validation)
-- Database schema, API contract, or config changes
-- The orchestrator is unsure how to fix it
-
-**When in doubt → dispatch ring droid.** If you cannot confidently classify a fix as
-simple, treat it as complex.
-
-#### Direct Fix (simple findings)
-
-The orchestrator applies the fix directly using Edit/MultiEdit tools. After applying:
-1. Run unit tests to verify no regression
-2. If tests fail, revert and escalate to ring droid dispatch
-
-#### Ring Droid Dispatch (complex findings)
-
-**Code fixes** → dispatch ring backend/frontend/QA droids with **TDD cycle** (RED-GREEN-REFACTOR):
-- `ring-dev-team-backend-engineer-golang` (Go), `ring-dev-team-backend-engineer-typescript` (TS),
-  `ring-dev-team-frontend-engineer` (React/Next.js), `ring-dev-team-qa-analyst` (tests)
-
-**Documentation fixes** → dispatch ring documentation droids **without TDD** (no tests for docs):
-- `ring-tw-team-functional-writer` (guides), `ring-tw-team-api-writer` (API docs),
-  `ring-tw-team-docs-reviewer` (quality fixes)
-
-**Ring droids are REQUIRED for complex fixes** — there is no alternative dispatch mechanism. If the
-required droids are not installed and a complex fix is needed, the skill MUST stop and
-inform the user which droids need to be installed.
-
 
 ### Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated) (summarized)
 

--- a/quick-report/skills/optimus-quick-report/SKILL.md
+++ b/quick-report/skills/optimus-quick-report/SKILL.md
@@ -308,88 +308,11 @@ state.json is implicitly `Pendente`.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Protocol: Default Scope Resolution
+### Protocol: Default Scope Resolution (summarized)
 
-**Referenced by:** report, quick-report
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Scope Resolution`.**
 
-Both `report` and `quick-report` support a version scope filter (`ativa`, `upcoming`,
-`all`, or a specific version name). Resolve the effective scope in this order:
-
-1. **Invocation wins.** If the user specified a scope in the invocation (e.g.,
-   "quick report all", "report v2", "report upcoming"), use that scope directly.
-   Skip steps 2-3.
-
-   **Force-ask keywords:** If the invocation contains `ask` or `menu`
-   (e.g., "quick report ask", "report menu"), skip step 2 and go straight to step 3
-   (the AskUser prompt). This lets the user override the saved default for a single run
-   and optionally overwrite it.
-
-2. **Config fallback.** If `.optimus/config.json` has a `defaultScope` key, use it:
-   ```bash
-   CONFIG_FILE="${MAIN_WORKTREE}/.optimus/config.json"
-   if [ -f "$CONFIG_FILE" ] && jq -e '.defaultScope' "$CONFIG_FILE" >/dev/null 2>&1; then
-     SCOPE=$(jq -r '.defaultScope' "$CONFIG_FILE")
-   fi
-   ```
-   **Validation:** `SCOPE` must be `ativa`, `upcoming`, `all`, or match a version name in
-   the `## Versions` table of `optimus-tasks.md`. If invalid (empty, unknown keyword, or a version
-   name that no longer exists), warn the user and fall through to step 3.
-   ```
-   WARNING: .optimus/config.json has defaultScope="<value>" but it is not valid
-   (must be ativa/upcoming/all or an existing version name). Falling back to prompt.
-   ```
-
-3. **Ask user.** Present the standard AskUser prompt:
-   ```
-   Which version scope do you want to see?
-   ```
-   Options:
-   - **Ativa** — only tasks from the active version (`<active_version_name>`)
-   - **Upcoming** — active + planned (Ativa, Próxima, Planejada — excludes Backlog and Concluída)
-   - **All** — all tasks across all versions
-   - **Specific version** — pick one version by name (follow-up AskUser lists versions)
-
-4. **Offer to persist (only when step 3 ran).** After the user picks a scope in step 3,
-   ask a follow-up via AskUser:
-   ```
-   Save "<chosen_scope>" as the default in .optimus/config.json?
-   You can still override per-invocation (e.g., "quick report all") or
-   use "quick report ask" to be prompted again.
-   ```
-   Options:
-   - **Save as default** — write `defaultScope` to `.optimus/config.json`
-   - **Just this time** — do not persist
-
-5. **Persist the scope (if user chose to save):**
-   ```bash
-   # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-   CONFIG_FILE="${MAIN_WORKTREE}/.optimus/config.json"
-   if [ ! -f "$CONFIG_FILE" ]; then
-     echo '{}' > "$CONFIG_FILE"
-   fi
-   if jq --arg s "$SCOPE" '.defaultScope = $s' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp"; then
-     if jq empty "${CONFIG_FILE}.tmp" 2>/dev/null; then
-       mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
-     else
-       rm -f "${CONFIG_FILE}.tmp"
-       echo "ERROR: jq produced invalid JSON — config.json unchanged"
-     fi
-   else
-     rm -f "${CONFIG_FILE}.tmp"
-     echo "ERROR: jq failed to update config.json"
-   fi
-   ```
-   **NOTE:** `config.json` is gitignored (per-user preference). The saved `defaultScope`
-   affects only the local environment — each user can choose their own default. These
-   skills are read-only for code/tasks — writing to `config.json` is the single allowed
-   side-effect, and only when the user explicitly agrees.
-
-**NOTE:** Scope names are case-insensitive for user input. Normalize to lowercase for
-`ativa`/`upcoming`/`all`, but preserve the original casing when the scope is a specific
-version name (version names are case-sensitive to match the Versions table).
-
-Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Default Scope Resolution."
-
+**Summary:** Read-only skills (report, quick-report) resolve a version scope filter (`ativa`, `upcoming`, `all`, or specific version name). Resolution order: (1) invocation argument wins, with `ask`/`menu` keywords forcing the prompt; (2) fall back to `defaultScope` in `${MAIN_WORKTREE}/.optimus/config.json` (validated against versions table — warn + reprompt if invalid); (3) `AskUser` with Ativa/Upcoming/All/Specific options; (4) offer to persist the choice to config.json (atomic jq write to tmp + mv). Scope names case-insensitive for keywords; case-preserved for version names. See full recipe in AGENTS.md.
 
 ### Protocol: Resolve Tasks Git Scope (summarized)
 

--- a/report/skills/optimus-report/SKILL.md
+++ b/report/skills/optimus-report/SKILL.md
@@ -747,88 +747,11 @@ state.json is implicitly `Pendente`.
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Protocol: Default Scope Resolution
+### Protocol: Default Scope Resolution (summarized)
 
-**Referenced by:** report, quick-report
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Scope Resolution`.**
 
-Both `report` and `quick-report` support a version scope filter (`ativa`, `upcoming`,
-`all`, or a specific version name). Resolve the effective scope in this order:
-
-1. **Invocation wins.** If the user specified a scope in the invocation (e.g.,
-   "quick report all", "report v2", "report upcoming"), use that scope directly.
-   Skip steps 2-3.
-
-   **Force-ask keywords:** If the invocation contains `ask` or `menu`
-   (e.g., "quick report ask", "report menu"), skip step 2 and go straight to step 3
-   (the AskUser prompt). This lets the user override the saved default for a single run
-   and optionally overwrite it.
-
-2. **Config fallback.** If `.optimus/config.json` has a `defaultScope` key, use it:
-   ```bash
-   CONFIG_FILE="${MAIN_WORKTREE}/.optimus/config.json"
-   if [ -f "$CONFIG_FILE" ] && jq -e '.defaultScope' "$CONFIG_FILE" >/dev/null 2>&1; then
-     SCOPE=$(jq -r '.defaultScope' "$CONFIG_FILE")
-   fi
-   ```
-   **Validation:** `SCOPE` must be `ativa`, `upcoming`, `all`, or match a version name in
-   the `## Versions` table of `optimus-tasks.md`. If invalid (empty, unknown keyword, or a version
-   name that no longer exists), warn the user and fall through to step 3.
-   ```
-   WARNING: .optimus/config.json has defaultScope="<value>" but it is not valid
-   (must be ativa/upcoming/all or an existing version name). Falling back to prompt.
-   ```
-
-3. **Ask user.** Present the standard AskUser prompt:
-   ```
-   Which version scope do you want to see?
-   ```
-   Options:
-   - **Ativa** — only tasks from the active version (`<active_version_name>`)
-   - **Upcoming** — active + planned (Ativa, Próxima, Planejada — excludes Backlog and Concluída)
-   - **All** — all tasks across all versions
-   - **Specific version** — pick one version by name (follow-up AskUser lists versions)
-
-4. **Offer to persist (only when step 3 ran).** After the user picks a scope in step 3,
-   ask a follow-up via AskUser:
-   ```
-   Save "<chosen_scope>" as the default in .optimus/config.json?
-   You can still override per-invocation (e.g., "quick report all") or
-   use "quick report ask" to be prompted again.
-   ```
-   Options:
-   - **Save as default** — write `defaultScope` to `.optimus/config.json`
-   - **Just this time** — do not persist
-
-5. **Persist the scope (if user chose to save):**
-   ```bash
-   # Initialize .optimus directory — see AGENTS.md Protocol: Initialize .optimus Directory.
-   CONFIG_FILE="${MAIN_WORKTREE}/.optimus/config.json"
-   if [ ! -f "$CONFIG_FILE" ]; then
-     echo '{}' > "$CONFIG_FILE"
-   fi
-   if jq --arg s "$SCOPE" '.defaultScope = $s' "$CONFIG_FILE" > "${CONFIG_FILE}.tmp"; then
-     if jq empty "${CONFIG_FILE}.tmp" 2>/dev/null; then
-       mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
-     else
-       rm -f "${CONFIG_FILE}.tmp"
-       echo "ERROR: jq produced invalid JSON — config.json unchanged"
-     fi
-   else
-     rm -f "${CONFIG_FILE}.tmp"
-     echo "ERROR: jq failed to update config.json"
-   fi
-   ```
-   **NOTE:** `config.json` is gitignored (per-user preference). The saved `defaultScope`
-   affects only the local environment — each user can choose their own default. These
-   skills are read-only for code/tasks — writing to `config.json` is the single allowed
-   side-effect, and only when the user explicitly agrees.
-
-**NOTE:** Scope names are case-insensitive for user input. Normalize to lowercase for
-`ativa`/`upcoming`/`all`, but preserve the original casing when the scope is a specific
-version name (version names are case-sensitive to match the Versions table).
-
-Skills reference this as: "Resolve default scope — see AGENTS.md Protocol: Default Scope Resolution."
-
+**Summary:** Read-only skills (report, quick-report) resolve a version scope filter (`ativa`, `upcoming`, `all`, or specific version name). Resolution order: (1) invocation argument wins, with `ask`/`menu` keywords forcing the prompt; (2) fall back to `defaultScope` in `${MAIN_WORKTREE}/.optimus/config.json` (validated against versions table — warn + reprompt if invalid); (3) `AskUser` with Ativa/Upcoming/All/Specific options; (4) offer to persist the choice to config.json (atomic jq write to tmp + mv). Scope names case-insensitive for keywords; case-preserved for version names. See full recipe in AGENTS.md.
 
 ### Protocol: Initialize .optimus Directory (summarized)
 

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -776,54 +776,11 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolves `TASKS_DIR` (from `.optimus/config.json` `tasksDir` key, default `docs/pre-dev`) and `TASKS_FILE` (`<tasksDir>/optimus-tasks.md`), then detects whether tasksDir lives inside the project repo (`same-repo`) or a separate git repo (`separate-repo`). Sets `TASKS_REPO_ROOT`, `TASKS_GIT_REL`, `TASKS_DEFAULT_BRANCH`, and exposes a `tasks_git()` helper that wraps `git -C "$TASKS_DIR"` in separate-repo mode. Hard guards: reject `tasksDir` starting with `-` (git-option injection), require `python3` for separate-repo path computation, validate `TASKS_DEFAULT_BRANCH` against `^[a-zA-Z0-9._/-]+$`. Skills MUST use `tasks_git` (never raw `git`) on `$TASKS_FILE`. See full recipe in AGENTS.md.
 
-### Protocol: Branch Name Derivation
+### Protocol: Branch Name Derivation (summarized)
 
-**Referenced by:** plan, build, review, pr-check, done (workspace auto-navigation)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Branch Name Derivation`.**
 
-Branch names are derived deterministically from the task's structural data in optimus-tasks.md.
-They are NOT stored in optimus-tasks.md — they are stored in state.json for quick reference
-and can always be re-derived.
-
-**Derivation rule:**
-
-```
-<tipo-prefix>/<task-id-lowercase>-<keywords>
-```
-
-Where:
-- `<tipo-prefix>` is mapped from the Tipo column: Feature→`feat`, Fix→`fix`,
-  Refactor→`refactor`, Chore→`chore`, Docs→`docs`, Test→`test`
-- `<task-id-lowercase>` is the task ID in lowercase (e.g., `t-003`)
-- `<keywords>` are 2-4 lowercase words from the Title, stripping articles,
-  prepositions, and generic words (implement, add, create, update)
-
-**Sanitization (applied to keywords before constructing branch name):**
-1. Convert to lowercase
-2. Replace non-alphanumeric characters (except hyphens) with hyphens
-3. Collapse consecutive hyphens to a single hyphen
-4. Remove leading/trailing hyphens from each keyword
-5. Truncate the full branch name to 100 characters
-
-**Examples:**
-- T-003 "User Auth JWT" (Feature) → `feat/t-003-user-auth-jwt`
-- T-007 "Duplicate Login" (Fix) → `fix/t-007-duplicate-login`
-- T-012 "Extract Middleware" (Refactor) → `refactor/t-012-extract-middleware`
-- T-015 "User Auth: JWT/OAuth2 Support" (Feature) → `feat/t-015-user-auth-jwt-oauth2-support`
-
-**Resolution order when looking for a task's branch:**
-1. Read `branch` from state.json (fastest, source-of-truth).
-2. Search by task ID using the kebab-anchored fallback (NEVER an unanchored
-   `grep -iF "$TASK_ID"`, which matches `T-1` against `T-10`/`T-100`):
-   ```bash
-   TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
-   git branch --list "*${TASK_KEBAB#-}*" 2>/dev/null
-   git worktree list --porcelain 2>/dev/null \
-     | awk -v anchor="$TASK_KEBAB" '/^worktree / { path=$2; if (index(tolower(path), anchor) > 0) print path }'
-   ```
-3. Derive from Tipo + ID + Title (always works).
-
-Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch Name Derivation."
-
+**Summary:** Branch names derived deterministically from task structural data — NOT stored in optimus-tasks.md, only cached in state.json. Format: `<tipo-prefix>/<task-id-lowercase>-<keywords>`. Tipo→prefix: Feature→feat, Fix→fix, Refactor→refactor, Chore→chore, Docs→docs, Test→test. Keywords: 2-4 lowercase title words, articles/prepositions/generic verbs (implement/add/create/update) stripped. Sanitization: lowercase → non-alphanumeric to hyphens → collapse hyphens → strip leading/trailing → 100-char cap. Resolution order: state.json `branch` field → kebab-anchored search (`-t-003-` to avoid T-1/T-10 collision via `git branch --list "*${KEBAB#-}*"`) → derive from Tipo+ID+Title. See full sanitization + Tipo table + examples in AGENTS.md.
 
 ### Protocol: Initialize .optimus Directory (summarized)
 
@@ -843,44 +800,11 @@ Skills reference this as: "Derive branch name — see AGENTS.md Protocol: Branch
 
 **Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
 
-### Protocol: Worktree Location
+### Protocol: Worktree Location (summarized)
 
-**Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Worktree Location`.**
 
-Optimus creates linked git worktrees during the task lifecycle:
-
-- `/optimus-plan` creates a worktree when a task starts (Step 1.0.5).
-- `/optimus-resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
-- Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
-
-**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
-
-**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
-
-**Why nested under the project repo:**
-
-| Concern | Resolution |
-|---|---|
-| Discoverability | All worktrees for a project listed by `ls <repo>/.worktrees/` |
-| Cleanup lifecycle | Removing the project directory also removes worktrees |
-| `.optimus/` companion | Both `.optimus/` and `.worktrees/` live inside the repo, gitignored — same operational pattern |
-| Cross-repo safety | Worktrees always belong to the **project repo**, never the tasks repo (separate-repo `tasksDir` does not affect worktree location) |
-| Main-worktree resolution | `git worktree list --porcelain` correctly identifies main first regardless of nested linked worktrees — Protocol: Resolve Main Worktree Path unaffected |
-
-**IDE exclusion (recommended):** add `.worktrees/` to your editor's search/index exclusions to prevent double-indexing the same files in main and linked worktrees.
-
-- VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
-- IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
-
-**Backwards compatibility:**
-
-- Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
-- New worktrees from `/optimus-plan` and `resume`'s recovery land in `.worktrees/`.
-- No forced migration.
-- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
-
-Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
-
+**Summary:** Linked worktrees created by plan / resume / Workspace Auto-Navigation / done-cleanup live at the canonical path `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by Initialize .optimus Directory + Session State protocols), project-rooted, resolved via Resolve Main Worktree Path so paths stay correct from any linked worktree. Branch names contain `/` (per Branch Name Derivation), creating intermediate `feat/`, `fix/` directories under `.worktrees/` automatically. Worktrees ALWAYS belong to the project repo, never the tasks repo (separate-repo `tasksDir` doesn't affect location). Recommend IDE exclusion (`.vscode/settings.json` `search.exclude`, IntelliJ Excluded). Backwards compat: legacy sibling paths still work via worktree metadata; no forced migration. See full convention + IDE config in AGENTS.md.
 
 ### Protocol: optimus-tasks.md Validation (HARD BLOCK) (summarized)
 

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -1072,48 +1072,13 @@ to import from Ring pre-dev." Do NOT proceed to task identification with an empt
 
 **Summary:** Resolve `MAIN_WORKTREE` once via `git worktree list --porcelain | awk '/^worktree / {print $2; exit}'` with `${MAIN_WORKTREE:?…}` defensive guard. Use `${MAIN_WORKTREE}/.optimus/...` for ALL `.optimus/` paths (gitignored, so doesn't propagate across linked worktrees). See full recipe in AGENTS.md.
 
-### Deep Research Before Presenting (MANDATORY for cycle review skills)
+### Deep Research Before Presenting (MANDATORY for cycle review skills) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Deep Research Before Presenting (MANDATORY for cycle review skills)`.**
+
+**Summary:** Before presenting ANY finding, cycle review skills (plan, review, pr-check, coderabbit-review) MUST research silently across 12 dimensions: project patterns + similar cases, architectural decisions (AGENTS.md/TRD/ADRs), existing codebase precedent, current task focus, user/consumer use cases, UX impact, API best practices, engineering best practices (SOLID/DRY/observability), language idioms (`WebSearch`), correctness over convenience, production resilience (timeouts, retries, leaks), data integrity + privacy (LGPD/GDPR). Recommendation Option A MUST be evidence-backed (not generic). NOT optional — prevents false-positive findings. See full 12-item checklist in AGENTS.md.
+
 Applies to: plan, review, pr-check, coderabbit-review
-
-**BEFORE presenting any finding to the user, the agent MUST research it deeply.** This
-research is done SILENTLY — do not show the research process. Present only the conclusions.
-
-**Research checklist (ALL items, every finding):**
-
-1. **Project patterns:** Read the affected file(s) fully. Check how similar cases are handled
-   elsewhere in the codebase. Identify existing conventions the finding might violate or follow.
-2. **Architectural decisions:** Review project rules (AGENTS.md, PROJECT_RULES.md, etc.) and
-   architecture docs (TRD, ADRs). Understand WHY the project is structured this way before
-   suggesting changes.
-3. **Existing codebase:** Search for precedent. If the codebase already does the same thing
-   in 10 other places without issue, that context changes the finding's weight.
-4. **Current task focus:** Is this finding within the scope of the task being worked on?
-   Tangential findings should be flagged as such (not dismissed, but contextualized).
-5. **User/consumer use cases:** Who consumes this code — end users, other services, internal
-   modules? How does the finding affect them? Trace the impact to real user scenarios.
-6. **UX impact:** For user-facing changes, evaluate usability, accessibility, error messaging,
-   and workflows. Would the user notice? Would it block their work?
-7. **API best practices:** For API changes, check REST conventions, error handling patterns,
-   idempotency, status codes, pagination, versioning, and backward compatibility.
-8. **Engineering best practices:** SOLID principles, DRY, separation of concerns, error
-   handling, resilience patterns, observability, testability.
-9. **Language-specific best practices:** Use `WebSearch` to research idioms and conventions
-   for the specific language (Go, TypeScript, Python, etc.). Check official style guides,
-   common linter rules, and community-accepted patterns.
-10. **Correctness over convenience:** Always recommend the correct approach, regardless of
-    effort. The easy option may be presented as an alternative, but Option A must be what
-    the agent believes is right based on all the research above.
-11. **Production resilience:** Would this code survive production conditions? Consider:
-    timeouts on external calls, retry with backoff, circuit breakers, graceful degradation,
-    resource cleanup (connections, handles, goroutines), graceful shutdown, and behavior
-    under load (N+1 queries, unbounded queries, connection pool exhaustion).
-12. **Data integrity and privacy:** Are transaction boundaries correct? Could partial writes
-    occur? Is PII properly handled (not logged, masked in responses)? LGPD/GDPR compliance?
-
-**After research, form the recommendation:** Option A MUST be the approach the agent
-believes is correct based on the research. It must be backed by evidence (project patterns,
-best practice references, official documentation), not just a generic suggestion.
-
 
 ### Finding Option Format (MANDATORY for cycle review skills)
 
@@ -1170,7 +1135,11 @@ All cycle review skills follow this pattern:
    - Skip — no action
    - Tell me more — if selected, STOP and answer immediately (do NOT continue to next finding)
 
-### Fix Implementation (Complexity-Based Dispatch)
+### Fix Implementation (Complexity-Based Dispatch) (summarized)
+
+> **Summary inlined here. Full recipe at `AGENTS.md -> Fix Implementation (Complexity-Based Dispatch)`.**
+
+**Summary:** Cycle review skills classify each approved fix before applying. **Simple** (single file, localized, exact code provided, obvious resolution: typo / missing nil guard / import / log line / dead code removal): orchestrator applies directly via Edit/MultiEdit, runs unit tests; on failure, reverts and escalates. **Complex** (multi-file, architectural impact, security-sensitive, schema/API/config changes, new tests needed, or unsure): dispatch ring droid. Code fixes use TDD cycle (RED-GREEN-REFACTOR) via `ring-dev-team-backend-engineer-golang`/`-typescript`, `ring-dev-team-frontend-engineer`, `ring-dev-team-qa-analyst`. Documentation fixes: `ring-tw-team-functional-writer`/`-api-writer`/`-docs-reviewer` (no TDD). When in doubt → dispatch. Ring droids are REQUIRED for complex fixes — STOP if missing. See full classification + dispatch templates in AGENTS.md.
 
 Fixes are classified by complexity. **Simple fixes** are applied directly by the
 orchestrator. **Complex fixes** (or fixes whose complexity cannot be determined) are
@@ -1179,46 +1148,6 @@ delegated to specialist ring droids.
 #### Complexity Classification
 
 For each approved fix, assess complexity BEFORE applying:
-
-**Simple fix (apply directly):**
-- The review agent already provided the exact code change needed
-- Single file, localized change (few lines)
-- Obvious resolution: typo, missing error check, wrong variable name, missing nil guard,
-  import fix, formatting, adding a log line, renaming, removing dead code
-- No new logic, no architectural impact, no new test scenarios needed
-
-**Complex fix (dispatch ring droid):**
-- Multiple files affected
-- Requires understanding broader codebase context or architectural decisions
-- New functionality, significant refactoring, or new integration points
-- Requires new test scenarios (not just updating existing ones)
-- Security-sensitive changes (auth, crypto, input validation)
-- Database schema, API contract, or config changes
-- The orchestrator is unsure how to fix it
-
-**When in doubt → dispatch ring droid.** If you cannot confidently classify a fix as
-simple, treat it as complex.
-
-#### Direct Fix (simple findings)
-
-The orchestrator applies the fix directly using Edit/MultiEdit tools. After applying:
-1. Run unit tests to verify no regression
-2. If tests fail, revert and escalate to ring droid dispatch
-
-#### Ring Droid Dispatch (complex findings)
-
-**Code fixes** → dispatch ring backend/frontend/QA droids with **TDD cycle** (RED-GREEN-REFACTOR):
-- `ring-dev-team-backend-engineer-golang` (Go), `ring-dev-team-backend-engineer-typescript` (TS),
-  `ring-dev-team-frontend-engineer` (React/Next.js), `ring-dev-team-qa-analyst` (tests)
-
-**Documentation fixes** → dispatch ring documentation droids **without TDD** (no tests for docs):
-- `ring-tw-team-functional-writer` (guides), `ring-tw-team-api-writer` (API docs),
-  `ring-tw-team-docs-reviewer` (quality fixes)
-
-**Ring droids are REQUIRED for complex fixes** — there is no alternative dispatch mechanism. If the
-required droids are not installed and a complex fix is needed, the skill MUST stop and
-inform the user which droids need to be installed.
-
 
 ### Protocol: Active Version Guard (summarized)
 
@@ -1244,39 +1173,11 @@ inform the user which droids need to be installed.
 
 **Summary:** Measure unit + integration test coverage via Makefile targets with stack-specific fallbacks (Go: `go test -coverprofile`; Node: `npm test -- --coverage`; Python: `pytest --cov=. --cov-report=term`). Run wrapped in `_optimus_quiet_run` (Protocol: Quiet Command Execution) to keep agent context clean — the agent sees only PASS/FAIL + extracted total percentage; full per-file breakdown stays in `.optimus/logs/` and native coverage files. Thresholds: unit 85%, integration 70% (NEEDS_FIX/HIGH finding below). When scanning untested functions, read coverage output FILE (not stdout) — flag business-logic functions at 0% as HIGH; infrastructure/generated code as SKIP. If no coverage command resolves, mark SKIP — do not fail verification. See full extraction recipes in AGENTS.md.
 
-### Protocol: Default Branch Refusal (HARD BLOCK)
+### Protocol: Default Branch Refusal (HARD BLOCK) (summarized)
 
-**Referenced by:** build, review, done
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Default Branch Refusal (HARD BLOCK)`.**
 
-**Why:** Workspace Auto-Navigation is the primary safeguard, but it can be bypassed
-in edge cases (user cancels the AskUser prompt, silent failure, future skill that
-forgets to invoke the protocol). A second, unconditional refusal at the start of any
-mutating stage prevents accidental commits, worktree removals, or status writes on
-the default branch.
-
-```bash
-DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
-if [ -z "$DEFAULT_BRANCH" ]; then
-  if git show-ref --verify refs/remotes/origin/main >/dev/null 2>&1; then
-    DEFAULT_BRANCH="main"
-  elif git show-ref --verify refs/remotes/origin/master >/dev/null 2>&1; then
-    DEFAULT_BRANCH="master"
-  fi
-fi
-CURRENT=$(git branch --show-current 2>/dev/null)
-if [ -n "$DEFAULT_BRANCH" ] && [ "$CURRENT" = "$DEFAULT_BRANCH" ]; then
-  echo "ERROR: refusing to run /optimus-<stage> on default branch '$CURRENT'." >&2
-  echo "       Switch to the task's feature branch (Workspace Auto-Navigation should have handled this)." >&2
-  exit 1
-fi
-```
-
-**Where to invoke:** immediately after Workspace Auto-Navigation completes, before
-the skill performs any state.json write, git commit, git worktree mutation, or
-status transition.
-
-Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see AGENTS.md Protocol: Default Branch Refusal."
-
+**Summary:** Mutating stage skills (build, review, done) MUST refuse to run on the project's default branch (main/master). Defense-in-depth even after Workspace Auto-Navigation. Resolves DEFAULT_BRANCH via `git symbolic-ref refs/remotes/origin/HEAD` with main→master fallback; compares to `git branch --show-current`; STOP with explicit error message if equal. Invoke immediately after Workspace Auto-Navigation, before any state.json write, git commit, worktree mutation, or status transition. See full recipe in AGENTS.md.
 
 ### Protocol: Divergence Warning (summarized)
 
@@ -1284,31 +1185,11 @@ Skills reference this as: "Refuse to run on default branch (HARD BLOCK) — see 
 
 **Summary:** Detects when `optimus-tasks.md` has diverged between the current branch and the tasks repo's default branch. Uses `tasks_git` so it works in both same-repo and separate-repo scopes. Throttles `tasks_git fetch` via a 5-minute cache marker at `${MAIN_WORKTREE}/.optimus/.last-tasks-fetch` (defense-in-depth: validates marker contents are numeric before arithmetic to survive corrupted marker files under `set -euo pipefail`). Compares against `origin/$TASKS_DEFAULT_BRANCH` via `tasks_git diff` limited to `$TASKS_GIT_REL`. On non-empty diff, warns via `AskUser` with options to **Sync now** (merge `origin/<default>`) or **Continue without syncing**. NOT a HARD BLOCK — divergence is a soft warning. Skipped silently when `TASKS_DEFAULT_BRANCH` is unresolved. See full recipe in AGENTS.md.
 
-## Protocol: Dry-Run Mode
+### Protocol: Dry-Run Mode (summarized)
 
-**Referenced by:** plan, build, review, done (all stage agents 1-4).
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Dry-Run Mode`.**
 
-All stage agents support **dry-run mode**. When the user includes "dry-run" or
-"preview" in their invocation (e.g., "dry-run spec T-003", "preview review T-012"),
-the agent MUST:
-
-1. **Run all analysis/validation phases normally** — agent dispatch, findings, etc.
-2. **Do NOT change task status** — skip the status update step in state.json.
-3. **Do NOT commit or push anything** — no git operations that modify state.
-4. **Do NOT create workspaces** — skip branch/worktree creation (stage-1 only).
-5. **Do NOT apply fixes** — skip batch-apply phases.
-6. **Do NOT increment stage stats** — skip the Increment Stage Stats protocol.
-7. **Do NOT write session files** — session state is for crash recovery of real
-   executions, not previews.
-8. **Skip convergence rounds 2+** — round 1 (primary review pass) is sufficient
-   for preview; do NOT enter the convergence loop.
-9. **Present results as informational** — phrase the summary as "what would happen"
-   without implying any side effects occurred.
-
-Stage agents may add stage-specific dry-run notes (e.g., which phase numbers
-to skip), but MUST NOT relax any of the rules above. The point of dry-run is
-to give the user a reliable preview with zero state mutation.
-
+**Summary:** All stage skills (plan, build, review, done) support dry-run mode — triggered when the invocation contains `dry-run` or `preview`. Run analysis/validation phases normally but: do NOT change task status in state.json, do NOT git commit/push, do NOT create branches/worktrees (stage-1), do NOT batch-apply fixes, do NOT increment stage stats, do NOT write session files, skip convergence rounds 2+. Present results as informational ("what would happen") with zero side effects. Stage skills may add per-stage dry-run notes but MUST NOT relax these rules. See full per-stage dry-run rules in AGENTS.md.
 
 ### Protocol: GitHub CLI Check (HARD BLOCK)
 
@@ -1324,41 +1205,11 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
-### Protocol: Increment Stage Stats
+### Protocol: Increment Stage Stats (summarized)
 
-**Referenced by:** plan, review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Increment Stage Stats`.**
 
-After the status change in state.json (and BEFORE any analysis work begins), increment
-the execution counter for the current stage in `.optimus/stats.json`. This tracks how many
-times each stage ran on each task — useful for spotting spec churn and review cycles.
-
-**NOTE:** Only increment when NOT in dry-run mode.
-
-1. Read `.optimus/stats.json`. If the file does not exist, start with an empty object `{}`.
-   If the file exists but is corrupted, reset it:
-   ```bash
-   # Requires Protocol: Resolve Main Worktree Path to have run first
-   # (or resolve inline; see that protocol).
-   MAIN_WORKTREE="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / {print $2; exit}')"
-   MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
-   STATS_FILE="${MAIN_WORKTREE}/.optimus/stats.json"
-   if [ -f "$STATS_FILE" ] && ! jq empty "$STATS_FILE" 2>/dev/null; then
-     echo "WARNING: stats.json is corrupted. Resetting counters."
-     echo '{}' > "$STATS_FILE"
-   fi
-   ```
-2. If the task ID key does not exist, initialize it:
-   ```json
-   { "plan_runs": 0, "review_runs": 0 }
-   ```
-3. Increment the appropriate counter (`plan_runs` for plan, `review_runs` for review).
-4. Set the timestamp field (`last_plan` or `last_review`) to the current UTC ISO 8601 time.
-5. Write the updated JSON back to `.optimus/stats.json` (pretty-printed, sorted keys).
-
-**NOTE:** stats.json is gitignored — no commit needed.
-
-Skills reference this as: "Increment stage stats — see AGENTS.md Protocol: Increment Stage Stats."
-
+**Summary:** Plan and review increment per-task execution counters in `${MAIN_WORKTREE}/.optimus/stats.json` immediately after the status change (BEFORE analysis starts). Skip in dry-run mode. Recipe: read stats.json (start `{}` if missing); reset to `{}` if corrupted (`jq empty` fails) with WARNING; init task key `{ "plan_runs": 0, "review_runs": 0 }` if absent; increment matching counter; set `last_plan` / `last_review` to UTC ISO 8601; write back pretty-printed with sorted keys. stats.json is gitignored — no commit. See full recipe in AGENTS.md.
 
 ### Protocol: Notification Hooks (summarized)
 
@@ -1409,75 +1260,11 @@ Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Titl
 
 **Summary:** `_optimus_quiet_run <label> <command>` redirects stdout+stderr to `${MAIN_WORKTREE}/.optimus/logs/<ts>-<label>-<pid>.log`, emits a single `PASS`/`FAIL` line, and on failure dumps the last 50 lines (with `cat -v` to neutralize ANSI/OSC escape sequences). Uses `umask 0077` on the log file (output may contain credentials/stack traces). Exit code preserved so `if _optimus_quiet_run ...; then ... fi` works. Reserved exit codes: `2` = missing label/command; `3` = cannot create logs dir. Log retention (30-day age cap + 500-file count cap) is pruned at every Initialize Directory + Session State call. Use for verification commands only; never for output the agent must parse turn-by-turn. See full recipe in AGENTS.md.
 
-### Protocol: Re-run Guard
+### Protocol: Re-run Guard (summarized)
 
-**Referenced by:** plan, review
+> **Summary inlined here. Full recipe at `AGENTS.md -> Protocol: Re-run Guard`.**
 
-After the convergence loop exits and the final report/summary is presented, evaluate
-whether to suggest advancement or offer a re-run. This protocol replaces the static
-"Next step suggestion" in plan and review.
-
-**Logic:**
-
-1. Count `total_findings` produced during this execution (all findings from round 1 AND
-   any convergence rounds that were dispatched — note: with opt-in gating, the user may
-   have skipped them all, in which case only round 1 contributes — from all agents and
-   static analysis, regardless of whether they were fixed or skipped by the user). If
-   findings were grouped (per Finding Presentation item 3), count grouped entries, not
-   individual occurrences.
-2. **If `total_findings == 0`:** The analysis is clean. Suggest the next stage:
-   - plan: "Spec validation clean — 0 findings. Next step: run `/optimus-build` to implement this task."
-   - review: "Implementation review clean — 0 findings. Next step: run `/optimus-done` to close this task."
-3. **If `total_findings > 0`:** Ask via `AskUser`:
-   ```
-   Validation found N findings (X fixed, Y skipped).
-   Re-running dispatches ALL review agents again with clean context (no memory of
-   previous findings — findings you previously skipped will reappear for review).
-   This will consume similar tokens to the initial run. Workspace and status are preserved.
-   ```
-   Options:
-   - **Re-run with clean context** — re-analyze from scratch
-   - **Advance to next stage** — proceed despite findings
-
-4. **If "Re-run with clean context":**
-   - Increment stage stats (new execution)
-   - **Skip:** GitHub CLI check, optimus-tasks.md validation, task identification, session state
-     check, status validation/change, workspace creation, divergence check
-   - **Re-execute:** project structure discovery, document loading, static analysis,
-     coverage profiling, agent dispatch (ALL agents), finding presentation, fix application,
-     convergence loop entry gate (and any rounds the user opts into)
-   - **Session file:** After re-run starts, the session protocol (Protocol: Session State)
-     resumes normal operation — update the session file at each phase transition as usual.
-     This ensures crash recovery during a re-run resumes from the correct phase.
-   - After the re-run completes, apply this protocol again (evaluate findings count)
-   - There is no limit on re-runs — the user controls when to stop
-
-   **Re-run reset semantics (MANDATORY):** When the user chooses "Re-run with clean
-   context", the orchestrator MUST:
-
-   1. Reset `convergence_status` to `null` in the session file (was set to `"CONVERGED"`
-      or another terminal state at the previous run's end).
-   2. Reset `phase` to the entry of the re-executed flow (typically the first phase
-      that performs work, NOT the load-only phases).
-   3. Overwrite `started_at` with the new run's timestamp; preserve `created_at`.
-   4. Preserve `task_id`, `task_branch`, and any other identity fields.
-   5. After reset, normal `Protocol: Session State` updates resume.
-
-   WITHOUT this reset, a previous run's `convergence_status: "CONVERGED"` would
-   short-circuit the re-run's loop, producing a phantom "no findings" result.
-
-5. **If "Advance to next stage":** Proceed to push commits and present the next step suggestion.
-
-**NOTE:** "0 findings" means the analysis produced zero findings — not that all findings
-were resolved. If the user skipped findings in a previous run, they will reappear on
-re-run (clean context has no memory of previous decisions). This is by design.
-
-**NOTE:** Re-run analyzes the current codebase state, including any fixes applied and
-committed during the previous run. It does NOT revert commits. This validates that
-applied fixes are correct and checks for any issues introduced by the fixes.
-
-Skills reference this as: "Execute re-run guard — see AGENTS.md Protocol: Re-run Guard."
-
+**Summary:** Replaces the static "next step" suggestion in plan and review. Counts `total_findings` from this execution (grouped entries count as 1). If 0 → suggest next stage (build for plan, done for review). If >0 → `AskUser` offering "Re-run with clean context" (re-dispatches ALL agents with no memory of prior decisions — skipped findings will reappear) or "Advance to next stage". Re-run reset semantics (MANDATORY): reset `convergence_status` to `null`, `phase` to entry, overwrite `started_at`; preserve identity fields. Skip GitHub CLI/tasks validation/workspace/divergence checks; re-execute discovery + dispatch. No re-run limit. See full reset checklist in AGENTS.md.
 
 ### Protocol: Ring Droid Requirement Check (summarized)
 

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3318,6 +3318,16 @@ class TestProtocolSummarizeMarker:
         "Project Rules Discovery",
         "Ring Droid Requirement Check",
         "Active Version Guard",
+        # Phase 8:
+        "Default Scope Resolution",
+        "Re-run Guard",
+        "Default Branch Refusal (HARD BLOCK)",
+        "Branch Name Derivation",
+        "Shell Safety Guidelines",
+        "Worktree Location",
+        "Increment Stage Stats",
+        # Note: "Dry-Run Mode" is summarized but uses `## ` (H2) form;
+        # tested via test_summarize_marker_present_for_dry_run_mode_section.
     ]
 
     def test_summarize_marker_present_for_top_protocols(self):
@@ -3458,5 +3468,77 @@ class TestProtocolSummarizeMarker:
         )
         assert marker_idx < summary_idx, (
             "Valid Status Values: marker must come before **Summary:** "
+            f"(marker={marker_idx}, summary={summary_idx})"
+        )
+
+    def test_summarize_marker_present_for_dry_run_mode_section(self):
+        """Phase 8: the `## Protocol: Dry-Run Mode` section is an H2 (not H3)
+        Protocol: heading — the `SUMMARIZED_PROTOCOLS` list assumes `### Protocol:`,
+        so Dry-Run Mode is guarded explicitly here."""
+        content = AGENTS_MD.read_text()
+        heading = "## Protocol: Dry-Run Mode"
+        idx = content.find(heading)
+        assert idx >= 0, f"{heading} missing from AGENTS.md"
+        window = content[idx: idx + 1500]
+        marker_idx = window.find("<!-- inline-mode: summarize -->")
+        summary_idx = window.find("**Summary:**")
+        assert marker_idx >= 0, (
+            "Dry-Run Mode: missing <!-- inline-mode: summarize --> marker "
+            "(must be placed immediately under the heading)"
+        )
+        assert summary_idx >= 0, (
+            "Dry-Run Mode: missing **Summary:** subsection "
+            "(must follow the summarize marker)"
+        )
+        assert marker_idx < summary_idx, (
+            "Dry-Run Mode: marker must come before **Summary:** "
+            f"(marker={marker_idx}, summary={summary_idx})"
+        )
+
+    def test_summarize_marker_present_for_deep_research_section(self):
+        """Phase 8: the `### Deep Research Before Presenting (MANDATORY for cycle
+        review skills)` section is a non-`Protocol:` H3 — guarded explicitly,
+        same rationale as File Location / Finding Presentation / etc."""
+        content = AGENTS_MD.read_text()
+        heading = "### Deep Research Before Presenting (MANDATORY for cycle review skills)"
+        idx = content.find(heading)
+        assert idx >= 0, f"{heading} missing from AGENTS.md"
+        window = content[idx: idx + 1500]
+        marker_idx = window.find("<!-- inline-mode: summarize -->")
+        summary_idx = window.find("**Summary:**")
+        assert marker_idx >= 0, (
+            "Deep Research Before Presenting: missing <!-- inline-mode: summarize "
+            "--> marker (must be placed immediately under the heading)"
+        )
+        assert summary_idx >= 0, (
+            "Deep Research Before Presenting: missing **Summary:** subsection "
+            "(must follow the summarize marker)"
+        )
+        assert marker_idx < summary_idx, (
+            "Deep Research Before Presenting: marker must come before **Summary:** "
+            f"(marker={marker_idx}, summary={summary_idx})"
+        )
+
+    def test_summarize_marker_present_for_fix_implementation_section(self):
+        """Phase 8: the `### Fix Implementation (Complexity-Based Dispatch)`
+        section is a non-`Protocol:` H3 — guarded explicitly, same rationale
+        as File Location / Finding Presentation / etc."""
+        content = AGENTS_MD.read_text()
+        heading = "### Fix Implementation (Complexity-Based Dispatch)"
+        idx = content.find(heading)
+        assert idx >= 0, f"{heading} missing from AGENTS.md"
+        window = content[idx: idx + 1500]
+        marker_idx = window.find("<!-- inline-mode: summarize -->")
+        summary_idx = window.find("**Summary:**")
+        assert marker_idx >= 0, (
+            "Fix Implementation: missing <!-- inline-mode: summarize --> marker "
+            "(must be placed immediately under the heading)"
+        )
+        assert summary_idx >= 0, (
+            "Fix Implementation: missing **Summary:** subsection "
+            "(must follow the summarize marker)"
+        )
+        assert marker_idx < summary_idx, (
+            "Fix Implementation: marker must come before **Summary:** "
             f"(marker={marker_idx}, summary={summary_idx})"
         )


### PR DESCRIPTION
## Summary

Phase 8 of inline-protocol bloat reduction (issue #34). Marks 10 longer-tail protocols with `<!-- inline-mode: summarize -->` markers + `**Summary:**` blocks so the inliner emits the terse summary into consuming SKILL.md / command-mirror files instead of the full body.

**Marginal saving this phase:** 2,601 → 1,692 inlined LOC (**−909 LOC**, well above the 200 LOC abort threshold).

**Diff stat:** 20 files changed, 289 insertions, 1,984 deletions (net −1,695 lines across SKILL.md + commands mirrors).

## Protocols summarized

| # | Protocol | Heading | Consumers |
|---|----------|---------|-----------|
| 1 | Default Scope Resolution | `### Protocol:` | 2 |
| 2 | Re-run Guard | `### Protocol:` | 2 |
| 3 | Deep Research Before Presenting | `###` (non-Protocol) | 3 |
| 4 | Default Branch Refusal (HARD BLOCK) | `### Protocol:` | 3 |
| 5 | Fix Implementation (Complexity-Based Dispatch) | `###` (non-Protocol) | 2 |
| 6 | Branch Name Derivation | `### Protocol:` | 2 |
| 7 | Shell Safety Guidelines | `### Protocol:` | 2 |
| 8 | Worktree Location | `### Protocol:` | 2 |
| 9 | Dry-Run Mode | `## Protocol:` (H2) | 4 |
| 10 | Increment Stage Stats | `### Protocol:` | 2 |

## Test coverage

- Added 8 H3 Protocol-form names to `SUMMARIZED_PROTOCOLS` in `scripts/test_skill_consistency.py`.
- Added 3 dedicated tests for non-standard headings (Dry-Run Mode H2, Deep Research H3, Fix Implementation H3), following the existing File Location / Format Validation / Finding Presentation / Valid Status Values pattern.
- Existing body-presence assertions on Default Branch Refusal, Re-run Guard, and Worktree Location still pass — Summaries are added on top; full bodies remain untouched in AGENTS.md.

## Cumulative across 8 phases

- Baseline (pre-Phase 1): 33,238 inlined LOC
- After Phase 8: 1,692 inlined LOC (**−95%** across SKILL.md surface)

## Test plan

- [x] `python3 scripts/inline-protocols.py` — 0 unmatched refs
- [x] `python3 scripts/sync-claude-commands.py` — 17 main + 17 alias mirrors regenerated
- [x] `make lint` — passes
- [x] `make test` — 347 tests pass (344 baseline + 3 new)