### PR TITLE
docs(tasksdir): document tasksDir convention with three layouts (#54)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,108 @@ the team) — but the repo that versions it depends on `tasksDir`: if `tasksDir`
 the project repo, it is committed alongside the code; if `tasksDir` is in a separate
 repo, it is committed there.
 
+### tasksDir Configuration
+
+`tasksDir` is the root path under which Ring pre-dev artifacts (`optimus-tasks.md`,
+`tasks/`, `subtasks/`) live. It controls **where** the planning tree is found and,
+indirectly, **which git repo** versions it. All stage agents resolve paths via
+`<tasksDir>/<TaskSpec>` — see Protocol: Resolve Tasks Git Scope.
+
+**Three valid layouts** are supported. The same `tasks_git` helper backs all three;
+skills do not need to special-case them.
+
+#### Layout 1 — Same-repo, default path (most common)
+
+`tasksDir` is unset (or set to `docs/pre-dev`). Ring artifacts live inside the project
+repo at `docs/pre-dev/`, are versioned together with the code, and propagate across
+linked worktrees automatically. No `.optimus/config.json` needed.
+
+```
+<project-repo>/
+├── .optimus/                # gitignored — operational state, per-user
+├── docs/
+│   └── pre-dev/             # ← tasksDir (default)
+│       ├── optimus-tasks.md
+│       ├── tasks/
+│       └── subtasks/
+├── src/
+└── README.md
+```
+
+#### Layout 2 — Same-repo, project-internal alias
+
+Use this when a project already has a folder for internal documentation (e.g.
+`internal-docs/`, `planning/`, `_internal/`) and you want Ring artifacts to live
+alongside it instead of under `docs/pre-dev/`. Same versioning semantics as Layout 1
+— the artifacts ship with the project repo. Set `tasksDir` in `.optimus/config.json`:
+
+```json
+{
+  "tasksDir": "internal-docs"
+}
+```
+
+```
+<project-repo>/
+├── .optimus/                # gitignored
+│   └── config.json          # ← {"tasksDir": "internal-docs"}
+├── internal-docs/           # ← tasksDir (project-internal)
+│   ├── optimus-tasks.md
+│   ├── tasks/
+│   ├── subtasks/
+│   └── architecture.md      # other internal docs co-located
+├── src/
+└── README.md
+```
+
+The folder name is unconstrained (any path inside the project repo works). The
+project-internal alias is a pure naming choice: the helper detects it as `same-repo`
+(scope determined by `git rev-parse --show-toplevel` matching the project repo) and
+commits via the project repo's git history.
+
+#### Layout 3 — Cross-repo (separate tasks repo)
+
+Use this when several project repos share a single tasks repo (multi-project portfolio,
+auditing, or compliance separation). `tasksDir` points to a path that resolves into a
+**different** git repo than the project repo. The helper detects `separate-repo` scope
+and runs git commands against the tasks repo via `git -C "$TASKS_DIR"`.
+
+```json
+{
+  "tasksDir": "../tasks-repo/project-alfa"
+}
+```
+
+```
+<workspace>/
+├── project-repo/            # current repo (project code)
+│   ├── .optimus/
+│   │   └── config.json      # ← {"tasksDir": "../tasks-repo/project-alfa"}
+│   ├── src/
+│   └── README.md
+└── tasks-repo/              # separate git repo (Ring artifacts)
+    └── project-alfa/        # ← tasksDir (relative path resolves here)
+        ├── optimus-tasks.md
+        ├── tasks/
+        └── subtasks/
+```
+
+Cross-repo mode requires `python3` (used to compute repo-relative paths during
+`git show origin/<default>:...` operations). The tasks repo's default branch is
+auto-detected; reject any `tasksDir` value beginning with `-` (git option injection).
+
+#### Picking a layout
+
+| Layout | When to use |
+|--------|-------------|
+| 1 — Default same-repo | Default. Simplest. Use unless you have a specific reason. |
+| 2 — Project-internal alias | Project already has a non-`docs/pre-dev/` convention for internal docs. |
+| 3 — Cross-repo | Multiple project repos must share one tasks repo, OR auditing/compliance requires separating task history from code history. |
+
+Renaming the key from `tasksDir` to something domain-specific (e.g. `internalDocsDir`)
+is **out of scope** — the value already accepts any folder name; the key is the same
+across all three layouts to keep tooling simple.
+
 ### Protocol: Resolve Main Worktree Path
 
 <!-- inline-mode: omit -->

--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ ALL marked protocols), `--no-omit` (treat omit as summarize for that run).
 
 Future improvements are tracked in `docs/future-improvements.md`.
 
+## Where tasks live (`tasksDir`)
+
+Ring pre-dev artifacts (`optimus-tasks.md`, `tasks/`, `subtasks/`) live under the path
+configured as `tasksDir` in `.optimus/config.json`. Three layouts are supported:
+
+| Layout | `tasksDir` value | Result |
+|--------|------------------|--------|
+| Default | unset | `<project-repo>/docs/pre-dev/` (same repo as code) |
+| Project-internal alias | `"internal-docs"` (or any folder) | `<project-repo>/internal-docs/` (same repo, custom folder) |
+| Cross-repo | `"../tasks-repo/project-alfa"` | A separate git repo |
+
+Example — co-locate Ring artifacts with other internal docs at `internal-docs/`:
+
+```json
+// .optimus/config.json
+{
+  "tasksDir": "internal-docs"
+}
+```
+
+For full details, layout trees, and the cross-repo helper contract, see
+[AGENTS.md — tasksDir Configuration](AGENTS.md#tasksdir-configuration).
+
 ## Worktree layout
 
 Optimus creates linked git worktrees under `<repo>/.worktrees/<branch-name>/` (gitignored). For project setup, configure your editor to exclude `.worktrees/` from search and indexing:

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -730,7 +730,7 @@ Present 2-3 options using the format from AGENTS.md "Common Patterns > Finding O
    **AskUser `[topic]` format:** Format: `(X/N) F#-Category`.
    Example: `[topic] (8/12) F8-DeadCode`.
 
-4. Use `AskUser` tool. **BLOCKING**: Do NOT advance to the next finding until the user decides.
+5. Use `AskUser` tool. **BLOCKING**: Do NOT advance to the next finding until the user decides.
    **Every AskUser MUST include these options:**
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
@@ -746,7 +746,7 @@ Present 2-3 options using the format from AGENTS.md "Common Patterns > Finding O
    [option] Tell me more
    ```
 
-5. **HARD BLOCK — IMMEDIATE RESPONSE RULE:** If the user selects "Tell me more" or responds
+6. **HARD BLOCK — IMMEDIATE RESPONSE RULE:** If the user selects "Tell me more" or responds
    with free text: **STOP IMMEDIATELY.** Do NOT continue to the next finding. Research and
    answer RIGHT NOW. Only after the user is satisfied, re-present the SAME finding's options.
    **NEVER defer to the end of the findings loop.**
@@ -756,7 +756,7 @@ Present 2-3 options using the format from AGENTS.md "Common Patterns > Finding O
    - "Let me continue with the next finding and come back to this" — NO
    - "I'll research this after the findings loop" — NO
    - "This is noted, moving to the next finding" — NO
-6. **Track all decisions** internally. Do NOT apply any fix yet — all fixes are applied in Phase 4.
+7. **Track all decisions** internally. Do NOT apply any fix yet — all fixes are applied in Phase 4.
 
 ## Phase 4: Apply Approved Corrections
 

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -791,7 +791,7 @@ Present 2-3 options using the format from AGENTS.md "Common Patterns > Finding O
    **AskUser `[topic]` format:** Format: `(X/N) F#-Category`.
    Example: `[topic] (8/12) F8-DeadCode`.
 
-4. Use `AskUser` tool. **BLOCKING**: Do NOT advance to the next finding until the user decides.
+5. Use `AskUser` tool. **BLOCKING**: Do NOT advance to the next finding until the user decides.
    **Every AskUser MUST include these options:**
    - One option per proposed solution (Option A, Option B, Option C, etc.)
    - Skip — no action
@@ -807,7 +807,7 @@ Present 2-3 options using the format from AGENTS.md "Common Patterns > Finding O
    [option] Tell me more
    ```
 
-5. **HARD BLOCK — IMMEDIATE RESPONSE RULE:** If the user selects "Tell me more" or responds
+6. **HARD BLOCK — IMMEDIATE RESPONSE RULE:** If the user selects "Tell me more" or responds
    with free text: **STOP IMMEDIATELY.** Do NOT continue to the next finding. Research and
    answer RIGHT NOW. Only after the user is satisfied, re-present the SAME finding's options.
    **NEVER defer to the end of the findings loop.**
@@ -817,7 +817,7 @@ Present 2-3 options using the format from AGENTS.md "Common Patterns > Finding O
    - "Let me continue with the next finding and come back to this" — NO
    - "I'll research this after the findings loop" — NO
    - "This is noted, moving to the next finding" — NO
-6. **Track all decisions** internally. Do NOT apply any fix yet — all fixes are applied in Phase 4.
+7. **Track all decisions** internally. Do NOT apply any fix yet — all fixes are applied in Phase 4.
 
 ## Phase 4: Apply Approved Corrections
 

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3412,6 +3412,67 @@ class TestSpecSelfHeal:
         )
 
 
+class TestTasksDirConvention:
+    """Issue #54: tasksDir convention is documented in AGENTS.md with three
+    layouts (default same-repo, project-internal alias, cross-repo) and
+    cross-referenced from README.md."""
+
+    def test_agents_md_has_tasksdir_section(self):
+        """AGENTS.md must declare a 'tasksDir Configuration' H3 section."""
+        agents_md = AGENTS_MD.read_text()
+        assert "### tasksDir Configuration" in agents_md, (
+            "AGENTS.md must contain a '### tasksDir Configuration' section "
+            "(issue #54 acceptance criterion)"
+        )
+
+    def test_agents_md_documents_three_layouts(self):
+        """The tasksDir Configuration section must document all three layouts:
+        default same-repo, project-internal alias, and cross-repo."""
+        agents_md = AGENTS_MD.read_text()
+        start = agents_md.find("### tasksDir Configuration")
+        end = agents_md.find("\n### ", start + 1)
+        section = agents_md[start:end if end > 0 else len(agents_md)]
+        # All three layouts must be named explicitly.
+        assert "Same-repo, default path" in section, (
+            "tasksDir section must document Layout 1 (same-repo, default path)"
+        )
+        assert "Same-repo, project-internal alias" in section, (
+            "tasksDir section must document Layout 2 (project-internal alias)"
+        )
+        assert "Cross-repo" in section, (
+            "tasksDir section must document Layout 3 (cross-repo / separate tasks repo)"
+        )
+
+    def test_agents_md_shows_config_snippet_and_tree(self):
+        """The section must include at least one config.json snippet AND at
+        least one directory-tree example so users can copy-paste the layout."""
+        agents_md = AGENTS_MD.read_text()
+        start = agents_md.find("### tasksDir Configuration")
+        end = agents_md.find("\n### ", start + 1)
+        section = agents_md[start:end if end > 0 else len(agents_md)]
+        # config.json snippet (JSON code block referencing tasksDir).
+        assert '"tasksDir":' in section, (
+            "tasksDir section must include a config.json snippet showing the key"
+        )
+        # Directory-tree example uses tree-drawing characters.
+        assert "├──" in section, (
+            "tasksDir section must include at least one directory-tree example"
+        )
+
+    def test_readme_references_tasksdir(self):
+        """README.md must mention tasksDir (acceptance criterion 2: at least
+        one README example referencing it)."""
+        readme = (REPO_ROOT / "README.md").read_text()
+        assert "tasksDir" in readme, (
+            "README.md must mention tasksDir (issue #54 acceptance criterion 2)"
+        )
+        # Must link to the AGENTS.md section so readers can find the full spec.
+        # Anchor casing varies across renderers; compare lowercased on both sides.
+        assert "agents.md#tasksdir-configuration" in readme.lower(), (
+            "README.md must link to AGENTS.md tasksDir Configuration section"
+        )
+
+
 class TestWorktreeLocationConvention:
     """F-worktrees: All worktree-creation sites use ${MAIN_WORKTREE}/.worktrees/<branch>
     pattern; .gitignore auto-inject uses post-F1 ${MAIN_WORKTREE}/.gitignore contract."""


### PR DESCRIPTION
## Summary

Closes #54.

Item 3/3 of the original closed issue #22 ("one-command flow") asked for documentation of the `tasksDir` convention so projects know they can point Ring artifacts at a project-internal folder (e.g. `internal-docs/`) instead of accepting the `docs/pre-dev/` default. That convention was supported by the helper but never documented. This PR adds:

- **AGENTS.md** — new `### tasksDir Configuration` section documenting all three valid layouts (default same-repo, project-internal alias, cross-repo), each with a `.optimus/config.json` snippet and a directory tree. Includes a "picking a layout" decision table and notes that renaming the key is out of scope.
- **README.md** — new `## Where tasks live (`tasksDir`)` subsection summarizing the three layouts in a table with a copy-pasteable example, linking to the AGENTS.md anchor for the full spec.
- **Tests** — new `TestTasksDirConvention` class (4 tests) asserting the AGENTS.md section exists, all three layouts are named, both a config snippet and directory tree are present, and the README mentions/links to the section.

### Drive-by fix

PR #62 inserted item 2 ("Skip confirmation when N==1") into `plan/skills/optimus-plan/SKILL.md` Step 3.1 but did not renumber items 4-6 that follow the sub-headings. `TestPhaseNumberingNoGaps::test_step_numbering_within_phase_is_sequential` was failing on `main`. Fixed in `97d089e` so this PR can merge cleanly.

## Acceptance criteria (from #54)

- [x] AGENTS.md has a 'tasksDir Configuration' section with three layouts documented.
- [x] At least one README.md example referencing it.
- [x] Existing skills don't need changes — they already resolve `tasksDir` correctly via the `tasks_git` helper.

## Test plan

- [x] `make test` — 364 passed (including 4 new `TestTasksDirConvention` tests + the previously-failing `TestPhaseNumberingNoGaps` test now green).
- [x] `make lint` — clean.
- [x] `make check-inline` — clean.
- [x] `commands/plan.md` regenerated via `python3 scripts/sync-claude-commands.py` (Claude command mirror stays in sync with the SKILL.md numbering fix).