### PR TITLE
feat(terminal): replace AppleScript title with iTerm2 Badge + Tab Color

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1504,7 +1504,7 @@ Skills reference this as: "Execute session state protocol from AGENTS.md using s
 
 <!-- inline-mode: omit -->
 
-**Summary:** `_optimus_set_title <text>` updates the terminal title for iTerm2-on-macOS via AppleScript (`osascript ... set name of s to newName`) — the only channel that reliably mutates `session.name` in "divorced" iTerm2 sessions where OSC 0/1/2 and SetUserVar are ineffective. Used by stage skills to surface task context (e.g., `optimus: PLAN T-007 — User auth`) so users running multiple Optimus sessions can identify them at a glance. The function is auto-inlined into 6 SKILLs by `inline-protocols.py` (do NOT manually paste the body in SKILL.md — F12f rule). Title is informational; failure to set it is non-fatal (silent no-op outside iTerm2/macOS, in Docker/CI without TTY, or when osascript denied). See full bash function in AGENTS.md.
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
 
 **Referenced by:** all stage agents (1-4), batch
 
@@ -1512,91 +1512,102 @@ After the task ID is identified and confirmed, set the terminal title to show th
 current stage and task. This allows users running multiple agents in parallel terminals
 to identify each terminal at a glance.
 
-**Set title (after task ID is known):**
+**Mark session (after task ID is known):**
 
 ```bash
-_optimus_set_title() {
-  # iTerm2 AppleScript title updater. Empirical testing showed that Optimus
-  # tasks always run in "divorced" iTerm2 sessions where the profile's
-  # autoNameFormat is locked to a literal — OSC 0/1/2 and OSC 1337
-  # SetUserVar are both ineffective in that state, so AppleScript's
-  # `set name of s` is the only channel that actually mutates session.name.
-  # The Execute tool runs bash without a controlling TTY, so /dev/tty fails
-  # with ENODEV; we resolve the parent process's TTY via ps instead. Walk
-  # up to 4 ancestors in case of nested shells. First run triggers a macOS
-  # TCC prompt ("droid wants to control iTerm"); approving enables this
-  # permanently. Silent no-op outside macOS/iTerm2 or when osascript is
-  # unavailable — non-iTerm2 / non-macOS users get no title update.
-  local title="$1"
-  local pid="$PPID" tty=""
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
   for _ in 1 2 3 4; do
     [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ') ;;
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
       *) break ;;
     esac
   done
-  if { [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ]; } \
-     && command -v osascript >/dev/null 2>&1 && [ -n "$tty" ] \
-     && [ "$tty" != "?" ] && [ "$tty" != "??" ]; then
-    osascript \
-      -e 'on run argv' \
-      -e '  set targetTty to "/dev/" & item 1 of argv' \
-      -e '  set newName to item 2 of argv' \
-      -e '  tell application "iTerm2"' \
-      -e '    repeat with w in windows' \
-      -e '      repeat with t in tabs of w' \
-      -e '        repeat with s in sessions of t' \
-      -e '          if (tty of s as string) is targetTty then' \
-      -e '            try' \
-      -e '              set name of s to newName' \
-      -e '            end try' \
-      -e '          end if' \
-      -e '        end repeat' \
-      -e '      end repeat' \
-      -e '    end repeat' \
-      -e '  end tell' \
-      -e 'end run' \
-      -- "$tty" "$title" >/dev/null 2>&1 || true
-  fi
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
 }
-_optimus_set_title "optimus: <STAGE> $TASK_ID — $TASK_TITLE"
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
 ```
 
-Example output in terminal tab: `optimus: REVIEW T-003 — User Auth JWT`
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
 
-**Why the parent-process TTY:** The Execute tool runs `bash -c` without a controlling
-terminal, so `/dev/tty` returns `ENODEV` ("Device not configured"). The resolver above
-asks `ps` for the parent's controlling TTY device path and matches it against iTerm2's
-session list via AppleScript — that device is connected to the user's real iTerm2
-session. If no ancestor has a TTY (Docker/CI) or osascript is unavailable, the
-function silently no-ops.
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
 
-**Restore title (at stage completion or exit):**
+**Restore at stage completion or exit:**
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```
 
-**NOTE:** This helper is iTerm2-on-macOS only. Optimus tasks always run in
-"divorced" iTerm2 sessions, where AppleScript's `set name of s` is the only
-channel that reliably mutates `session.name`. Non-iTerm2 / non-macOS users
-will not see a title update.
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
 
-**Troubleshooting iTerm2 (if the title still doesn't update):**
+**Troubleshooting iTerm2:**
 
-1. **Window > Edit Tab Title** must be empty. A manually-set tab title is
-   sticky on the tab label and overrides the session name visually, even
-   when `session.name` is updated correctly underneath.
-2. The first run on macOS triggers a TCC prompt ("`droid` wants to control
-   `iTerm`"). Approve it to enable the helper. Denying makes the helper a
-   silent no-op.
-3. The helper requires the parent process to have a controlling TTY. Inside
-   Docker/CI without a TTY, no ancestor will resolve and the helper will
-   silently no-op.
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
 
-Skills reference this as: "Set terminal title — see AGENTS.md Protocol: Terminal Identification."
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 ### Protocol: Workspace Auto-Navigation (HARD BLOCK)
 

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -144,7 +144,7 @@ starting the next task.
 
 For each task in the execution order:
 
-Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage=`BATCH` and include the current task ID in the title (e.g., `optimus: BATCH T-003 — User Auth JWT`). Update the title each time the task changes.
+Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage=`BATCH` and include the current task ID and title (e.g., `_optimus_mark_session BATCH "T-003" "User Auth JWT"`). Update the marker each time the task changes.
 
 ### Step 2.1: Stage Dispatch
 
@@ -231,7 +231,7 @@ After completing a task (all stages done), re-evaluate the remaining task pool:
 
 ## Phase 3: Batch Summary
 
-After all tasks are processed (or the user stops), restore the terminal title via `_optimus_set_title ""` (see Protocol: Terminal Identification for the function definition):
+After all tasks are processed (or the user stops), restore the terminal session via `_optimus_clear_session` (see Protocol: Terminal Identification for the function definition):
 
 ```markdown
 ## Batch Execution Summary

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -132,16 +132,16 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `BUILD`:
+Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `BUILD`:
 
 ```bash
-_optimus_set_title "optimus: BUILD $TASK_ID — $TASK_TITLE"
+_optimus_mark_session BUILD "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 1.3: Validate and Update Task Status

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -100,7 +100,7 @@ starting the next task.
 
 For each task in the execution order:
 
-Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage=`BATCH` and include the current task ID in the title (e.g., `optimus: BATCH T-003 — User Auth JWT`). Update the title each time the task changes.
+Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage=`BATCH` and include the current task ID and title (e.g., `_optimus_mark_session BATCH "T-003" "User Auth JWT"`). Update the marker each time the task changes.
 
 ### Step 2.1: Stage Dispatch
 
@@ -187,7 +187,7 @@ After completing a task (all stages done), re-evaluate the remaining task pool:
 
 ## Phase 3: Batch Summary
 
-After all tasks are processed (or the user stops), restore the terminal title via `_optimus_set_title ""` (see Protocol: Terminal Identification for the function definition):
+After all tasks are processed (or the user stops), restore the terminal session via `_optimus_clear_session` (see Protocol: Terminal Identification for the function definition):
 
 ```markdown
 ## Batch Execution Summary

--- a/commands/build.md
+++ b/commands/build.md
@@ -70,16 +70,16 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `BUILD`:
+Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `BUILD`:
 
 ```bash
-_optimus_set_title "optimus: BUILD $TASK_ID — $TASK_TITLE"
+_optimus_mark_session BUILD "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 1.3: Validate and Update Task Status

--- a/commands/done.md
+++ b/commands/done.md
@@ -105,16 +105,16 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `DONE`:
+Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `DONE`:
 
 ```bash
-_optimus_set_title "optimus: DONE $TASK_ID — $TASK_TITLE"
+_optimus_mark_session DONE "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 1.1: Validate Task Status

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -75,16 +75,16 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `PLAN`:
+Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `PLAN`:
 
 ```bash
-_optimus_set_title "optimus: PLAN $TASK_ID — $TASK_TITLE"
+_optimus_mark_session PLAN "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 1.0.3: Validate Task Status (DO NOT modify yet)

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -458,16 +458,16 @@ If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
 
 ### Step 4.1: Set Terminal Title
 
-Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `RESUME`:
+Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `RESUME`:
 
 ```bash
-_optimus_set_title "optimus: RESUME $TASK_ID — $TASK_TITLE"
+_optimus_mark_session RESUME "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On exit or after Phase 5 delegates to another stage skill**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 4.2: Collect Worktree Telemetry

--- a/commands/review.md
+++ b/commands/review.md
@@ -88,16 +88,16 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `REVIEW`:
+Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `REVIEW`:
 
 ```bash
-_optimus_set_title "optimus: REVIEW $TASK_ID — $TASK_TITLE"
+_optimus_mark_session REVIEW "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 1.0.8: Validate and Update Task Status

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -148,16 +148,16 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `DONE`:
+Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `DONE`:
 
 ```bash
-_optimus_set_title "optimus: DONE $TASK_ID — $TASK_TITLE"
+_optimus_mark_session DONE "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 1.1: Validate Task Status

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -136,16 +136,16 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `PLAN`:
+Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `PLAN`:
 
 ```bash
-_optimus_set_title "optimus: PLAN $TASK_ID — $TASK_TITLE"
+_optimus_mark_session PLAN "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 1.0.3: Validate Task Status (DO NOT modify yet)

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -517,16 +517,16 @@ If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
 
 ### Step 4.1: Set Terminal Title
 
-Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `RESUME`:
+Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `RESUME`:
 
 ```bash
-_optimus_set_title "optimus: RESUME $TASK_ID — $TASK_TITLE"
+_optimus_mark_session RESUME "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On exit or after Phase 5 delegates to another stage skill**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 4.2: Collect Worktree Telemetry

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -153,16 +153,16 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Set terminal title — see AGENTS.md Protocol: Terminal Identification. Use stage label `REVIEW`:
+Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `REVIEW`:
 
 ```bash
-_optimus_set_title "optimus: REVIEW $TASK_ID — $TASK_TITLE"
+_optimus_mark_session REVIEW "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-_optimus_set_title ""
+_optimus_clear_session
 ```
 
 ### Step 1.0.8: Validate and Update Task Status

--- a/scripts/inline-protocols.py
+++ b/scripts/inline-protocols.py
@@ -534,10 +534,14 @@ def inline_protocols(
         # F3.3e: Detect manual paste of inlined helper functions in the body.
         # The inliner appends these as part of shared protocols; if a SKILL
         # body also defines them, output ends up with duplicate definitions
-        # (and drift risk if one copy diverges). _optimus_sanitize is checked
-        # as a future-regression guard — it was removed in F2.
+        # (and drift risk if one copy diverges). _optimus_sanitize and
+        # _optimus_set_title are checked as future-regression guards —
+        # _optimus_sanitize was removed in F2 and _optimus_set_title was
+        # replaced by _optimus_mark_session / _optimus_clear_session.
         body_function_guards = (
             "_optimus_quiet_run() {",
+            "_optimus_mark_session() {",
+            "_optimus_clear_session() {",
             "_optimus_set_title() {",
             "_optimus_sanitize() {",
         )

--- a/scripts/test_inline_protocols.py
+++ b/scripts/test_inline_protocols.py
@@ -669,6 +669,42 @@ class TestBodyLevelInlineGuard:
         assert "WARNING" in captured.err
         assert "_optimus_sanitize" in captured.err
 
+    def test_warns_on_mark_session_in_body(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        body = (
+            "see AGENTS.md Protocol: Echo.\n"
+            "_optimus_mark_session() {\n"
+            "  printf '\\e]1337;SetBadgeFormat=%s\\a' \"$1\"\n"
+            "}\n"
+        )
+        self._setup(tmp_path, monkeypatch, body)
+        ip.inline_protocols()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "_optimus_mark_session" in captured.err
+
+    def test_warns_on_clear_session_in_body(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        body = (
+            "see AGENTS.md Protocol: Echo.\n"
+            "_optimus_clear_session() {\n"
+            "  printf '\\e]1337;SetBadgeFormat=\\a'\n"
+            "}\n"
+        )
+        self._setup(tmp_path, monkeypatch, body)
+        ip.inline_protocols()
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "_optimus_clear_session" in captured.err
+
 
 # --- F3.3f: Canonical reference phrasing in skills ---
 

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -272,12 +272,12 @@ class TestStageRenameConsistency:
 OLD_TITLE_FORMAT = re.compile(
     r"printf.*optimus:.*%s\s*\|\s*%s"
 )
-# Matches the title literal used by either `printf` OR `_optimus_set_title`,
-# in the form `optimus: STAGE $TASK_ID — $TASK_TITLE` (or %s placeholders,
-# or `<STAGE>` placeholder used in protocol templates, or a concrete example
-# like `optimus: BATCH T-003 — User Auth JWT`).
+# Matches a `_optimus_mark_session` invocation passing stage label, task id,
+# and task title (positional args). Accepts the literal stage names used
+# across skills, the `<STAGE>` placeholder used in the AGENTS.md protocol
+# template, or a concrete example like `_optimus_mark_session BATCH "T-003" "User Auth JWT"`.
 NEW_TITLE_FORMAT = re.compile(
-    r'optimus:\s*(?:%s|[A-Z]+|<\w+>)\s+(?:%s|\$TASK_ID|T-\d+)\s*—\s*(?:%s|\$TASK_TITLE|[\w][\w ]*)'
+    r'_optimus_mark_session\s+(?:"<STAGE>"|[A-Z]+)\s+(?:"\$TASK_ID"|"T-\d+")\s+(?:"\$TASK_TITLE"|"[^"]+")'
 )
 TITLE_SKILLS = ["plan", "build", "review", "done", "batch"]
 
@@ -312,22 +312,27 @@ class TestTerminalTitleFormat:
         )
 
     def test_all_stage_skills_have_terminal_title_step(self):
-        """All stage/batch skills must have a Set Terminal Title step."""
+        """All stage/batch skills must have a Mark/Set Terminal Session step."""
         missing = []
         for skill in TITLE_SKILLS:
             content = _read_skill(skill)
-            if "Set Terminal Title" not in content and "Set terminal title" not in content:
+            if (
+                "Set Terminal Title" not in content
+                and "Set terminal title" not in content
+                and "Mark Terminal Session" not in content
+                and "Mark terminal session" not in content
+            ):
                 missing.append(skill)
         assert missing == [], (
-            "Skills missing 'Set Terminal Title' step:\n"
+            "Skills missing 'Mark Terminal Session' step:\n"
             + "\n".join(f"  - {v}" for v in missing)
         )
 
     def test_all_title_skills_have_restore_title(self):
         """All title skills must have a restore terminal title command
-        via the `_optimus_set_title ""` helper call.
+        via the `_optimus_clear_session` helper call.
         """
-        restore_helper = re.compile(r'_optimus_set_title\s+""')
+        restore_helper = re.compile(r'_optimus_clear_session\b')
         missing = []
         for skill in TITLE_SKILLS:
             content = _read_skill(skill)
@@ -339,11 +344,14 @@ class TestTerminalTitleFormat:
         )
 
     def test_helper_has_applescript_layer(self):
-        """Layer A (AppleScript) must be present in every TITLE_SKILLS helper.
+        """Terminal Identification helper coverage must be present in every
+        TITLE_SKILLS file.
 
-        iTerm2 profiles with "Terminal may set window title" disabled silently
-        discard OSC 0/1/2 title updates. AppleScript `set name of session` is
-        the only channel that reliably mutates session.name in that scenario.
+        The protocol body lives in AGENTS.md and now uses iTerm2 escape
+        sequences (Badge OSC 1337 + Tab Color OSC 6) via
+        `_optimus_mark_session` / `_optimus_clear_session`, replacing the
+        previous AppleScript title approach (which only worked with focus
+        and required TCC permission).
 
         Phase 3 of issue #34 marked `Protocol: Terminal Identification` as
         summarize-mode (stub pointer in consumers). Phase 9 promoted it to
@@ -351,7 +359,7 @@ class TestTerminalTitleFormat:
         directly). This test detects the active mode and asserts the
         appropriate invariant for each:
 
-          * full-body mode (no marker): osascript body must appear verbatim.
+          * full-body mode (no marker): mark/clear-session body must appear verbatim.
           * summarize mode: stub pointer `(summarized)` must appear.
           * omit mode (Phase 9+): SKILL body must reference the protocol via
             `AGENTS.md Protocol: Terminal Identification` so the agent knows
@@ -391,14 +399,14 @@ class TestTerminalTitleFormat:
             else:
                 # Pre-Phase-3 invariant: full helper body inlined verbatim.
                 if (
-                    "osascript" not in content
-                    or "set name of s to" not in content
+                    "_optimus_mark_session" not in content
+                    or "SetBadgeFormat" not in content
                 ):
                     missing.append(skill)
         label = {
             "omit": "AGENTS.md back-reference (Phase 9 omit mode)",
             "summarize": "summarized stub pointer",
-            None: "AppleScript Layer A (osascript set name of s)",
+            None: "iTerm2 Badge/Tab-Color helper (_optimus_mark_session)",
         }[mode]
         assert missing == [], (
             f"Skills missing Terminal Identification {label}:\n"
@@ -1457,14 +1465,11 @@ class TestResumeAdmin:
         )
 
     def test_resume_sets_terminal_title(self):
-        """resume must set the terminal title per AGENTS.md Protocol: Terminal Identification."""
+        """resume must mark the terminal session per AGENTS.md Protocol: Terminal Identification."""
         content = _read_skill("resume")
         body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
-        assert re.search(r'optimus:\s+RESUME\s+\$TASK_ID', body), (
-            "resume must set terminal title with RESUME label"
-        )
-        assert re.search(r'_optimus_set_title\s+"optimus:\s+RESUME', body), (
-            "resume must invoke the _optimus_set_title helper with the RESUME label"
+        assert re.search(r'_optimus_mark_session\s+RESUME\s+"\$TASK_ID"\s+"\$TASK_TITLE"', body), (
+            "resume must invoke the _optimus_mark_session helper with the RESUME label"
         )
 
     # --- Round 2 regression tests ---
@@ -2855,21 +2860,26 @@ class TestDiscoverReviewDroidsDenyList:
 
 
 class TestTerminalIdentificationNotPastedInBody:
-    """F12f: After consolidating `_optimus_set_title`, no SKILL body should
-    contain a manual definition. The function comes from the inlined block
-    via the `AGENTS.md Protocol: Terminal Identification` reference."""
+    """F12f: After consolidating `_optimus_mark_session` / `_optimus_clear_session`,
+    no SKILL body should contain a manual definition. The functions come from
+    the inlined block via the `AGENTS.md Protocol: Terminal Identification`
+    reference."""
 
     def test_no_set_title_definition_in_skill_bodies(self):
         violations = []
         for skill_path in _all_skill_files():
             content = skill_path.read_text()
             body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
-            if "_optimus_set_title() {" in body:
+            if (
+                "_optimus_mark_session() {" in body
+                or "_optimus_clear_session() {" in body
+            ):
                 violations.append(str(skill_path.relative_to(REPO_ROOT)))
         assert violations == [], (
             "These SKILL.md files still contain a body-level "
-            "`_optimus_set_title()` definition; move it to the inlined "
-            "`Protocol: Terminal Identification` block:\n"
+            "`_optimus_mark_session()` or `_optimus_clear_session()` "
+            "definition; move it to the inlined `Protocol: Terminal "
+            "Identification` block:\n"
             + "\n".join(violations)
         )
 


### PR DESCRIPTION
## Summary

Replace `_optimus_set_title` with `_optimus_mark_session` + `_optimus_clear_session`. The previous AppleScript approach only updated the iTerm2 session name reliably when the tab had focus, required TCC permission, and was sticky to manually-set tab titles — making multi-session identification unreliable.

The new helper writes two iTerm2 escape sequences directly to the parent shell's controlling TTY:

- **Badge** (OSC 1337 `SetBadgeFormat`) — large semi-transparent overlay text, visible in Mission Control thumbnails and Dock previews even when the window is unfocused or backgrounded.
- **Tab Color** (OSC 6 `SetColors=tab`) — tints the tab itself, visible in the tab bar regardless of which tab is active. Per-stage palette: PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple.

Both signals are focus-independent. No AppleScript, no TCC prompt, no parent-TTY-as-blocker — silent no-op outside iTerm2/macOS as before. Inline-mode remains `omit`, so SKILLs keep only the call site; the function body lives in AGENTS.md.

## Files

- `AGENTS.md` — new function bodies, Summary, troubleshooting (Protocol: Terminal Identification)
- 6 `*/skills/optimus-*/SKILL.md` + 6 `commands/*.md` — call-site swap (`_optimus_set_title` → `_optimus_mark_session`/`_optimus_clear_session`)
- `scripts/inline-protocols.py` — extend regression guards to the new function names
- `scripts/test_skill_consistency.py` — update matchers
- `scripts/test_inline_protocols.py` — +2 new regression-guard tests

## Test plan

- [x] `python3 -m pytest scripts/test_skill_consistency.py scripts/test_inline_protocols.py` — 230 passed
- [x] `python3 scripts/inline-protocols.py` — clean (0 SKILLs needed re-inline)
- [x] `bash -n` syntax check on extracted functions
- [x] Dry-run with `LC_TERMINAL` unset → silent no-op (exit 0)
- [ ] **Manual iTerm2 verification (reviewer):** open 2-3 tabs, run different stages, defocus the window, check Mission Control thumbnails show distinct badges and tab colors per stage; run a stage with `DONE` and confirm color/badge updates immediately; run `_optimus_clear_session` and confirm reset