### PR TITLE
fix(plan): inline canonical Tipo→prefix case statement

### DIFF
--- a/commands/plan.md
+++ b/commands/plan.md
@@ -268,7 +268,35 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
 
 **If on the default branch:**
 
-1. **Derive branch name** — see AGENTS.md Protocol: Branch Name Derivation.
+1. **Derive branch name** — see AGENTS.md Protocol: Branch Name Derivation. Apply the canonical case statement below; do NOT improvise from the prose. The mapping is identical to `resume/skills/optimus:resume/SKILL.md:315-326`.
+
+   ```bash
+   # Tipo → branch prefix (canonical mapping, must match resume SKILL).
+   case "$TASK_TIPO" in
+     Feature)   TIPO_PREFIX="feat" ;;
+     Fix)       TIPO_PREFIX="fix" ;;
+     Refactor)  TIPO_PREFIX="refactor" ;;
+     Chore)     TIPO_PREFIX="chore" ;;
+     Docs)      TIPO_PREFIX="docs" ;;
+     Test)      TIPO_PREFIX="test" ;;
+     *)
+       echo "ERROR: Unknown Tipo '$TASK_TIPO' for $TASK_ID — cannot derive branch prefix." >&2
+       exit 1 ;;
+   esac
+   SLUG=$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')
+   KEYWORDS=$(echo "$TASK_TITLE" \
+     | tr '[:upper:]' '[:lower:]' \
+     | tr -c 'a-z0-9-' '-' \
+     | tr -s '-' \
+     | sed 's/^-//; s/-$//')
+   if [ -n "$KEYWORDS" ]; then
+     BRANCH_NAME="${TIPO_PREFIX}/${SLUG}-${KEYWORDS}"
+   else
+     BRANCH_NAME="${TIPO_PREFIX}/${SLUG}"
+   fi
+   # Truncate to 100 chars per AGENTS.md Protocol: Branch Name Derivation.
+   BRANCH_NAME=$(echo "$BRANCH_NAME" | cut -c1-100 | sed 's/-$//')
+   ```
 
 2. **Update state.json:**
    Write status `Validando Spec` and the derived branch name to state.json — see
@@ -285,8 +313,7 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
    fi
    MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
-   # BRANCH_NAME must be a real branch name (substituted from Protocol: Branch Name Derivation), not the placeholder.
-   BRANCH_NAME="<tipo-prefix>/<task-id>-<keywords>"
+   # BRANCH_NAME was set above by the canonical case statement (Step 1).
    # Path-traversal guard (defense in depth).
    case "$BRANCH_NAME" in
      *..*|/*) echo "ERROR: refusing unsafe branch '$BRANCH_NAME'." >&2; exit 1 ;;

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -329,7 +329,35 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
 
 **If on the default branch:**
 
-1. **Derive branch name** — see AGENTS.md Protocol: Branch Name Derivation.
+1. **Derive branch name** — see AGENTS.md Protocol: Branch Name Derivation. Apply the canonical case statement below; do NOT improvise from the prose. The mapping is identical to `resume/skills/optimus-resume/SKILL.md:315-326`.
+
+   ```bash
+   # Tipo → branch prefix (canonical mapping, must match resume SKILL).
+   case "$TASK_TIPO" in
+     Feature)   TIPO_PREFIX="feat" ;;
+     Fix)       TIPO_PREFIX="fix" ;;
+     Refactor)  TIPO_PREFIX="refactor" ;;
+     Chore)     TIPO_PREFIX="chore" ;;
+     Docs)      TIPO_PREFIX="docs" ;;
+     Test)      TIPO_PREFIX="test" ;;
+     *)
+       echo "ERROR: Unknown Tipo '$TASK_TIPO' for $TASK_ID — cannot derive branch prefix." >&2
+       exit 1 ;;
+   esac
+   SLUG=$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')
+   KEYWORDS=$(echo "$TASK_TITLE" \
+     | tr '[:upper:]' '[:lower:]' \
+     | tr -c 'a-z0-9-' '-' \
+     | tr -s '-' \
+     | sed 's/^-//; s/-$//')
+   if [ -n "$KEYWORDS" ]; then
+     BRANCH_NAME="${TIPO_PREFIX}/${SLUG}-${KEYWORDS}"
+   else
+     BRANCH_NAME="${TIPO_PREFIX}/${SLUG}"
+   fi
+   # Truncate to 100 chars per AGENTS.md Protocol: Branch Name Derivation.
+   BRANCH_NAME=$(echo "$BRANCH_NAME" | cut -c1-100 | sed 's/-$//')
+   ```
 
 2. **Update state.json:**
    Write status `Validando Spec` and the derived branch name to state.json — see
@@ -346,8 +374,7 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
    fi
    MAIN_WORKTREE="${MAIN_WORKTREE:?MAIN_WORKTREE not resolved — not in a git repository}"
 
-   # BRANCH_NAME must be a real branch name (substituted from Protocol: Branch Name Derivation), not the placeholder.
-   BRANCH_NAME="<tipo-prefix>/<task-id>-<keywords>"
+   # BRANCH_NAME was set above by the canonical case statement (Step 1).
    # Path-traversal guard (defense in depth).
    case "$BRANCH_NAME" in
      *..*|/*) echo "ERROR: refusing unsafe branch '$BRANCH_NAME'." >&2; exit 1 ;;

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3603,3 +3603,73 @@ class TestProtocolInlineModeMarker:
             "Phase 9 omit-mode violations (inliner did NOT respect omit "
             "for these protocols):\n" + "\n".join(f"  - {v}" for v in violations)
         )
+
+
+# --- Branch name derivation must be inlined as bash, not a placeholder ---
+
+
+class TestBranchNameDerivation:
+    """plan SKILL must inline the canonical Tipo→prefix case statement so
+    runtime agents do not improvise the mapping. Background: a runtime agent
+    that read the prose-only protocol produced `feature/...` worktrees in
+    one run and `feat/...` in another, mixing two paths under .worktrees/."""
+
+    _MAPPING = [
+        ("Feature",  "feat"),
+        ("Fix",      "fix"),
+        ("Refactor", "refactor"),
+        ("Chore",    "chore"),
+        ("Docs",     "docs"),
+        ("Test",     "test"),
+    ]
+
+    def _plan_body(self) -> str:
+        """Return the hand-authored body of plan SKILL.md (without the
+        auto-inlined protocols block)."""
+        content = (REPO_ROOT / "plan" / "skills" / "optimus-plan"
+                   / "SKILL.md").read_text()
+        return content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+
+    def test_plan_inlines_canonical_case_statement(self):
+        """All six Tipo→prefix mappings must appear as bash case-arms in
+        plan SKILL — not just as prose in AGENTS.md."""
+        body = self._plan_body()
+        for tipo, prefix in self._MAPPING:
+            assert f"{tipo})" in body, (
+                f"plan SKILL.md must contain bash case arm '{tipo})' "
+                f"to map Tipo {tipo!r} → prefix {prefix!r}"
+            )
+            assert f'TIPO_PREFIX="{prefix}"' in body, (
+                f"plan SKILL.md must set TIPO_PREFIX={prefix!r} for "
+                f"Tipo {tipo!r}"
+            )
+
+    def test_plan_does_not_use_tipo_prefix_placeholder(self):
+        """The literal '<tipo-prefix>' placeholder must not appear inside
+        a BRANCH_NAME assignment. (It may still appear in the prose
+        description of the branch name format — the guard is specifically
+        about the bash assignment line.)"""
+        body = self._plan_body()
+        for line in body.splitlines():
+            if "BRANCH_NAME=" in line and "<tipo-prefix>" in line:
+                raise AssertionError(
+                    f"plan SKILL.md still has unfilled placeholder "
+                    f"in BRANCH_NAME assignment: {line.strip()!r}"
+                )
+
+    def test_plan_branch_derivation_matches_resume(self):
+        """plan and resume must use the same case statement so worktree
+        paths and resume's branch resolution stay in lockstep."""
+        plan_body = self._plan_body()
+        resume_content = (REPO_ROOT / "resume" / "skills" / "optimus-resume"
+                          / "SKILL.md").read_text()
+        resume_body = resume_content.split(
+            "<!-- INLINE-PROTOCOLS:START -->", 1
+        )[0]
+        # Each (Tipo, prefix) pair must be present in BOTH skills.
+        for tipo, prefix in self._MAPPING:
+            for label, body in (("plan", plan_body), ("resume", resume_body)):
+                assert f"{tipo})" in body and f'TIPO_PREFIX="{prefix}"' in body, (
+                    f"{label} SKILL.md missing canonical case arm "
+                    f"{tipo} → {prefix}"
+                )


### PR DESCRIPTION
## Summary

Step 1.0.5 of plan SKILL had a placeholder line:

\`\`\`bash
BRANCH_NAME=\"<tipo-prefix>/<task-id>-<keywords>\"
\`\`\`

The runtime agent was supposed to manually substitute by reading \`AGENTS.md Protocol: Branch Name Derivation\`, but that protocol is marked \`<!-- inline-mode: omit -->\` and is NOT auto-injected. The agent had to interpret the prose table, and different runs produced different prefixes for the same Tipo.

## Real-world impact

A user reported two \`.worktrees/\` subdirs after running \`/optimus:plan\` on two tasks of the same Tipo (Feature):

\`\`\`
.worktrees/feat/<id>-<keywords>       ← correct (Feature → feat per protocol)
.worktrees/feature/<id>-<keywords>    ← incorrect (Tipo used as-is)
\`\`\`

Both worktrees were created on the same machine across two runs.

## Fix

Replace the placeholder in plan SKILL with the canonical bash case statement, mirroring the implementation already in \`resume/skills/optimus-resume/SKILL.md:315-326\`. Runtime agents no longer interpret prose — they execute fixed code.

## Tests

\`TestBranchNameDerivation\` (3 tests):

- \`test_plan_inlines_canonical_case_statement\` — all six \`Tipo)\`/\`TIPO_PREFIX=\"...\"\` arms present in plan body
- \`test_plan_does_not_use_tipo_prefix_placeholder\` — no BRANCH_NAME line still references \`<tipo-prefix>\`
- \`test_plan_branch_derivation_matches_resume\` — plan and resume use the same six (Tipo, prefix) pairs, locking the lockstep invariant

## Cleanup of existing user state (out of scope)

Users who hit this bug will have stray \`.worktrees/feature/...\` directories. Removing them is manual and depends on whether work-in-progress is in there. Not automated to avoid data loss.

## Test plan
- [x] \`python3 -m pytest scripts/test_skill_consistency.py -k TestBranchNameDerivation -v\` — 3 passed
- [x] \`python3 -m pytest scripts/\` — 351 passed
- [x] \`scripts/sync-claude-commands.py\` is idempotent (commands/plan.md regenerated; second run shows no diff)
- [ ] Smoke test (manual after merge): create 2 Feature tasks, run \`/optimus:plan T-X\` on each, verify both worktrees land in \`.worktrees/feat/...\`

Closes the bug surfaced by user observation post PR #42 (worktree standardization).