### PR TITLE
docs(conventions): document Conventional Commits usage end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ Pendente → Validando Spec → Em Andamento → Validando Impl → DONE
 | `review` | 3 | Validates completed task implementation against spec, coding standards, and best practices using parallel specialist agents | `/optimus-review` |
 | `done` | 4 | Requires PR in final state (merged or closed) before marking task done. Cleans up worktree and branch interactively | `/optimus-done` |
 
+## Conventions
+
+Optimus uses **Conventional Commits 1.0.0** end-to-end — derived automatically from each task's `Tipo` column:
+
+| Tipo | Prefix | Branch | Commit / PR title |
+|------|--------|--------|-------------------|
+| `Feature` | `feat` | `feat/t-003-user-auth` | `feat(T-003): add login API` |
+| `Fix` | `fix` | `fix/t-007-duplicate-login` | `fix(T-007): debounce submit` |
+| `Refactor` | `refactor` | `refactor/t-012-...` | `refactor(T-012): ...` |
+| `Chore` | `chore` | `chore/t-015-...` | `chore(T-015): ...` |
+| `Docs` | `docs` | `docs/t-018-...` | `docs(T-018): ...` |
+| `Test` | `test` | `test/t-021-...` | `test(T-021): ...` |
+
+Branch names, commit messages, and PR titles are all derived from the same `Tipo` — no manual mapping needed. `build` validates PR titles against the Conventional Commits regex and offers to fix non-conforming titles via `gh pr edit`. Structural edits to `optimus-tasks.md` (new task, dependency edit, version move) always use `chore(tasks):` regardless of the affected tasks' Tipo.
+
+Full spec: [AGENTS.md — Conventional Commits](AGENTS.md#conventional-commits-pr-titles-and-commit-messages) and [Branch Name Derivation](AGENTS.md#protocol-branch-name-derivation).
+
 ## Review & Verification Skills
 
 | Skill | Description | Command |

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -187,7 +187,7 @@ The user can then modify any field before confirming.
 **Option B: From scratch.** Ask the user for task details using `AskUser` (one question at a time or batch if info provided):
 
 1. **Title** (required): Short description of the task
-2. **Tipo** (required): `Feature`, `Fix`, `Refactor`, `Chore`, `Docs`, or `Test`
+2. **Tipo** (required): `Feature`, `Fix`, `Refactor`, `Chore`, `Docs`, or `Test`. The Tipo determines the Conventional Commits prefix used downstream by `plan` (branch name), `build` (commit messages), and `review` (PR title) — see AGENTS.md "Valid Tipo Values" table for the full mapping.
 3. **Priority** (required): `Alta`, `Media`, or `Baixa`
 4. **Estimate** (optional): Task size estimate (`S`, `M`, `L`, `XL`, `2h`, `1d`, etc.). Default: `-`
 5. **Version** (required): Must match a version in the Versions table. Default: the version with Status `Ativa`


### PR DESCRIPTION
## Summary
- Add a **Conventions** section to README with the Tipo→Prefix→Branch→Commit/PR-title mapping table and links to the canonical AGENTS.md sections (`Conventional Commits` and `Branch Name Derivation`).
- Clarify in `tasks/skills/optimus-tasks/SKILL.md` that the chosen `Tipo` drives the Conventional Commits prefix used downstream by `plan` (branch), `build` (commits), and `review` (PR title).

## Why
The convention is already enforced by `build` (PR-title regex validation) and hardcoded in `plan`/`resume` (branch derivation), but it was only documented in AGENTS.md — invisible to anyone reading the README or creating tasks via `/optimus:tasks`. These two doc additions close the gap without touching any execution skill, code, or test.

## Test plan
- [x] `grep -n 'Conventional Commits' README.md tasks/skills/optimus-tasks/SKILL.md` shows the new content.
- [x] AGENTS.md anchors referenced in README exist (`#conventional-commits-pr-titles-and-commit-messages` at L488; `#protocol-branch-name-derivation` at L2771).
- [ ] CI passes (no behavioral changes; docs-only diff).