### PR TITLE
fix(sync): force-refresh Droid plugins via uninstall+install (mirror PR #44)

### DIFF
--- a/scripts/test_sync_user_plugins.py
+++ b/scripts/test_sync_user_plugins.py
@@ -349,18 +349,36 @@ class TestOrphanRemoval:
         assert "uninstall orphan@optimus" in log_content
 
 
-class TestScopeConflict:
-    def test_reinstalls_on_scope_conflict(self, tmp_path: Path) -> None:
+class TestForceRefresh:
+    """The Droid branch refreshes existing plugins via uninstall+install.
+
+    Rationale: `droid plugin update` can be a no-op when marketplace.json's
+    `version` field hasn't changed, even when the underlying source files
+    have. Optimus ships SKILL changes without bumping the marketplace version
+    on every PR, so update would leave users on stale cached SKILL.md.
+    Mirrors the fix applied to the Claude branch in PR #44.
+    """
+
+    def test_existing_plugins_are_refreshed_via_uninstall_install(
+        self, tmp_path: Path
+    ) -> None:
         log = tmp_path / "droid.log"
         _create_mock_bin(tmp_path, "droid", _droid_script(
-            log, list_output="alpha@optimus  installed", update_exit=1))
+            log, list_output="alpha@optimus  installed"))
         _create_marketplace(tmp_path, ["alpha"])
         result = _run_sync(tmp_path, exclude_claude=True)
         assert result.returncode == 0
-        assert "reinstalled" in result.stdout.lower()
+        # Output marker confirms refresh path was taken.
+        assert "(refreshed)" in result.stdout.lower()
         log_content = log.read_text()
+        # uninstall happens BEFORE install (force-refresh ordering).
         assert "uninstall alpha@optimus" in log_content
         assert "install alpha@optimus" in log_content
+        assert log_content.find("uninstall alpha@optimus") < log_content.find(
+            "install alpha@optimus"
+        )
+        # `update` is no longer used as the primary path.
+        assert "update alpha@optimus" not in log_content
 
 
 class TestMarketplaceOverride:
@@ -545,7 +563,13 @@ class TestTimeoutWrapper:
 
 
 class TestSerialRetry:
-    def test_retries_transient_update_before_reinstall(self, tmp_path: Path) -> None:
+    def test_retries_transient_install_failure_during_refresh(
+        self, tmp_path: Path
+    ) -> None:
+        """When the parallel uninstall+install pass loses a race for a plugin
+        already in INSTALLED, the serial retry runs the same uninstall+install
+        sequence again. The plugin lands as Updated on success.
+        """
         log = tmp_path / "droid.log"
         state_dir = tmp_path / "state"
         state_dir.mkdir()
@@ -554,16 +578,15 @@ CMD="$1 $2"
 case "$CMD" in
   "plugin marketplace") exit 0 ;;
   "plugin list") echo "alpha@optimus  installed" ;;
-  "plugin update")
-    count_file="{state_dir}/update.count"
+  "plugin uninstall") echo "uninstall $3" >> "{log}"; exit 0 ;;
+  "plugin install")
+    count_file="{state_dir}/install.count"
     count=$(cat "$count_file" 2>/dev/null || echo 0)
     count=$((count + 1))
     echo "$count" > "$count_file"
-    echo "update $3 #$count" >> "{log}"
+    echo "install $3 #$count" >> "{log}"
     if [ "$count" -eq 1 ]; then exit 1; fi
     exit 0 ;;
-  "plugin uninstall") echo "uninstall $3" >> "{log}"; exit 0 ;;
-  "plugin install") echo "install $3" >> "{log}"; exit 0 ;;
   *) echo "unknown: $@" >> "{log}" ;;
 esac
 """
@@ -574,10 +597,11 @@ esac
         assert "Retrying failed plugin operations serially" in result.stdout
         assert "Updated: 1" in result.stdout
         log_content = log.read_text()
-        assert "update alpha@optimus #1" in log_content
-        assert "update alpha@optimus #2" in log_content
-        assert "uninstall alpha@optimus" not in log_content
-        assert "install alpha@optimus" not in log_content
+        # First install attempt (parallel pass) failed; serial retry succeeded.
+        assert "install alpha@optimus #1" in log_content
+        assert "install alpha@optimus #2" in log_content
+        # `update` is no longer part of the refresh path.
+        assert "update alpha@optimus" not in log_content
 
     def test_retries_transient_install_serially(self, tmp_path: Path) -> None:
         log = tmp_path / "droid.log"

--- a/sync/scripts/sync-user-plugins.sh
+++ b/sync/scripts/sync-user-plugins.sh
@@ -343,13 +343,22 @@ _sync_droid() {
     done <<< "$new_plugins"
   fi
 
-  # Update existing plugins (parallel)
+  # Refresh existing plugins (parallel) via uninstall+install.
+  #
+  # NOTE: We do NOT call `droid plugin update` here. Optimus ships SKILL prose
+  # changes without bumping marketplace.json's `version` field on every PR;
+  # `droid plugin update` can be a no-op in that case (mirrors the bug fixed
+  # for Claude in PR #44). Uninstall + reinstall guarantees a fresh fetch
+  # from the marketplace cache so the user gets the latest committed prose.
+  # Cost: one extra round-trip per plugin (~1s); acceptable since the outer
+  # loop runs in parallel.
   if [ -n "$existing_plugins" ]; then
-    echo "Updating existing plugins..."
+    echo "Refreshing existing plugins..."
     while IFS= read -r plugin; do
       [ -z "$plugin" ] && continue
       (
-        if _droid plugin update "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
+        _droid plugin uninstall "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1 || true
+        if _droid plugin install "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
           echo "OK" > "$results_dir/update-${plugin}"
         else
           echo "RETRY" > "$results_dir/update-${plugin}"
@@ -398,15 +407,14 @@ _sync_droid() {
   fi
 
   if [ -n "$retry_updates" ]; then
+    # Serial retry of the uninstall+install refresh path. The parallel pass
+    # may have lost a race (e.g. plugin daemon contention); doing it serially
+    # gives each plugin a clean shot.
     while IFS= read -r plugin; do
       [ -z "$plugin" ] && continue
-      if _droid plugin update "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-        echo "OK" > "$results_dir/update-${plugin}"
-        continue
-      fi
       _droid plugin uninstall "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1 || true
       if _droid plugin install "${plugin}@${MARKETPLACE_NAME}" >/dev/null 2>&1; then
-        echo "REINSTALLED" > "$results_dir/update-${plugin}"
+        echo "OK" > "$results_dir/update-${plugin}"
       else
         echo "FAIL" > "$results_dir/update-${plugin}"
       fi
@@ -449,8 +457,7 @@ _sync_droid() {
       [ -z "$plugin" ] && continue
       result=$(_read_result "$results_dir/update-${plugin}")
       case "$result" in
-        OK)          echo "  * $plugin ... OK";            updated=$((updated + 1)) ;;
-        REINSTALLED) echo "  * $plugin ... OK (reinstalled)"; updated=$((updated + 1)) ;;
+        OK)          echo "  * $plugin ... OK (refreshed)"; updated=$((updated + 1)) ;;
         *)           echo "  * $plugin ... FAIL";           failed=$((failed + 1)) ;;
       esac
     done <<< "$existing_plugins"


### PR DESCRIPTION
## Summary

\`droid plugin update\` can be a no-op when marketplace.json's \`version\` field hasn't changed, even when the underlying source files have. Same bug as #44 fixed for Claude.

## Real-world impact

After PR #41 merged, this user ran \`/optimus:sync\` twice and 15 of 17 Droid plugins remained stuck at the previous commit hash. They had to run a manual uninstall+install loop to refresh:

\`\`\`bash
for p in batch coderabbit-review deep-doc-review deep-review done help import plan pr-check report resolve resume review sync tasks; do
  droid plugin uninstall \"\$p@optimus\"
  droid plugin install \"\$p@optimus\"
done
\`\`\`

This PR makes \`/optimus:sync\` do exactly that automatically.

## Changes

- \`sync/scripts/sync-user-plugins.sh\` (\`_sync_droid\`): the parallel pass over \`existing_plugins\` now does uninstall+install per plugin (mirror of #44 for Claude). Output \`Updating existing plugins...\` becomes \`Refreshing existing plugins...\`. Per-plugin status marker becomes \`* plugin ... OK (refreshed)\`.
- \`sync/scripts/sync-user-plugins.sh\` (serial retry): the \`retry_updates\` path now also does uninstall+install instead of trying \`update\` first then falling back. Removes a state branch, simplifies the logic.
- \`scripts/test_sync_user_plugins.py\`:
  - \`TestForceRefresh::test_existing_plugins_are_refreshed_via_uninstall_install\` (replaces \`TestScopeConflict::test_reinstalls_on_scope_conflict\`) — asserts ordering (uninstall before install), the (refreshed) output marker, and absence of \`update\` calls.
  - \`TestSerialRetry::test_retries_transient_install_failure_during_refresh\` (replaces \`test_retries_transient_update_before_reinstall\`) — asserts the serial retry uses the same uninstall+install sequence.

## Why not bump marketplace version on every PR

Considered and rejected (same reasoning as #44): manual discipline, churn, force-refresh is the right semantic regardless. The Droid branch had this problem too because Droid's update-vs-version semantics mirror Claude's.

## Test plan
- [x] \`python3 -m pytest scripts/test_sync_user_plugins.py\` — 66 passed
- [x] \`python3 -m pytest scripts/\` — 347 passed
- [ ] Smoke test (manual after merge): edit any SKILL.md prose locally, push to main, run \`/optimus:sync\`, verify each \`droid plugin list\` entry advances to the new commit hash.