### PR TITLE
fix(sync): tolerate leading whitespace in droid plugin list output

### DIFF
--- a/scripts/test_sync_user_plugins.py
+++ b/scripts/test_sync_user_plugins.py
@@ -335,6 +335,40 @@ class TestUpdateWithExisting:
         assert result.returncode == 0
         assert "Updated: 1" in result.stdout
 
+    def test_parses_real_droid_list_format_with_leading_whitespace(
+        self, tmp_path: Path
+    ) -> None:
+        """Real `droid plugin list` output indents plugin lines with leading
+        whitespace (e.g. '  build@optimus  [user]  bb5b60e'). The awk parser
+        must be tolerant of that. Regression: an earlier version used
+        `/^[a-z0-9]/` which silently dropped every plugin and made all of
+        them be classified as NEW (causing 17/17 install failures with
+        'already installed at user scope').
+        """
+        log = tmp_path / "droid.log"
+        # Mimic real Droid CLI output: header line + indented plugin lines.
+        list_output = (
+            "Installed plugins:\n"
+            "  alpha@optimus  [user]  abc1234\n"
+            "  core@factory-plugins  [project]  def5678"
+        )
+        _create_mock_bin(tmp_path, "droid", _droid_script(
+            log, list_output=list_output))
+        _create_marketplace(tmp_path, ["alpha"])
+        result = _run_sync(tmp_path, exclude_claude=True)
+        assert result.returncode == 0, result.stderr
+        # Plugin should be classified as EXISTING (not NEW), so the refresh
+        # path runs (* alpha ... OK (refreshed)) — not the install path
+        # (+ alpha ... OK or FAIL).
+        assert "Updated: 1" in result.stdout, (
+            "alpha@optimus must be detected as installed when the mock emits "
+            "indented Droid CLI format. Got stdout:\n" + result.stdout
+        )
+        assert "(refreshed)" in result.stdout
+        # The unrelated `core@factory-plugins` line must NOT match (different
+        # marketplace) — the awk filter is anchored on @MARKETPLACE_NAME.
+        assert "core" not in result.stdout.lower().split("droid")[1]
+
 
 class TestOrphanRemoval:
     def test_removes_orphaned_plugins(self, tmp_path: Path) -> None:

--- a/sync/scripts/sync-user-plugins.sh
+++ b/sync/scripts/sync-user-plugins.sh
@@ -258,13 +258,21 @@ _sync_droid() {
   echo "── Droid (Factory) ──"
   echo ""
 
-  # Get installed optimus plugins. Single awk pass: filter to lines starting
-  # with [a-z0-9] whose first field ends with @MARKETPLACE_NAME, then strip
-  # that suffix and emit the bare name.
+  # Get installed optimus plugins. Single awk pass: filter to lines whose
+  # first non-whitespace token ends with @MARKETPLACE_NAME, then strip that
+  # suffix and emit the bare name.
+  #
+  # NOTE: real `droid plugin list` output indents plugin lines with leading
+  # whitespace (e.g. "  build@optimus  [user]  bb5b60e"). The previous regex
+  # `/^[a-z0-9]/` required the line to START with a letter/digit, which
+  # silently dropped every plugin and made `installed` empty — causing the
+  # whole sync to misclassify all plugins as NEW and fail with
+  # "already installed at user scope" on every install. The leading
+  # `[[:space:]]*` prefix makes the parser tolerant of indentation.
   local installed
   installed=$(_droid plugin list 2>/dev/null \
     | awk -v mp="@${MARKETPLACE_NAME}" '
-        /^[a-z0-9]/ && index($1, mp) == length($1) - length(mp) + 1 {
+        /^[[:space:]]*[a-z0-9]/ && index($1, mp) == length($1) - length(mp) + 1 {
           sub(mp"$", "", $1)
           print $1
         }


### PR DESCRIPTION
## Summary

Real \`droid plugin list\` indents plugin lines with leading whitespace:

\`\`\`
Installed plugins:
  build@optimus  [user]  bb5b60e
  quick-report@optimus  [user]  bb5b60e
\`\`\`

The awk parser at \`sync/scripts/sync-user-plugins.sh:267\` used \`/^[a-z0-9]/\` which required the line to START with a letter or digit. Every indented plugin line was silently dropped. Consequence: \`installed\` was empty, \`_compute_diffs\` classified every plugin as NEW, and the install path failed for all of them with \"already installed at user scope\".

## Real-world impact

Every user with \`droid\` CLI installed has been hitting **17/17 install failures** on \`/optimus:sync\` after the first run. Just observed in this session:

\`\`\`
── Droid (Factory) ──

Installing new plugins...
Retrying failed plugin operations serially...
  + batch ... FAIL
  ... (15 more)
  + tasks ... FAIL

  Droid — Added: 0 | Updated: 0 | Removed: 0 | Failed: 17
\`\`\`

Manual workaround was a \`for p in ...; do droid plugin uninstall \$p@optimus; done\` loop.

## Why tests didn't catch it

The \`_droid_script\` mock at \`scripts/test_sync_user_plugins.py:39-53\` emits plugin lines WITHOUT leading whitespace, so the bug was invisible to all existing tests. Fixed in this PR by adding a regression test that feeds indented output mimicking real CLI format.

## Changes

- \`sync/scripts/sync-user-plugins.sh\` (line 267): awk regex \`/^[a-z0-9]/\` → \`/^[[:space:]]*[a-z0-9]/\`. Added a comment explaining the indentation hazard.
- \`scripts/test_sync_user_plugins.py\` \`TestUpdateWithExisting::test_parses_real_droid_list_format_with_leading_whitespace\`: feeds mock with header + indented plugin lines + an unrelated \`core@factory-plugins\` line; asserts EXISTING detection, refresh path runs, and other marketplaces are not misattributed.

## Test plan
- [x] \`python3 -m pytest scripts/test_sync_user_plugins.py -k TestUpdateWithExisting\` — 2 passed
- [x] \`python3 -m pytest scripts/\` — 352 passed
- [ ] Smoke test (manual after merge): \`/optimus:sync\` with all 17 Droid plugins already installed should now show \"Refreshing existing plugins...\" + \"Updated: 17 | Failed: 0\" (instead of 17/17 install failures).