### PR TITLE
feat(skills): offer Ring track selection (lightweight vs full) (#53)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2751,6 +2751,28 @@ as a valid Cancelado-state sentinel; they MUST NOT treat absence of the `branch`
 field as a meaningful state difference. The State Management writer ALWAYS produces
 the full `{status, branch, updated_at}` triple.
 
+**Optional `ring_track` field:**
+Plan, tasks, and import set a `ring_track` field on a task's record when the spec is
+generated via Ring (`ring:pre-dev-feature` → `"feature"`, `ring:pre-dev-full` →
+`"full"`), alongside a `ring_track_recorded_at` timestamp. The field is informational
+only — it is not used to gate any flow today; it preserves the user's track decision
+for future runs and audits. It is set once at spec generation time and is left
+untouched by subsequent state writes. The standard `{status, branch, updated_at}`
+writer does NOT clear it (writes use a merge that preserves unrelated fields when
+the dedicated `ring_track` snippet is used). Example merged record:
+
+```json
+{
+  "T-001": {
+    "status": "Validando Spec",
+    "branch": "feat/t-001-...",
+    "updated_at": "2026-04-28T12:34:56Z",
+    "ring_track": "feature",
+    "ring_track_recorded_at": "2026-04-28T12:30:00Z"
+  }
+}
+```
+
 **state.json is NEVER committed.** It is gitignored. No `git add` or `git commit`
 for state changes.
 

--- a/commands/import.md
+++ b/commands/import.md
@@ -236,12 +236,40 @@ without Ring pre-dev specs):
    N tasks have no Ring pre-dev spec. How should I proceed?
    ```
    Options:
-   - **Generate all via Ring** — invoke `ring:pre-dev-feature` for each task
+   - **Generate all via Ring** — invoke a Ring pre-dev skill for each task (track chosen per task — see below)
    - **Generate selectively** — for each task, ask Generate via Ring / Link existing spec / Defer (per-task choice)
    - **Skip all** — keep TaskSpec as `-` for all; the next `/optimus:plan T-XXX` will offer to resolve
+
+   **Whenever a Ring skill is about to be invoked (in either "Generate all via Ring"
+   or the "Generate via Ring" branch of "Generate selectively"), first prompt for
+   the Ring track per task:**
+
+   ```
+   [topic] (X/N) Which Ring track for T-XXX? (Estimate: <estimate>)
+   ```
+
+   Options (mark the auto-suggested one with " (recommended)"):
+   - **Lightweight** (`ring:pre-dev-feature`) — 4 gates, for tasks <2 days
+   - **Full** (`ring:pre-dev-full`) — 9 gates, for tasks ≥2 days or multi-component features
+
+   Save the user's choice for the current task as `RING_TRACK` ∈ {`feature`, `full`}. The selected skill name is `ring:pre-dev-feature` (when `feature`) or `ring:pre-dev-full` (when `full`).
+
+   **Auto-suggestion rule** (read the task's `Estimate` column; suggest the matching option as "(recommended)"; the user can always override):
+
+   | Estimate value | Suggested default |
+   |----------------|-------------------|
+   | `S`, `M` | Lightweight |
+   | `L`, `XL` | Full |
+   | Hour-based (e.g. `2h`, `8h`) | Lightweight |
+   | `1d` | Lightweight |
+   | Multi-day (`2d`, `3d`, `1w`, etc.) | Full |
+   | `-` or unknown | Lightweight |
+
+   Verify the chosen Ring skill is available. If unavailable → fall back to the OTHER track if it is available; if neither is available → fall back to "Link existing spec" (or "Defer", in the "Generate all via Ring" path) and warn the user.
+
 3. If "Generate all via Ring":
-   - For each task, invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
-   - After Ring generates the spec, update the task's TaskSpec value.
+   - For each task, run the per-task track prompt above to pick `RING_TRACK`, then invoke the chosen Ring skill (`ring:pre-dev-feature` OR `ring:pre-dev-full`) via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+   - After Ring generates the spec, update the task's TaskSpec value AND record the chosen track in state.json (see step 7 below).
    - If Ring fails for a task, warn the user and keep that task's TaskSpec as `-` (the next `/optimus:plan T-XXX` will offer to resolve).
 4. If "Generate selectively":
    - For each task with `TaskSpec = -`, ask via `AskUser`:
@@ -249,12 +277,34 @@ without Ring pre-dev specs):
      [topic] (X/N) Task T-XXX (<title>) — how should I handle the spec?
      ```
      Options:
-     - **Generate via Ring** (recommended) — invoke `ring:pre-dev-feature`
+     - **Generate via Ring** (recommended) — run the per-task track prompt above to pick `RING_TRACK`, then invoke the chosen Ring skill (`ring:pre-dev-feature` OR `ring:pre-dev-full`).
      - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`; pick from top 5 matches; **HARD BLOCK** validate the chosen path: (a) exists, (b) is a regular file (NOT a symlink), (c) resolves inside `<TASKS_DIR>` with no intermediate symlink components, (d) contains no pipe (`|`), control characters, newlines. Apply the realpath/case-glob/symlink rejection block from AGENTS.md Protocol: TaskSpec Resolution.
      - **Defer** — keep TaskSpec as `-`; the next `/optimus:plan T-XXX` will offer to resolve.
 5. If "Skip all":
    - Keep TaskSpec as `-` for every task; inform the user that `/optimus:plan T-XXX` will offer to generate or link a spec when they next plan that task.
 6. If Ring is not available at any point, warn and keep TaskSpec as `-` for the affected tasks.
+7. **Record the chosen Ring track in state.json (per task that successfully ran Ring)** — see AGENTS.md Protocol: State Management. If `.optimus/` does not yet exist, see AGENTS.md Protocol: Initialize .optimus Directory first. The snippet below performs an idempotent merge into the task's existing record (preserving any `status`, `branch`, `updated_at` fields):
+
+   ```bash
+   # Record the chosen Ring track for the current task (idempotent merge)
+   if [ ! -f "$STATE_FILE" ]; then echo '{}' > "$STATE_FILE"; fi
+   UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   if jq --arg id "$TASK_ID" --arg track "$RING_TRACK" --arg ts "$UPDATED_AT" \
+     '.[$id] = ((.[$id] // {}) + {ring_track: $track, ring_track_recorded_at: $ts})' \
+     "$STATE_FILE" > "${STATE_FILE}.tmp"; then
+     if jq empty "${STATE_FILE}.tmp" 2>/dev/null; then
+       mv "${STATE_FILE}.tmp" "$STATE_FILE"
+     else
+       rm -f "${STATE_FILE}.tmp"
+       echo "ERROR: jq produced invalid JSON — state.json unchanged" >&2
+       exit 1
+     fi
+   else
+     rm -f "${STATE_FILE}.tmp"
+     echo "ERROR: jq failed to update state.json" >&2
+     exit 1
+   fi
+   ```
 
 ---
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -213,21 +213,66 @@ workspace, no `Validando Spec` status leak).
    - **Cancel** — abort plan
 
 4. **If "Generate via Ring":**
-   1. Verify `ring:pre-dev-feature` is available. If unavailable → fall back to "Link existing spec" automatically and warn the user.
-   2. Invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
-   3. **If Ring fails or returns no spec path:**
+   1. **Choose the Ring track.** Read the task's `Estimate` column and apply the auto-suggestion rule below to pick the recommended default. Ask via `AskUser`:
+
+      ```
+      [topic] (1/1) Which Ring track for T-XXX? (Estimate: <estimate>)
+      ```
+
+      Options (mark the auto-suggested one with " (recommended)"):
+      - **Lightweight** (`ring:pre-dev-feature`) — 4 gates, for tasks <2 days
+      - **Full** (`ring:pre-dev-full`) — 9 gates, for tasks ≥2 days or multi-component features
+
+      Save the user's choice as `RING_TRACK` ∈ {`feature`, `full`}. The selected skill name is `ring:pre-dev-feature` (when `feature`) or `ring:pre-dev-full` (when `full`).
+
+      **Auto-suggestion rule** (suggest the matching option as "(recommended)"; the user can always override):
+
+      | Estimate value | Suggested default |
+      |----------------|-------------------|
+      | `S`, `M` | Lightweight |
+      | `L`, `XL` | Full |
+      | Hour-based (e.g. `2h`, `8h`) | Lightweight |
+      | `1d` | Lightweight |
+      | Multi-day (`2d`, `3d`, `1w`, etc.) | Full |
+      | `-` or unknown | Lightweight |
+
+   2. Verify the chosen Ring skill (`ring:pre-dev-feature` OR `ring:pre-dev-full`) is available. If unavailable → fall back to the OTHER track if it is available; if neither is available → fall back to "Link existing spec" automatically and warn the user.
+   3. Invoke the chosen Ring skill via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+   4. **If Ring fails or returns no spec path:**
       - Warn the user: "Ring failed to generate the spec: <error>."
       - Re-prompt with `Link existing spec` / `Cancel`. Do NOT silently fall through.
       - If user picks Cancel → STOP — "Plan cancelled — task spec required."
-   4. **If Ring succeeds:**
+   5. **If Ring succeeds:**
       - Capture the generated spec file path (relative to `<TASKS_DIR>`). Save in a variable `SPEC_PATH`.
       - Update the task's `TaskSpec` column in `optimus-tasks.md`.
-   5. **Re-validate** optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
+   6. **Re-validate** optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
       - If validation fails:
         a. Revert the in-memory edit to the TaskSpec column.
         b. Remove the spec file Ring just created at `<TASKS_DIR>/<SPEC_PATH>` (rollback Ring's side effect).
         c. STOP and report the validation error.
-   6. Commit the TaskSpec update:
+   7. **Record the chosen Ring track in state.json** — see AGENTS.md Protocol: State Management. The snippet below performs an idempotent merge into the task's existing record (preserving `status`, `branch`, `updated_at`):
+
+      ```bash
+      # Record the chosen Ring track (idempotent merge into existing record)
+      if [ ! -f "$STATE_FILE" ]; then echo '{}' > "$STATE_FILE"; fi
+      UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      if jq --arg id "$TASK_ID" --arg track "$RING_TRACK" --arg ts "$UPDATED_AT" \
+        '.[$id] = ((.[$id] // {}) + {ring_track: $track, ring_track_recorded_at: $ts})' \
+        "$STATE_FILE" > "${STATE_FILE}.tmp"; then
+        if jq empty "${STATE_FILE}.tmp" 2>/dev/null; then
+          mv "${STATE_FILE}.tmp" "$STATE_FILE"
+        else
+          rm -f "${STATE_FILE}.tmp"
+          echo "ERROR: jq produced invalid JSON — state.json unchanged" >&2
+          exit 1
+        fi
+      else
+        rm -f "${STATE_FILE}.tmp"
+        echo "ERROR: jq failed to update state.json" >&2
+        exit 1
+      fi
+      ```
+   8. Commit the TaskSpec update:
       ```bash
       tasks_git add "$TASKS_GIT_REL"
       COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }

--- a/commands/tasks.md
+++ b/commands/tasks.md
@@ -135,7 +135,7 @@ The user can then modify any field before confirming.
 **Option B: From scratch.** Ask the user for task details using `AskUser` (one question at a time or batch if info provided):
 
 1. **Title** (required): Short description of the task
-2. **Tipo** (required): `Feature`, `Fix`, `Refactor`, `Chore`, `Docs`, or `Test`
+2. **Tipo** (required): `Feature`, `Fix`, `Refactor`, `Chore`, `Docs`, or `Test`. The Tipo determines the Conventional Commits prefix used downstream by `plan` (branch name), `build` (commit messages), and `review` (PR title) — see AGENTS.md "Valid Tipo Values" table for the full mapping.
 3. **Priority** (required): `Alta`, `Media`, or `Baixa`
 4. **Estimate** (optional): Task size estimate (`S`, `M`, `L`, `XL`, `2h`, `1d`, etc.). Default: `-`
 5. **Version** (required): Must match a version in the Versions table. Default: the version with Status `Ativa`
@@ -253,15 +253,60 @@ Options:
 
 **If "Generate via Ring":**
 
-1. Verify `ring:pre-dev-feature` is available. If unavailable → warn and fall back to "Link existing spec" automatically.
-2. Invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
-3. **If Ring fails or returns no spec path:**
+1. **Choose the Ring track.** Read the task's `Estimate` column (the value the user just provided for this new task) and apply the auto-suggestion rule below to pick the recommended default. Ask via `AskUser`:
+
+   ```
+   [topic] (1/1) Which Ring track for T-XXX? (Estimate: <estimate>)
+   ```
+
+   Options (mark the auto-suggested one with " (recommended)"):
+   - **Lightweight** (`ring:pre-dev-feature`) — 4 gates, for tasks <2 days
+   - **Full** (`ring:pre-dev-full`) — 9 gates, for tasks ≥2 days or multi-component features
+
+   Save the user's choice as `RING_TRACK` ∈ {`feature`, `full`}. The selected skill name is `ring:pre-dev-feature` (when `feature`) or `ring:pre-dev-full` (when `full`).
+
+   **Auto-suggestion rule** (suggest the matching option as "(recommended)"; the user can always override):
+
+   | Estimate value | Suggested default |
+   |----------------|-------------------|
+   | `S`, `M` | Lightweight |
+   | `L`, `XL` | Full |
+   | Hour-based (e.g. `2h`, `8h`) | Lightweight |
+   | `1d` | Lightweight |
+   | Multi-day (`2d`, `3d`, `1w`, etc.) | Full |
+   | `-` or unknown | Lightweight |
+
+2. Verify the chosen Ring skill (`ring:pre-dev-feature` OR `ring:pre-dev-full`) is available. If unavailable → fall back to the OTHER track if it is available; if neither is available → warn and fall back to "Link existing spec" automatically.
+3. Invoke the chosen Ring skill via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+4. **If Ring fails or returns no spec path:**
    - Warn the user: "Ring failed to generate the spec: <error>."
    - Re-prompt with `Link existing spec` / `Defer`. Do NOT silently fall through.
-4. **If Ring succeeds:**
+5. **If Ring succeeds:**
    - Ring generates the spec file in `<TASKS_DIR>/tasks/`.
    - Capture the generated spec file path (relative to `TASKS_DIR`).
    - Store as the `TaskSpec` value for this task.
+6. **Record the chosen Ring track in state.json** — see AGENTS.md Protocol: State Management. If `.optimus/` does not yet exist, see AGENTS.md Protocol: Initialize .optimus Directory first. The snippet below performs an idempotent merge into the task's existing record (preserving any `status`, `branch`, `updated_at` fields):
+
+   ```bash
+   # Record the chosen Ring track (idempotent merge into existing record)
+   if [ ! -f "$STATE_FILE" ]; then echo '{}' > "$STATE_FILE"; fi
+   UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   if jq --arg id "$TASK_ID" --arg track "$RING_TRACK" --arg ts "$UPDATED_AT" \
+     '.[$id] = ((.[$id] // {}) + {ring_track: $track, ring_track_recorded_at: $ts})' \
+     "$STATE_FILE" > "${STATE_FILE}.tmp"; then
+     if jq empty "${STATE_FILE}.tmp" 2>/dev/null; then
+       mv "${STATE_FILE}.tmp" "$STATE_FILE"
+     else
+       rm -f "${STATE_FILE}.tmp"
+       echo "ERROR: jq produced invalid JSON — state.json unchanged" >&2
+       exit 1
+     fi
+   else
+     rm -f "${STATE_FILE}.tmp"
+     echo "ERROR: jq failed to update state.json" >&2
+     exit 1
+   fi
+   ```
 
 **If "Link existing spec":**
 

--- a/import/skills/optimus-import/SKILL.md
+++ b/import/skills/optimus-import/SKILL.md
@@ -284,12 +284,40 @@ without Ring pre-dev specs):
    N tasks have no Ring pre-dev spec. How should I proceed?
    ```
    Options:
-   - **Generate all via Ring** — invoke `ring:pre-dev-feature` for each task
+   - **Generate all via Ring** — invoke a Ring pre-dev skill for each task (track chosen per task — see below)
    - **Generate selectively** — for each task, ask Generate via Ring / Link existing spec / Defer (per-task choice)
    - **Skip all** — keep TaskSpec as `-` for all; the next `/optimus-plan T-XXX` will offer to resolve
+
+   **Whenever a Ring skill is about to be invoked (in either "Generate all via Ring"
+   or the "Generate via Ring" branch of "Generate selectively"), first prompt for
+   the Ring track per task:**
+
+   ```
+   [topic] (X/N) Which Ring track for T-XXX? (Estimate: <estimate>)
+   ```
+
+   Options (mark the auto-suggested one with " (recommended)"):
+   - **Lightweight** (`ring:pre-dev-feature`) — 4 gates, for tasks <2 days
+   - **Full** (`ring:pre-dev-full`) — 9 gates, for tasks ≥2 days or multi-component features
+
+   Save the user's choice for the current task as `RING_TRACK` ∈ {`feature`, `full`}. The selected skill name is `ring:pre-dev-feature` (when `feature`) or `ring:pre-dev-full` (when `full`).
+
+   **Auto-suggestion rule** (read the task's `Estimate` column; suggest the matching option as "(recommended)"; the user can always override):
+
+   | Estimate value | Suggested default |
+   |----------------|-------------------|
+   | `S`, `M` | Lightweight |
+   | `L`, `XL` | Full |
+   | Hour-based (e.g. `2h`, `8h`) | Lightweight |
+   | `1d` | Lightweight |
+   | Multi-day (`2d`, `3d`, `1w`, etc.) | Full |
+   | `-` or unknown | Lightweight |
+
+   Verify the chosen Ring skill is available. If unavailable → fall back to the OTHER track if it is available; if neither is available → fall back to "Link existing spec" (or "Defer", in the "Generate all via Ring" path) and warn the user.
+
 3. If "Generate all via Ring":
-   - For each task, invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
-   - After Ring generates the spec, update the task's TaskSpec value.
+   - For each task, run the per-task track prompt above to pick `RING_TRACK`, then invoke the chosen Ring skill (`ring:pre-dev-feature` OR `ring:pre-dev-full`) via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+   - After Ring generates the spec, update the task's TaskSpec value AND record the chosen track in state.json (see step 7 below).
    - If Ring fails for a task, warn the user and keep that task's TaskSpec as `-` (the next `/optimus-plan T-XXX` will offer to resolve).
 4. If "Generate selectively":
    - For each task with `TaskSpec = -`, ask via `AskUser`:
@@ -297,12 +325,34 @@ without Ring pre-dev specs):
      [topic] (X/N) Task T-XXX (<title>) — how should I handle the spec?
      ```
      Options:
-     - **Generate via Ring** (recommended) — invoke `ring:pre-dev-feature`
+     - **Generate via Ring** (recommended) — run the per-task track prompt above to pick `RING_TRACK`, then invoke the chosen Ring skill (`ring:pre-dev-feature` OR `ring:pre-dev-full`).
      - **Link existing spec** — search `<TASKS_DIR>/tasks/*.md`; pick from top 5 matches; **HARD BLOCK** validate the chosen path: (a) exists, (b) is a regular file (NOT a symlink), (c) resolves inside `<TASKS_DIR>` with no intermediate symlink components, (d) contains no pipe (`|`), control characters, newlines. Apply the realpath/case-glob/symlink rejection block from AGENTS.md Protocol: TaskSpec Resolution.
      - **Defer** — keep TaskSpec as `-`; the next `/optimus-plan T-XXX` will offer to resolve.
 5. If "Skip all":
    - Keep TaskSpec as `-` for every task; inform the user that `/optimus-plan T-XXX` will offer to generate or link a spec when they next plan that task.
 6. If Ring is not available at any point, warn and keep TaskSpec as `-` for the affected tasks.
+7. **Record the chosen Ring track in state.json (per task that successfully ran Ring)** — see AGENTS.md Protocol: State Management. If `.optimus/` does not yet exist, see AGENTS.md Protocol: Initialize .optimus Directory first. The snippet below performs an idempotent merge into the task's existing record (preserving any `status`, `branch`, `updated_at` fields):
+
+   ```bash
+   # Record the chosen Ring track for the current task (idempotent merge)
+   if [ ! -f "$STATE_FILE" ]; then echo '{}' > "$STATE_FILE"; fi
+   UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   if jq --arg id "$TASK_ID" --arg track "$RING_TRACK" --arg ts "$UPDATED_AT" \
+     '.[$id] = ((.[$id] // {}) + {ring_track: $track, ring_track_recorded_at: $ts})' \
+     "$STATE_FILE" > "${STATE_FILE}.tmp"; then
+     if jq empty "${STATE_FILE}.tmp" 2>/dev/null; then
+       mv "${STATE_FILE}.tmp" "$STATE_FILE"
+     else
+       rm -f "${STATE_FILE}.tmp"
+       echo "ERROR: jq produced invalid JSON — state.json unchanged" >&2
+       exit 1
+     fi
+   else
+     rm -f "${STATE_FILE}.tmp"
+     echo "ERROR: jq failed to update state.json" >&2
+     exit 1
+   fi
+   ```
 
 ---
 

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -274,21 +274,66 @@ workspace, no `Validando Spec` status leak).
    - **Cancel** — abort plan
 
 4. **If "Generate via Ring":**
-   1. Verify `ring:pre-dev-feature` is available. If unavailable → fall back to "Link existing spec" automatically and warn the user.
-   2. Invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
-   3. **If Ring fails or returns no spec path:**
+   1. **Choose the Ring track.** Read the task's `Estimate` column and apply the auto-suggestion rule below to pick the recommended default. Ask via `AskUser`:
+
+      ```
+      [topic] (1/1) Which Ring track for T-XXX? (Estimate: <estimate>)
+      ```
+
+      Options (mark the auto-suggested one with " (recommended)"):
+      - **Lightweight** (`ring:pre-dev-feature`) — 4 gates, for tasks <2 days
+      - **Full** (`ring:pre-dev-full`) — 9 gates, for tasks ≥2 days or multi-component features
+
+      Save the user's choice as `RING_TRACK` ∈ {`feature`, `full`}. The selected skill name is `ring:pre-dev-feature` (when `feature`) or `ring:pre-dev-full` (when `full`).
+
+      **Auto-suggestion rule** (suggest the matching option as "(recommended)"; the user can always override):
+
+      | Estimate value | Suggested default |
+      |----------------|-------------------|
+      | `S`, `M` | Lightweight |
+      | `L`, `XL` | Full |
+      | Hour-based (e.g. `2h`, `8h`) | Lightweight |
+      | `1d` | Lightweight |
+      | Multi-day (`2d`, `3d`, `1w`, etc.) | Full |
+      | `-` or unknown | Lightweight |
+
+   2. Verify the chosen Ring skill (`ring:pre-dev-feature` OR `ring:pre-dev-full`) is available. If unavailable → fall back to the OTHER track if it is available; if neither is available → fall back to "Link existing spec" automatically and warn the user.
+   3. Invoke the chosen Ring skill via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+   4. **If Ring fails or returns no spec path:**
       - Warn the user: "Ring failed to generate the spec: <error>."
       - Re-prompt with `Link existing spec` / `Cancel`. Do NOT silently fall through.
       - If user picks Cancel → STOP — "Plan cancelled — task spec required."
-   4. **If Ring succeeds:**
+   5. **If Ring succeeds:**
       - Capture the generated spec file path (relative to `<TASKS_DIR>`). Save in a variable `SPEC_PATH`.
       - Update the task's `TaskSpec` column in `optimus-tasks.md`.
-   5. **Re-validate** optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
+   6. **Re-validate** optimus-tasks.md — see AGENTS.md Protocol: optimus-tasks.md Validation.
       - If validation fails:
         a. Revert the in-memory edit to the TaskSpec column.
         b. Remove the spec file Ring just created at `<TASKS_DIR>/<SPEC_PATH>` (rollback Ring's side effect).
         c. STOP and report the validation error.
-   6. Commit the TaskSpec update:
+   7. **Record the chosen Ring track in state.json** — see AGENTS.md Protocol: State Management. The snippet below performs an idempotent merge into the task's existing record (preserving `status`, `branch`, `updated_at`):
+
+      ```bash
+      # Record the chosen Ring track (idempotent merge into existing record)
+      if [ ! -f "$STATE_FILE" ]; then echo '{}' > "$STATE_FILE"; fi
+      UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      if jq --arg id "$TASK_ID" --arg track "$RING_TRACK" --arg ts "$UPDATED_AT" \
+        '.[$id] = ((.[$id] // {}) + {ring_track: $track, ring_track_recorded_at: $ts})' \
+        "$STATE_FILE" > "${STATE_FILE}.tmp"; then
+        if jq empty "${STATE_FILE}.tmp" 2>/dev/null; then
+          mv "${STATE_FILE}.tmp" "$STATE_FILE"
+        else
+          rm -f "${STATE_FILE}.tmp"
+          echo "ERROR: jq produced invalid JSON — state.json unchanged" >&2
+          exit 1
+        fi
+      else
+        rm -f "${STATE_FILE}.tmp"
+        echo "ERROR: jq failed to update state.json" >&2
+        exit 1
+      fi
+      ```
+   8. Commit the TaskSpec update:
       ```bash
       tasks_git add "$TASKS_GIT_REL"
       COMMIT_MSG_FILE=$(mktemp -t optimus.XXXXXX) || { echo "ERROR: mktemp failed" >&2; exit 1; }

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3259,6 +3259,158 @@ class TestSpecSelfHeal:
                 f"{skill_path.parent.parent.name} 'Link existing spec' must explicitly mention symlinks"
             )
 
+    # --- Issue #53: Ring track selection (lightweight vs full) ---
+
+    def test_plan_offers_track_selection(self):
+        """plan SKILL.md must offer BOTH ring:pre-dev-feature AND ring:pre-dev-full
+        inside the Step 1.0.4.5 'Generate via Ring' branch."""
+        body = (REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md").read_text()
+        body = body.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        start = body.find("### Step 1.0.4.5")
+        end = body.find("### Step 1.0.5", start + 1)
+        section = body[start:end] if start >= 0 and end > start else ""
+        assert "ring:pre-dev-feature" in section, (
+            "plan Step 1.0.4.5 must mention ring:pre-dev-feature (lightweight track)"
+        )
+        assert "ring:pre-dev-full" in section, (
+            "plan Step 1.0.4.5 must mention ring:pre-dev-full (full track)"
+        )
+
+    def test_tasks_offers_track_selection(self):
+        """tasks SKILL.md must offer BOTH ring:pre-dev-feature AND ring:pre-dev-full
+        inside the Step 2.3.1 'Generate via Ring' branch."""
+        body = (REPO_ROOT / "tasks" / "skills" / "optimus-tasks" / "SKILL.md").read_text()
+        body = body.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        start = body.find("### Step 2.3.1")
+        end = body.find("### Step 2.4", start + 1)
+        section = body[start:end] if start >= 0 and end > start else ""
+        assert "ring:pre-dev-feature" in section, (
+            "tasks Step 2.3.1 must mention ring:pre-dev-feature (lightweight track)"
+        )
+        assert "ring:pre-dev-full" in section, (
+            "tasks Step 2.3.1 must mention ring:pre-dev-full (full track)"
+        )
+
+    def test_import_offers_track_selection(self):
+        """import SKILL.md must offer BOTH ring:pre-dev-feature AND ring:pre-dev-full
+        inside Step 1.6 (covers BOTH 'Generate all via Ring' AND
+        'Generate selectively → Generate via Ring')."""
+        body = (REPO_ROOT / "import" / "skills" / "optimus-import" / "SKILL.md").read_text()
+        body = body.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        start = body.find("### Step 1.6")
+        # Section ends at the next horizontal rule or Phase 2 heading.
+        end_candidates = [
+            body.find("\n---\n", start + 1),
+            body.find("## Phase 2", start + 1),
+        ]
+        end_candidates = [i for i in end_candidates if i > 0]
+        end = min(end_candidates) if end_candidates else -1
+        section = body[start:end] if start >= 0 and end > start else ""
+        assert "ring:pre-dev-feature" in section, (
+            "import Step 1.6 must mention ring:pre-dev-feature (lightweight track)"
+        )
+        assert "ring:pre-dev-full" in section, (
+            "import Step 1.6 must mention ring:pre-dev-full (full track)"
+        )
+
+    def test_track_selection_estimate_table(self):
+        """Each of the 3 SKILLs must mention the Estimate-based default rule
+        (Lightweight + Full + Estimate) within the relevant slice."""
+        slices = [
+            (
+                REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md",
+                "### Step 1.0.4.5",
+                "### Step 1.0.5",
+            ),
+            (
+                REPO_ROOT / "tasks" / "skills" / "optimus-tasks" / "SKILL.md",
+                "### Step 2.3.1",
+                "### Step 2.4",
+            ),
+            (
+                REPO_ROOT / "import" / "skills" / "optimus-import" / "SKILL.md",
+                "### Step 1.6",
+                None,  # special: ends at --- or Phase 2
+            ),
+        ]
+        for path, start_marker, end_marker in slices:
+            body = path.read_text().split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            start = body.find(start_marker)
+            if end_marker is None:
+                end_candidates = [
+                    body.find("\n---\n", start + 1),
+                    body.find("## Phase 2", start + 1),
+                ]
+                end_candidates = [i for i in end_candidates if i > 0]
+                end = min(end_candidates) if end_candidates else -1
+            else:
+                end = body.find(end_marker, start + 1)
+            section = body[start:end] if start >= 0 and end > start else ""
+            for needle in ("Lightweight", "Full", "Estimate"):
+                assert needle in section, (
+                    f"{path.parent.parent.name} {start_marker} must mention "
+                    f"'{needle}' as part of the Ring-track Estimate default rule"
+                )
+
+    def test_state_records_ring_track(self):
+        """Each of the 3 SKILLs must reference both `ring_track` AND
+        `Protocol: State Management` within the relevant slice."""
+        slices = [
+            (
+                REPO_ROOT / "plan" / "skills" / "optimus-plan" / "SKILL.md",
+                "### Step 1.0.4.5",
+                "### Step 1.0.5",
+            ),
+            (
+                REPO_ROOT / "tasks" / "skills" / "optimus-tasks" / "SKILL.md",
+                "### Step 2.3.1",
+                "### Step 2.4",
+            ),
+            (
+                REPO_ROOT / "import" / "skills" / "optimus-import" / "SKILL.md",
+                "### Step 1.6",
+                None,
+            ),
+        ]
+        for path, start_marker, end_marker in slices:
+            body = path.read_text().split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+            start = body.find(start_marker)
+            if end_marker is None:
+                end_candidates = [
+                    body.find("\n---\n", start + 1),
+                    body.find("## Phase 2", start + 1),
+                ]
+                end_candidates = [i for i in end_candidates if i > 0]
+                end = min(end_candidates) if end_candidates else -1
+            else:
+                end = body.find(end_marker, start + 1)
+            section = body[start:end] if start >= 0 and end > start else ""
+            assert "ring_track" in section, (
+                f"{path.parent.parent.name} {start_marker} must reference 'ring_track' "
+                "(the state.json field for the chosen Ring track)"
+            )
+            assert "Protocol: State Management" in section, (
+                f"{path.parent.parent.name} {start_marker} must reference "
+                "'AGENTS.md Protocol: State Management' for the ring_track write"
+            )
+
+    def test_agents_md_documents_ring_track(self):
+        """AGENTS.md Protocol: State Management section must document `ring_track`
+        and show it in the example JSON."""
+        agents_md = AGENTS_MD.read_text()
+        start = agents_md.find("### Protocol: State Management")
+        assert start > 0, "Protocol: State Management section missing"
+        end = agents_md.find("\n### ", start + 1)
+        section = agents_md[start:end if end > 0 else len(agents_md)]
+        assert "ring_track" in section, (
+            "AGENTS.md Protocol: State Management must document the ring_track field"
+        )
+        # The example JSON must include the field too — assert both the key
+        # and a representative value form (a JSON line like `"ring_track": "feature"`).
+        assert '"ring_track":' in section, (
+            "AGENTS.md Protocol: State Management example JSON must show ring_track"
+        )
+
 
 class TestWorktreeLocationConvention:
     """F-worktrees: All worktree-creation sites use ${MAIN_WORKTREE}/.worktrees/<branch>

--- a/tasks/skills/optimus-tasks/SKILL.md
+++ b/tasks/skills/optimus-tasks/SKILL.md
@@ -305,15 +305,60 @@ Options:
 
 **If "Generate via Ring":**
 
-1. Verify `ring:pre-dev-feature` is available. If unavailable → warn and fall back to "Link existing spec" automatically.
-2. Invoke `ring:pre-dev-feature` via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
-3. **If Ring fails or returns no spec path:**
+1. **Choose the Ring track.** Read the task's `Estimate` column (the value the user just provided for this new task) and apply the auto-suggestion rule below to pick the recommended default. Ask via `AskUser`:
+
+   ```
+   [topic] (1/1) Which Ring track for T-XXX? (Estimate: <estimate>)
+   ```
+
+   Options (mark the auto-suggested one with " (recommended)"):
+   - **Lightweight** (`ring:pre-dev-feature`) — 4 gates, for tasks <2 days
+   - **Full** (`ring:pre-dev-full`) — 9 gates, for tasks ≥2 days or multi-component features
+
+   Save the user's choice as `RING_TRACK` ∈ {`feature`, `full`}. The selected skill name is `ring:pre-dev-feature` (when `feature`) or `ring:pre-dev-full` (when `full`).
+
+   **Auto-suggestion rule** (suggest the matching option as "(recommended)"; the user can always override):
+
+   | Estimate value | Suggested default |
+   |----------------|-------------------|
+   | `S`, `M` | Lightweight |
+   | `L`, `XL` | Full |
+   | Hour-based (e.g. `2h`, `8h`) | Lightweight |
+   | `1d` | Lightweight |
+   | Multi-day (`2d`, `3d`, `1w`, etc.) | Full |
+   | `-` or unknown | Lightweight |
+
+2. Verify the chosen Ring skill (`ring:pre-dev-feature` OR `ring:pre-dev-full`) is available. If unavailable → fall back to the OTHER track if it is available; if neither is available → warn and fall back to "Link existing spec" automatically.
+3. Invoke the chosen Ring skill via the `Skill` tool. The Skill tool has no argument channel — state the task title and tipo in conversation context immediately before the invocation (e.g., "Generating spec for T-XXX: <title> (Tipo: <tipo>)"). Ring will read these from context.
+4. **If Ring fails or returns no spec path:**
    - Warn the user: "Ring failed to generate the spec: <error>."
    - Re-prompt with `Link existing spec` / `Defer`. Do NOT silently fall through.
-4. **If Ring succeeds:**
+5. **If Ring succeeds:**
    - Ring generates the spec file in `<TASKS_DIR>/tasks/`.
    - Capture the generated spec file path (relative to `TASKS_DIR`).
    - Store as the `TaskSpec` value for this task.
+6. **Record the chosen Ring track in state.json** — see AGENTS.md Protocol: State Management. If `.optimus/` does not yet exist, see AGENTS.md Protocol: Initialize .optimus Directory first. The snippet below performs an idempotent merge into the task's existing record (preserving any `status`, `branch`, `updated_at` fields):
+
+   ```bash
+   # Record the chosen Ring track (idempotent merge into existing record)
+   if [ ! -f "$STATE_FILE" ]; then echo '{}' > "$STATE_FILE"; fi
+   UPDATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+   if jq --arg id "$TASK_ID" --arg track "$RING_TRACK" --arg ts "$UPDATED_AT" \
+     '.[$id] = ((.[$id] // {}) + {ring_track: $track, ring_track_recorded_at: $ts})' \
+     "$STATE_FILE" > "${STATE_FILE}.tmp"; then
+     if jq empty "${STATE_FILE}.tmp" 2>/dev/null; then
+       mv "${STATE_FILE}.tmp" "$STATE_FILE"
+     else
+       rm -f "${STATE_FILE}.tmp"
+       echo "ERROR: jq produced invalid JSON — state.json unchanged" >&2
+       exit 1
+     fi
+   else
+     rm -f "${STATE_FILE}.tmp"
+     echo "ERROR: jq failed to update state.json" >&2
+     exit 1
+   fi
+   ```
 
 **If "Link existing spec":**
 


### PR DESCRIPTION
## Summary

Closes #53.

`/optimus:plan`, `/optimus:tasks`, and `/optimus:import` previously hard-coded `ring:pre-dev-feature` when the user picked "Generate via Ring". This PR adds a sub-prompt asking the user to choose the Ring track:

- **Lightweight** (`ring:pre-dev-feature`) — 4 gates, for tasks <2 days
- **Full** (`ring:pre-dev-full`) — 9 gates, for tasks ≥2 days or multi-component features

The default is auto-suggested from the task's `Estimate` column (S/M/hour-based/`1d` → Lightweight, L/XL/multi-day → Full) and is always overridable. When the chosen Ring skill is unavailable, fall back to the other track; if neither is available, fall back to "Link existing spec".

The chosen track is recorded in `.optimus/state.json` under `<TASK_ID>.ring_track` (idempotent jq merge that preserves `status`, `branch`, `updated_at`). `AGENTS.md Protocol: State Management` documents the new field with an example record.

Applied symmetrically to:
- `plan/skills/optimus-plan/SKILL.md` Step 1.0.4.5
- `tasks/skills/optimus-tasks/SKILL.md` Step 2.3.1
- `import/skills/optimus-import/SKILL.md` Step 1.6 (both "Generate all via Ring" and "Generate selectively → Generate via Ring")

## Acceptance criteria (from #53)

- [x] All three skills offer the lightweight/full sub-prompt after 'Generate via Ring'.
- [x] Estimate-column-based default is suggested but overridable.
- [x] `TestSpecSelfHeal` grows tests for both tracks (6 new tests).
- [x] Decision recorded in `.optimus/state.json` (`<TASK_ID>.ring_track`).

## Test plan

- [x] `make test` — 360 passed
- [x] `make lint` — clean
- [x] `make check-inline` — clean (inlined-protocol blocks regenerated for the three command mirrors)
- [x] New tests added to `class TestSpecSelfHeal`:
  - `test_plan_offers_track_selection`
  - `test_tasks_offers_track_selection`
  - `test_import_offers_track_selection`
  - `test_track_selection_estimate_table`
  - `test_state_records_ring_track`
  - `test_agents_md_documents_ring_track`
- [x] Existing `test_build_review_dont_self_heal` still passes — no Ring references leaked into build/review.