### PR TITLE
fix(skills): skip confirmation prompt when only 1 finding to review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3062,14 +3062,18 @@ All cycle review skills follow this pattern:
    `"(X/N)"` sequence. The user makes ONE decision for the entire group.
 4. Announce total findings count: `"### Total findings to review: N"` (where N reflects
    grouped entries — a group of 5 same-nature findings counts as 1)
-5. Present overview table with severity counts
-6. **Deep research BEFORE presenting each finding** (see research checklist below)
-7. Walk through findings ONE AT A TIME with `"(X/N)"` progress prefix in the header, ordered by severity
+5. **When N==1, skip any confirmation/gating prompt.** Present the single finding immediately
+   with header `(1/1) ...`. Do NOT ask "Review 1 finding?", "Proceed?", "Ready?" or similar —
+   there is no batching/scoping decision to make with a single finding. The user invoked the
+   review skill; presenting the only finding *is* the review.
+6. Present overview table with severity counts
+7. **Deep research BEFORE presenting each finding** (see research checklist below)
+8. Walk through findings ONE AT A TIME with `"(X/N)"` progress prefix in the header, ordered by severity
    (CRITICAL first, then HIGH, MEDIUM, LOW). **ALL findings MUST be presented regardless of
    severity** — the agent NEVER skips, filters, or auto-resolves any finding. The decision to
    fix or skip is ALWAYS the user's. For grouped entries, list all affected files/locations
    within the single presentation.
-8. For each finding: present research-backed analysis + options, collect decision via AskUser.
+9. For each finding: present research-backed analysis + options, collect decision via AskUser.
    **Every AskUser for a finding decision MUST include these options:**
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
@@ -3099,7 +3103,7 @@ All cycle review skills follow this pattern:
 
    This scope is enforced by `TestStructuredAskUserScope` in `scripts/test_skill_consistency.py`.
 
-9. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
+10. **HARD BLOCK — IMMEDIATE RESPONSE RULE — If the user selects "Tell me more" OR responds
    with free text (a question, disagreement, or request for clarification):**
    **STOP IMMEDIATELY.** Do NOT continue to the next finding. Do NOT batch the response.
    Research the user's concern RIGHT NOW using `WebSearch`, codebase analysis, or both.
@@ -3113,9 +3117,9 @@ All cycle review skills follow this pattern:
    - "Let me continue with the next finding and come back to this" — NO
    - "I'll research this after the findings loop" — NO
    - "This is noted, moving to the next finding" — NO
-10. After ALL N decisions collected: apply ALL approved fixes (see below)
-11. Run verification (see Verification Timing below)
-12. Present final summary
+11. After ALL N decisions collected: apply ALL approved fixes (see below)
+12. Run verification (see Verification Timing below)
+13. Present final summary
 
 ### Pressure Resistance Patterns
 

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -173,6 +173,8 @@ Categorize ALL findings (regardless of origin) by severity:
 
 **BEFORE presenting the first finding:** Announce total findings count prominently: `"### Total findings to review: N"`
 
+**If N==1, skip any confirmation prompt** — present the single finding directly with header `(1/1) ...`. The user already chose to review by invoking the skill.
+
 Process ONE finding at a time, in severity order (CRITICAL first, LOW last). Collect ALL decisions first — do NOT apply any fix during this phase.
 
 For EACH finding, present with `"(X/N)"` progress prefix in the header, including the origin tag:

--- a/commands/coderabbit-review.md
+++ b/commands/coderabbit-review.md
@@ -116,6 +116,8 @@ Categorize ALL findings (regardless of origin) by severity:
 
 **BEFORE presenting the first finding:** Announce total findings count prominently: `"### Total findings to review: N"`
 
+**If N==1, skip any confirmation prompt** — present the single finding directly with header `(1/1) ...`. The user already chose to review by invoking the skill.
+
 Process ONE finding at a time, in severity order (CRITICAL first, LOW last). Collect ALL decisions first — do NOT apply any fix during this phase.
 
 For EACH finding, present with `"(X/N)"` progress prefix in the header, including the origin tag:

--- a/commands/deep-doc-review.md
+++ b/commands/deep-doc-review.md
@@ -160,6 +160,7 @@ Present the full findings table for a bird's-eye view:
 **BEFORE presenting the first finding, you MUST:**
 1. Count the TOTAL number of findings (N)
 2. Display the total prominently: `"### Total findings to review: N"`
+3. **Skip confirmation when N==1:** Present the single finding directly with header `(1/1) ...`. Do NOT ask "Review 1 finding?" or similar — the user already chose to review.
 
 **For EVERY finding presented, you MUST:**
 1. Include `"(X/N)"` progress prefix in the header

--- a/commands/deep-review.md
+++ b/commands/deep-review.md
@@ -210,6 +210,7 @@ Findings are presented ONE AT A TIME, decisions collected for ALL, then fixes ap
 **BEFORE presenting the first finding, you MUST:**
 1. Count the TOTAL number of findings (N)
 2. Display the total prominently: `"### Total findings to review: N"`
+3. **Skip confirmation when N==1:** Present the single finding directly with header `(1/1) ...`. Do NOT ask "Review 1 finding?" or similar — the user already chose to review.
 
 **For EVERY finding presented, you MUST:**
 1. Include `"(X/N)"` progress prefix in the header

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -702,8 +702,9 @@ Merge agent findings with the findings from Steps 2.1-2.3. Deduplicate and sort 
 ### Step 3.1: Present Summary, then Walk Through Each Finding
 
 1. **Announce total findings count:** Display `"### Total findings to review: N"` prominently before presenting the first finding
-2. **Present the summary report** (tables from Output Format) for bird's-eye view
-3. **Then present findings ONE AT A TIME** in priority order: contradictions > missing specs > test gaps > observability > DoD > ambiguities
+2. **Skip confirmation when N==1:** Present the single finding directly with header `(1/1) ...`. Do NOT ask "Review 1 finding?" or similar — the user already chose to review.
+3. **Present the summary report** (tables from Output Format) for bird's-eye view
+4. **Then present findings ONE AT A TIME** in priority order: contradictions > missing specs > test gaps > observability > DoD > ambiguities
 
 **For EACH finding**, present with `"(X/N)"` progress prefix in the header:
 

--- a/commands/pr-check.md
+++ b/commands/pr-check.md
@@ -884,7 +884,8 @@ Findings are presented ONE AT A TIME, decisions collected for ALL, then fixes ap
 **BEFORE presenting the first finding, you MUST:**
 1. Count the TOTAL number of findings (N) — sum of genuine findings, validated comments, contested comments, and new agent findings
 2. Display the total prominently: `"### Total findings to review: N"`
-3. This total MUST be visible to the user BEFORE any finding is presented
+3. **Skip confirmation when N==1:** Present the single finding directly with header `(1/1) ...`. Do NOT ask "Review 1 finding?" or similar — the user already chose to review.
+4. This total MUST be visible to the user BEFORE any finding is presented
 
 **For EVERY finding presented, you MUST:**
 1. Include `"(X/N)"` progress prefix in the header — this is NOT optional
@@ -1692,6 +1693,7 @@ Render the standard summary below.
 - Every finding must include source attribution
 - Only review files changed in the PR
 - ALWAYS announce total findings count (N) before presenting the first finding: `"### Total findings to review: N"`
+- **When N==1, skip any gating prompt** — present the single finding directly with header `(1/1) ...`. Do not ask "Review 1 finding?" or similar.
 - Present findings ONE AT A TIME in severity order, ALWAYS showing "(X/N)" progress prefix in EVERY finding header
 - Collect ALL decisions first (Phase 6), then apply ALL approved fixes at once (Phase 8)
 - Coverage verification runs ONLY after all fixes are applied; the convergence loop is opt-in (gated)

--- a/commands/review.md
+++ b/commands/review.md
@@ -465,6 +465,8 @@ Security verdict: PASS / FAIL
 
 **BEFORE presenting the first finding:** Announce total findings count prominently: `"### Total findings to review: N"`
 
+**If N==1, skip any confirmation prompt** — present the single finding directly with header `(1/1) ...`. The user already chose to review by invoking the skill.
+
 Process ONE finding at a time, starting from highest severity. Present ALL findings sequentially, collecting the user's decision for each. Do NOT apply any fix during this phase — only collect decisions.
 
 For EACH finding, present with `"(X/N)"` progress prefix in the header:

--- a/deep-doc-review/skills/optimus-deep-doc-review/SKILL.md
+++ b/deep-doc-review/skills/optimus-deep-doc-review/SKILL.md
@@ -208,6 +208,7 @@ Present the full findings table for a bird's-eye view:
 **BEFORE presenting the first finding, you MUST:**
 1. Count the TOTAL number of findings (N)
 2. Display the total prominently: `"### Total findings to review: N"`
+3. **Skip confirmation when N==1:** Present the single finding directly with header `(1/1) ...`. Do NOT ask "Review 1 finding?" or similar — the user already chose to review.
 
 **For EVERY finding presented, you MUST:**
 1. Include `"(X/N)"` progress prefix in the header

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -261,6 +261,7 @@ Findings are presented ONE AT A TIME, decisions collected for ALL, then fixes ap
 **BEFORE presenting the first finding, you MUST:**
 1. Count the TOTAL number of findings (N)
 2. Display the total prominently: `"### Total findings to review: N"`
+3. **Skip confirmation when N==1:** Present the single finding directly with header `(1/1) ...`. Do NOT ask "Review 1 finding?" or similar — the user already chose to review.
 
 **For EVERY finding presented, you MUST:**
 1. Include `"(X/N)"` progress prefix in the header

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -763,8 +763,9 @@ Merge agent findings with the findings from Steps 2.1-2.3. Deduplicate and sort 
 ### Step 3.1: Present Summary, then Walk Through Each Finding
 
 1. **Announce total findings count:** Display `"### Total findings to review: N"` prominently before presenting the first finding
-2. **Present the summary report** (tables from Output Format) for bird's-eye view
-3. **Then present findings ONE AT A TIME** in priority order: contradictions > missing specs > test gaps > observability > DoD > ambiguities
+2. **Skip confirmation when N==1:** Present the single finding directly with header `(1/1) ...`. Do NOT ask "Review 1 finding?" or similar — the user already chose to review.
+3. **Present the summary report** (tables from Output Format) for bird's-eye view
+4. **Then present findings ONE AT A TIME** in priority order: contradictions > missing specs > test gaps > observability > DoD > ambiguities
 
 **For EACH finding**, present with `"(X/N)"` progress prefix in the header:
 

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -956,7 +956,8 @@ Findings are presented ONE AT A TIME, decisions collected for ALL, then fixes ap
 **BEFORE presenting the first finding, you MUST:**
 1. Count the TOTAL number of findings (N) — sum of genuine findings, validated comments, contested comments, and new agent findings
 2. Display the total prominently: `"### Total findings to review: N"`
-3. This total MUST be visible to the user BEFORE any finding is presented
+3. **Skip confirmation when N==1:** Present the single finding directly with header `(1/1) ...`. Do NOT ask "Review 1 finding?" or similar — the user already chose to review.
+4. This total MUST be visible to the user BEFORE any finding is presented
 
 **For EVERY finding presented, you MUST:**
 1. Include `"(X/N)"` progress prefix in the header — this is NOT optional
@@ -1764,6 +1765,7 @@ Render the standard summary below.
 - Every finding must include source attribution
 - Only review files changed in the PR
 - ALWAYS announce total findings count (N) before presenting the first finding: `"### Total findings to review: N"`
+- **When N==1, skip any gating prompt** — present the single finding directly with header `(1/1) ...`. Do not ask "Review 1 finding?" or similar.
 - Present findings ONE AT A TIME in severity order, ALWAYS showing "(X/N)" progress prefix in EVERY finding header
 - Collect ALL decisions first (Phase 6), then apply ALL approved fixes at once (Phase 8)
 - Coverage verification runs ONLY after all fixes are applied; the convergence loop is opt-in (gated)

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -530,6 +530,8 @@ Security verdict: PASS / FAIL
 
 **BEFORE presenting the first finding:** Announce total findings count prominently: `"### Total findings to review: N"`
 
+**If N==1, skip any confirmation prompt** — present the single finding directly with header `(1/1) ...`. The user already chose to review by invoking the skill.
+
 Process ONE finding at a time, starting from highest severity. Present ALL findings sequentially, collecting the user's decision for each. Do NOT apply any fix during this phase — only collect decisions.
 
 For EACH finding, present with `"(X/N)"` progress prefix in the header:


### PR DESCRIPTION
## Summary

When review skills find exactly 1 finding, they used to emit a "Review 1 finding?" / "Proceed?" gating prompt before presenting it. With N==1 there is no batching or scoping decision to make, so the prompt was pure friction. After this change, the skill goes straight to `(1/1) — ...`.

The prompt was emergent LLM behavior (politeness/caution) rather than an explicit instruction in any SKILL.md — the fix is therefore an **explicit anti-pattern instruction** that tells the LLM not to introduce that ask.

## Skills affected (6)

| Skill | Phase | Sites |
|---|---|---|
| `/optimus:prc` (pr-check) | Phase 6 + Critical Rules checklist | 2 |
| `/optimus:dr` (deep-review) | Phase 5 | 1 |
| `/optimus:cr` (coderabbit-review) | Phase 3 | 1 |
| `/optimus:ddr` (deep-doc-review) | Phase 5 | 1 |
| `/optimus:rv` (review) | Phase 6 | 1 |
| `/optimus:sp` (plan) | Phase 3 | 1 |

## Two-layer placement (defense in depth)

1. **`AGENTS.md`** — canonical bullet 5 in the "Finding Presentation" pattern (longer text listing example questions to NOT ask). Items 5-12 renumbered to 6-13.
2. **Each SKILL.md and `commands/*.md` mirror** — inline rule right after the `"### Total findings to review: N"` announcement.

The inline duplication is intentional: skills do not always load `AGENTS.md`, so the rule needs to live where the LLM emits the announcement.

## Files changed (13)

- `AGENTS.md`
- `pr-check/skills/optimus-pr-check/SKILL.md` + `commands/pr-check.md`
- `deep-review/skills/optimus-deep-review/SKILL.md` + `commands/deep-review.md`
- `coderabbit-review/skills/optimus-coderabbit-review/SKILL.md` + `commands/coderabbit-review.md`
- `deep-doc-review/skills/optimus-deep-doc-review/SKILL.md` + `commands/deep-doc-review.md`
- `review/skills/optimus-review/SKILL.md` + `commands/review.md`
- `plan/skills/optimus-plan/SKILL.md` + `commands/plan.md`

## Test plan

- [x] `python3 scripts/test_skill_consistency.py` passes (exit 0)
- [x] Verified `AGENTS.md` renumbering does not break cross-references (`"item 13"` at line 632 references a different list)
- [ ] Smoke test: run `/optimus:prc` against a PR with exactly 1 unresolved comment and confirm it presents `(1/1)` without asking for confirmation
- [ ] Regression: run `/optimus:prc` against a PR with N>=2 findings and confirm normal one-by-one flow still works