### PR TITLE
feat(worktrees): flatten .worktrees/ layout via / → - translation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1715,7 +1715,7 @@ Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Ter
 
 <!-- inline-mode: omit -->
 
-**Summary:** When an Optimus stage skill (build, review, done) is invoked from the default branch (main/master) instead of from the task's linked worktree, automatically detect the correct workspace and navigate there before any mutation. Resolution order: (1) state.json `branch` field for the task; (2) match against `git worktree list` by branch ref; (3) fallback path-segment match by anchored kebab task-ID (`-t-NNN-`); (4) recovery: if branch exists but worktree is missing, create at `${MAIN_WORKTREE}/.worktrees/<branch-name>` per Protocol: Worktree Location. HARD BLOCK on default branch — refuses to mutate from main/master regardless of resolution outcome. See full recipe + Default Branch Refusal cross-reference in AGENTS.md.
+**Summary:** When an Optimus stage skill (build, review, done) is invoked from the default branch (main/master) instead of from the task's linked worktree, automatically detect the correct workspace and navigate there before any mutation. Resolution order: (1) state.json `branch` field for the task; (2) match against `git worktree list` by branch ref; (3) fallback path-segment match by anchored kebab task-ID (`-t-NNN-`); (4) recovery: if branch exists but worktree is missing, create at `${MAIN_WORKTREE}/.worktrees/<flat-branch-name>` (branch with `/` → `-`) per Protocol: Worktree Location. HARD BLOCK on default branch — refuses to mutate from main/master regardless of resolution outcome. See full recipe + Default Branch Refusal cross-reference in AGENTS.md.
 
 **Referenced by:** stages 2-4
 
@@ -1764,8 +1764,8 @@ fi
    - **If N eligible tasks** → list all with worktree paths via `AskUser`:
      ```
      Multiple tasks available:
-       T-001 — User auth (Em Andamento) → <repo>/.worktrees/feat/t-001-user-auth/
-       T-002 — Login page (Em Andamento) → <repo>/.worktrees/feat/t-002-login-page/
+       T-001 — User auth (Em Andamento) → <repo>/.worktrees/feat-t-001-user-auth/
+       T-002 — Login page (Em Andamento) → <repo>/.worktrees/feat-t-002-login-page/
      Which task should I continue?
      ```
    - After task is identified, locate the worktree. Prefer the source-of-truth
@@ -1817,7 +1817,10 @@ fi
      case "<branch-name>" in
        *..*|/*) echo "ERROR: refusing unsafe branch name." >&2; exit 1 ;;
      esac
-     WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/<branch-name>"
+     # Flatten branch name: every `/` becomes `-` so the worktree dir is flat
+     # (e.g., feat/t-007-... → feat-t-007-...). See Protocol: Worktree Location.
+     FLAT_BRANCH="${BRANCH_NAME//\//\-}"
+     WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${FLAT_BRANCH}"
 
      if ! git worktree add "$WORKTREE_DIR" "<branch-name>"; then
        echo "ERROR: 'git worktree add $WORKTREE_DIR' failed (branch already checked out, dir collision, or filesystem error)." >&2
@@ -3077,7 +3080,7 @@ Skills reference this as: "Check active version guard — see AGENTS.md Protocol
 
 <!-- inline-mode: omit -->
 
-**Summary:** Linked worktrees created by plan / resume / Workspace Auto-Navigation / done-cleanup live at the canonical path `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by Initialize .optimus Directory + Session State protocols), project-rooted, resolved via Resolve Main Worktree Path so paths stay correct from any linked worktree. Branch names contain `/` (per Branch Name Derivation), creating intermediate `feat/`, `fix/` directories under `.worktrees/` automatically. Worktrees ALWAYS belong to the project repo, never the tasks repo (separate-repo `tasksDir` doesn't affect location). Recommend IDE exclusion (`.vscode/settings.json` `search.exclude`, IntelliJ Excluded). Backwards compat: legacy sibling paths still work via worktree metadata; no forced migration. See full convention + IDE config in AGENTS.md.
+**Summary:** Linked worktrees created by plan / resume / Workspace Auto-Navigation / done-cleanup live at the canonical path `${MAIN_WORKTREE}/.worktrees/<flat-branch-name>` — gitignored (auto-injected by Initialize .optimus Directory + Session State protocols), project-rooted, resolved via Resolve Main Worktree Path so paths stay correct from any linked worktree. Branch names contain `/` (per Branch Name Derivation); the worktree directory is created with a flat directory name with `/` replaced by `-` (e.g., `feat/t-007-...` → `feat-t-007-...`). Worktrees ALWAYS belong to the project repo, never the tasks repo (separate-repo `tasksDir` doesn't affect location). Recommend IDE exclusion (`.vscode/settings.json` `search.exclude`, IntelliJ Excluded). Backwards compat: legacy sibling paths and legacy nested-format worktrees still work via worktree metadata; no forced migration. See full convention + IDE config in AGENTS.md.
 
 **Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
 
@@ -3087,9 +3090,9 @@ Optimus creates linked git worktrees during the task lifecycle:
 - `/optimus-resume` creates a worktree on recovery if branch exists but worktree is missing (Step 3.3).
 - Protocol: Workspace Auto-Navigation (see Reusable Protocols) creates a worktree as a fallback when an Optimus skill is invoked from the default branch and the task's worktree is missing.
 
-**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path).
+**Canonical path:** `${MAIN_WORKTREE}/.worktrees/<flat-branch-name>` — gitignored (auto-injected by `Protocol: Initialize .optimus Directory` and `Protocol: Session State`), project-rooted, and resolved against the main worktree (path correct even when invoked from a linked worktree, per Protocol: Resolve Main Worktree Path). Where `<flat-branch-name>` = branch with each `/` replaced by `-` (POSIX bash: `${BRANCH_NAME//\//\-}`).
 
-**Note on branch names with `/`:** branch names contain `/` (see `Protocol: Branch Name Derivation`). Used as a directory under `.worktrees/`, the `/` creates intermediate subdirectories — `<repo>/.worktrees/feat/t-007-user-auth/`. `git worktree add` creates these automatically. `ls .worktrees/` shows the tipo-prefix dirs (`feat/`, `fix/`, `chore/`); `find .worktrees/ -mindepth 2 -maxdepth 2 -type d` lists each leaf.
+**Note on branch names with `/`:** Branch names contain `/` (see `Protocol: Branch Name Derivation`), but the worktree directory name is FLATTENED — every `/` is replaced by `-`. Example: branch `feat/t-007-user-auth` lands at `<repo>/.worktrees/feat-t-007-user-auth/`. The translation rule is a single bash parameter expansion: `${BRANCH_NAME//\//\-}`. Multi-slash branches translate every slash (`feat/sub/x` → `feat-sub-x`). The branch name itself is unchanged in `git`. List worktrees with `ls .worktrees/` (one entry per worktree, no nested dirs) or `find .worktrees/ -mindepth 1 -maxdepth 1 -type d`.
 
 **Why nested under the project repo:**
 
@@ -3109,9 +3112,10 @@ Optimus creates linked git worktrees during the task lifecycle:
 **Backwards compatibility:**
 
 - Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
+- Existing nested-format worktrees (`.worktrees/feat/t-001-user-auth/`) created by older optimus-plan runs continue to work — `git worktree list` is layout-agnostic. Optionally consolidate with `git worktree move .worktrees/feat/t-001-user-auth .worktrees/feat-t-001-user-auth`. No forced migration.
 - New worktrees from `/optimus-plan` and `resume`'s recovery land in `.worktrees/`.
 - No forced migration.
-- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<branch-name>` when convenient.
+- Users may relocate manually with `git worktree move <old-path> ${MAIN_WORKTREE}/.worktrees/<flat-branch-name>` (where `<flat-branch-name>` is the branch with `/` → `-`) when convenient.
 
 Skills reference this as: "see AGENTS.md Protocol: Worktree Location."
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ For full details, layout trees, and the cross-repo helper contract, see
 
 ## Worktree layout
 
-Optimus creates linked git worktrees under `<repo>/.worktrees/<branch-name>/` (gitignored). For project setup, configure your editor to exclude `.worktrees/` from search and indexing:
+Optimus creates linked git worktrees under `<repo>/.worktrees/<flat-branch-name>/` (gitignored), where `<flat-branch-name>` is the branch name with each `/` replaced by `-` (e.g., branch `feat/t-001-user-auth` → directory `.worktrees/feat-t-001-user-auth/`). Branch names themselves are unchanged in git. For project setup, configure your editor to exclude `.worktrees/` from search and indexing:
 
 - **VS Code** (`.vscode/settings.json`):
   ```json

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -124,8 +124,8 @@ tracks the working directory for each task and switches context between tasks.
 **Working directory tracking:**
 ```json
 {
-  "T-003": {"worktree": "<repo>/.worktrees/feat/t-003-user-auth", "branch": "feat/t-003-user-auth"},
-  "T-004": {"worktree": "<repo>/.worktrees/feat/t-004-login-page", "branch": "feat/t-004-login-page"}
+  "T-003": {"worktree": "<repo>/.worktrees/feat-t-003-user-auth", "branch": "feat/t-003-user-auth"},
+  "T-004": {"worktree": "<repo>/.worktrees/feat-t-004-login-page", "branch": "feat/t-004-login-page"}
 }
 ```
 
@@ -275,7 +275,7 @@ After all tasks are processed (or the user stops), restore the terminal session 
      - **Stop batch entirely** — pause everything
 - If the user stops the batch, write progress to `.optimus/sessions/session-batch.json`:
   ```json
-  {"tasks": ["T-003", "T-004", "T-005"], "completed": ["T-003"], "current": "T-004", "current_stage": 3, "worktrees": {"T-003": "<repo>/.worktrees/feat/t-003-user-auth", "T-004": "<repo>/.worktrees/feat/t-004-login-page"}}
+  {"tasks": ["T-003", "T-004", "T-005"], "completed": ["T-003"], "current": "T-004", "current_stage": 3, "worktrees": {"T-003": "<repo>/.worktrees/feat-t-003-user-auth", "T-004": "<repo>/.worktrees/feat-t-004-login-page"}}
   ```
   On next invocation, if this file exists:
   1. **Check staleness:** If `updated_at` (or file modification time) is older than 24h, delete the file and proceed fresh — project state may have changed significantly.

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -80,8 +80,8 @@ tracks the working directory for each task and switches context between tasks.
 **Working directory tracking:**
 ```json
 {
-  "T-003": {"worktree": "<repo>/.worktrees/feat/t-003-user-auth", "branch": "feat/t-003-user-auth"},
-  "T-004": {"worktree": "<repo>/.worktrees/feat/t-004-login-page", "branch": "feat/t-004-login-page"}
+  "T-003": {"worktree": "<repo>/.worktrees/feat-t-003-user-auth", "branch": "feat/t-003-user-auth"},
+  "T-004": {"worktree": "<repo>/.worktrees/feat-t-004-login-page", "branch": "feat/t-004-login-page"}
 }
 ```
 
@@ -231,7 +231,7 @@ After all tasks are processed (or the user stops), restore the terminal session 
      - **Stop batch entirely** — pause everything
 - If the user stops the batch, write progress to `.optimus/sessions/session-batch.json`:
   ```json
-  {"tasks": ["T-003", "T-004", "T-005"], "completed": ["T-003"], "current": "T-004", "current_stage": 3, "worktrees": {"T-003": "<repo>/.worktrees/feat/t-003-user-auth", "T-004": "<repo>/.worktrees/feat/t-004-login-page"}}
+  {"tasks": ["T-003", "T-004", "T-005"], "completed": ["T-003"], "current": "T-004", "current_stage": 3, "worktrees": {"T-003": "<repo>/.worktrees/feat-t-003-user-auth", "T-004": "<repo>/.worktrees/feat-t-004-login-page"}}
   ```
   On next invocation, if this file exists:
   1. **Check staleness:** If `updated_at` (or file modification time) is older than 24h, delete the file and proceed fresh — project state may have changed significantly.

--- a/commands/done.md
+++ b/commands/done.md
@@ -348,7 +348,8 @@ Options:
 
 ```bash
 git worktree remove "$WORKTREE_PATH"
-# Cleanup intermediate parent dirs (e.g., empty .worktrees/feat/ after removing leaf).
+# Cleanup empty parent dirs (legacy nested layout only — flat layout's parent
+# is .worktrees/ directly, so the loop exits after one iteration).
 # Idempotent: rmdir refuses non-empty dirs silently.
 parent="$(dirname "$WORKTREE_PATH")"
 while [ "$parent" != "${MAIN_WORKTREE}/.worktrees" ] && [ "$parent" != "/" ]; do
@@ -357,8 +358,7 @@ while [ "$parent" != "${MAIN_WORKTREE}/.worktrees" ] && [ "$parent" != "/" ]; do
 done
 ```
 
-This walks up from the removed worktree leaf to `${MAIN_WORKTREE}/.worktrees/` removing
-empty intermediate dirs (`feat/`, `fix/`, etc.) but stops at `.worktrees/` itself.
+This loop walks up from the removed worktree to `${MAIN_WORKTREE}/.worktrees/` and removes empty parent dirs. With the FLAT layout (`Protocol: Worktree Location`), a flat worktree's parent is `.worktrees/` directly so the loop exits after one iteration. Legacy nested worktrees (still supported for backwards-compat) trigger the loop to clean up their `feat/` / `fix/` parent dir as before.
 
 **Edge case — running INSIDE the worktree:** If the agent's current working directory IS
 the worktree being removed, `cd` to the main repository first:

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -363,7 +363,8 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
    case "$BRANCH_NAME" in
      *..*|/*) echo "ERROR: refusing unsafe branch '$BRANCH_NAME'." >&2; exit 1 ;;
    esac
-   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${BRANCH_NAME}"
+   FLAT_BRANCH="${BRANCH_NAME//\//\-}"     # / → - so worktree dirs are flat
+   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${FLAT_BRANCH}"
    ```
    **Pre-check:** If `WORKTREE_DIR` already exists but is not a git worktree, ask via
    `AskUser`: "Directory `<path>` already exists but is not a git worktree."

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -300,8 +300,9 @@ fi
 
 # Anchor the match on the kebab-cased task ID (e.g., `-t-1-`) so substrings like
 # `t-1` cannot match `t-10`/`t-100`. Worktree paths follow Protocol: Worktree
-# Location: ${MAIN_WORKTREE}/.worktrees/<branch-name> (legacy sibling paths
-# ../<repo>-<id>-<keywords> still resolve via git worktree list metadata).
+# Location: ${MAIN_WORKTREE}/.worktrees/<flat-branch-name> (branch slashes
+# replaced with hyphens; legacy sibling paths ../<repo>-<id>-<keywords> still
+# resolve via git worktree list metadata).
 # Feature branches follow `<tipo>/<id>-<keywords>` — both surround the
 # lowercased ID with hyphens.
 TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
@@ -350,7 +351,8 @@ fi
    case "$TASK_BRANCH" in
      *..*|/*) echo "ERROR: refusing unsafe branch '$TASK_BRANCH'." >&2; exit 1 ;;
    esac
-   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${TASK_BRANCH}"
+   FLAT_BRANCH="${TASK_BRANCH//\//\-}"     # / → - so worktree dirs are flat
+   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${FLAT_BRANCH}"
 
    # HARD BLOCK on git worktree add failure (dir exists, branch checked out elsewhere, etc.)
    if ! git worktree add "$WORKTREE_DIR" "$TASK_BRANCH"; then

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -391,7 +391,8 @@ Options:
 
 ```bash
 git worktree remove "$WORKTREE_PATH"
-# Cleanup intermediate parent dirs (e.g., empty .worktrees/feat/ after removing leaf).
+# Cleanup empty parent dirs (legacy nested layout only — flat layout's parent
+# is .worktrees/ directly, so the loop exits after one iteration).
 # Idempotent: rmdir refuses non-empty dirs silently.
 parent="$(dirname "$WORKTREE_PATH")"
 while [ "$parent" != "${MAIN_WORKTREE}/.worktrees" ] && [ "$parent" != "/" ]; do
@@ -400,8 +401,7 @@ while [ "$parent" != "${MAIN_WORKTREE}/.worktrees" ] && [ "$parent" != "/" ]; do
 done
 ```
 
-This walks up from the removed worktree leaf to `${MAIN_WORKTREE}/.worktrees/` removing
-empty intermediate dirs (`feat/`, `fix/`, etc.) but stops at `.worktrees/` itself.
+This loop walks up from the removed worktree to `${MAIN_WORKTREE}/.worktrees/` and removes empty parent dirs. With the FLAT layout (`Protocol: Worktree Location`), a flat worktree's parent is `.worktrees/` directly so the loop exits after one iteration. Legacy nested worktrees (still supported for backwards-compat) trigger the loop to clean up their `feat/` / `fix/` parent dir as before.
 
 **Edge case — running INSIDE the worktree:** If the agent's current working directory IS
 the worktree being removed, `cd` to the main repository first:

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -424,7 +424,8 @@ Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelin
    case "$BRANCH_NAME" in
      *..*|/*) echo "ERROR: refusing unsafe branch '$BRANCH_NAME'." >&2; exit 1 ;;
    esac
-   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${BRANCH_NAME}"
+   FLAT_BRANCH="${BRANCH_NAME//\//\-}"     # / → - so worktree dirs are flat
+   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${FLAT_BRANCH}"
    ```
    **Pre-check:** If `WORKTREE_DIR` already exists but is not a git worktree, ask via
    `AskUser`: "Directory `<path>` already exists but is not a git worktree."

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -359,8 +359,9 @@ fi
 
 # Anchor the match on the kebab-cased task ID (e.g., `-t-1-`) so substrings like
 # `t-1` cannot match `t-10`/`t-100`. Worktree paths follow Protocol: Worktree
-# Location: ${MAIN_WORKTREE}/.worktrees/<branch-name> (legacy sibling paths
-# ../<repo>-<id>-<keywords> still resolve via git worktree list metadata).
+# Location: ${MAIN_WORKTREE}/.worktrees/<flat-branch-name> (branch slashes
+# replaced with hyphens; legacy sibling paths ../<repo>-<id>-<keywords> still
+# resolve via git worktree list metadata).
 # Feature branches follow `<tipo>/<id>-<keywords>` — both surround the
 # lowercased ID with hyphens.
 TASK_KEBAB="-$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')-"
@@ -409,7 +410,8 @@ fi
    case "$TASK_BRANCH" in
      *..*|/*) echo "ERROR: refusing unsafe branch '$TASK_BRANCH'." >&2; exit 1 ;;
    esac
-   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${TASK_BRANCH}"
+   FLAT_BRANCH="${TASK_BRANCH//\//\-}"     # / → - so worktree dirs are flat
+   WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${FLAT_BRANCH}"
 
    # HARD BLOCK on git worktree add failure (dir exists, branch checked out elsewhere, etc.)
    if ! git worktree add "$WORKTREE_DIR" "$TASK_BRANCH"; then

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3474,8 +3474,9 @@ class TestTasksDirConvention:
 
 
 class TestWorktreeLocationConvention:
-    """F-worktrees: All worktree-creation sites use ${MAIN_WORKTREE}/.worktrees/<branch>
-    pattern; .gitignore auto-inject uses post-F1 ${MAIN_WORKTREE}/.gitignore contract."""
+    """F-worktrees: All worktree-creation sites use ${MAIN_WORKTREE}/.worktrees/<flat-branch>
+    where flat-branch = branch with / replaced by -; .gitignore auto-inject uses post-F1
+    ${MAIN_WORKTREE}/.gitignore contract."""
 
     CREATOR_FILES = [
         (REPO_ROOT / "AGENTS.md", "Workspace Auto-Navigation"),


### PR DESCRIPTION
## Summary

Branches in optimus-managed projects contain `/` (per `Protocol: Branch Name Derivation`), so worktrees today land at nested paths like `.worktrees/feat/t-001-user-auth/`. This PR switches to a flat layout where every `/` in the branch name is replaced by `-` when deriving the directory name:

```
<repo>/
├── .worktrees/                   ← gitignored
│   ├── feat-t-001-user-auth/     ← branch feat/t-001-user-auth
│   ├── feat-t-002-login-page/    ← branch feat/t-002-login-page
│   ├── fix-t-007-bug-validation/
│   └── chore-t-012-deps-update/
```

**Branch names themselves are unchanged in git** — only the worktree directory derivation changes.

## Translation rule (applied at every path-derivation site)

```bash
FLAT_BRANCH="${BRANCH_NAME//\//\-}"     # POSIX bash parameter expansion
WORKTREE_DIR="${MAIN_WORKTREE}/.worktrees/${FLAT_BRANCH}"
```

Applies to every `/`. Multi-slash branches: `feat/sub/x` → `feat-sub-x`.

## Touched files

**Source-of-truth (7 files):**
- `AGENTS.md` — Protocol: Worktree Location rewritten; Workspace Auto-Navigation updated; task-listing examples flattened; backwards-compat bullet added for legacy nested format
- `plan/skills/optimus-plan/SKILL.md` — Step 1.0.5 path derivation
- `resume/skills/optimus-resume/SKILL.md` — Step 3.3 recovery path
- `done/skills/optimus-done/SKILL.md` — cleanup loop unchanged (still correct); explanatory comment updated
- `batch/skills/optimus-batch/SKILL.md` — JSON example paths flattened
- `README.md` — user-facing prose updated with the `/` → `-` rule
- `scripts/test_skill_consistency.py` — class docstring updated

**Generated mirrors (4 files, regenerated by `scripts/sync-claude-commands.py`):**
- `commands/{plan,resume,done,batch}.md`

## Backwards compatibility

- Existing nested-format worktrees (`.worktrees/feat/t-001-user-auth/`) keep working — `git worktree list` is layout-agnostic.
- No forced migration. Users who want to consolidate run `git worktree move .worktrees/feat/t-001-user-auth .worktrees/feat-t-001-user-auth` manually (one-liner documented in the backwards-compat section).
- The `done` cleanup loop continues to walk up and remove empty `feat/` / `fix/` parent dirs IF a legacy nested worktree is removed under it; for flat worktrees the loop exits after one iteration at `.worktrees/`.

## Test plan

- [x] `make test` — 364 passed (`TestSkillConsistency`, `TestWorktreePathResolution`, `TestClaudeCommandsSync` all green)
- [x] `make lint` — clean (ruff, py_compile, shellcheck)
- [x] Sync idempotent — `python3 scripts/sync-claude-commands.py` produces no further diff after running once
- [x] Spec self-consistency grep — `grep -rn '\.worktrees/feat/' AGENTS.md README.md commands/ */skills/*/SKILL.md` returns ONLY the intentional backwards-compat note in AGENTS.md
- [ ] **Live smoke test pending** — run `/optimus:plan` against a task with a `/`-containing branch name in any optimus-managed project and confirm the worktree appears at `.worktrees/<flat>/`. Then `/optimus:done` and confirm clean removal.