### PR TITLE
fix(skills): block worktree-location prompts in plan/resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3082,6 +3082,11 @@ Skills reference this as: "Check active version guard — see AGENTS.md Protocol
 
 **Summary:** Linked worktrees created by plan / resume / Workspace Auto-Navigation / done-cleanup live at the canonical path `${MAIN_WORKTREE}/.worktrees/<flat-branch-name>` — gitignored (auto-injected by Initialize .optimus Directory + Session State protocols), project-rooted, resolved via Resolve Main Worktree Path so paths stay correct from any linked worktree. Branch names contain `/` (per Branch Name Derivation); the worktree directory is created with a flat directory name with `/` replaced by `-` (e.g., `feat/t-007-...` → `feat-t-007-...`). Worktrees ALWAYS belong to the project repo, never the tasks repo (separate-repo `tasksDir` doesn't affect location). Recommend IDE exclusion (`.vscode/settings.json` `search.exclude`, IntelliJ Excluded). Backwards compat: legacy sibling paths and legacy nested-format worktrees still work via worktree metadata; no forced migration. See full convention + IDE config in AGENTS.md.
 
+**Authoritative.** Skills (plan, resume, build, done) MUST NOT ask the user
+about worktree location. The path is fixed; project `CLAUDE.md` conventions
+are overridden by this protocol. Backwards compatibility below covers
+**existing** worktrees only — it is not a menu of options for new worktrees.
+
 **Referenced by:** plan (Step 1.0.5), resume (Step 3.3 Case 2), Protocol: Workspace Auto-Navigation (see Reusable Protocols), done (Phase 4.1 cleanup)
 
 Optimus creates linked git worktrees during the task lifecycle:
@@ -3109,7 +3114,7 @@ Optimus creates linked git worktrees during the task lifecycle:
 - VS Code (`.vscode/settings.json`): `"search.exclude": { "**/.worktrees": true }, "files.watcherExclude": { "**/.worktrees/**": true }`
 - IntelliJ: mark `.worktrees/` as Excluded in Project Structure.
 
-**Backwards compatibility:**
+**Backwards compatibility (existing worktrees only — NOT alternatives for new worktrees):**
 
 - Existing worktrees in older sibling locations (`../<repo>-<task>`) continue to work — `git worktree list` finds them regardless of path.
 - Existing nested-format worktrees (`.worktrees/feat/t-001-user-auth/`) created by older optimus-plan runs continue to work — `git worktree list` is layout-agnostic. Optionally consolidate with `git worktree move .worktrees/feat/t-001-user-auth .worktrees/feat-t-001-user-auth`. No forced migration.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -304,6 +304,12 @@ workspace, no `Validando Spec` status leak).
 
 ### Step 1.0.5: Reserve Task and Create Workspace
 
+**AUTHORITATIVE — DO NOT PROMPT.** The worktree path is fixed by `Protocol: Worktree Location`.
+Do NOT ask the user where to place the worktree. Do NOT enumerate alternatives
+(parent dir, in-place, etc.). Project `CLAUDE.md` worktree conventions are
+**OVERRIDDEN** by this skill. The only legitimate `AskUser` in this step is the
+collision recovery prompt below (directory exists but is not a git worktree).
+
 **Canonical worktree path** — see AGENTS.md Protocol: Worktree Location.
 
 Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines.

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -324,6 +324,11 @@ fi
 
 ### Step 3.3: Apply Resolution Order
 
+**AUTHORITATIVE — DO NOT PROMPT.** When recreating a missing worktree, the path
+is fixed by `Protocol: Worktree Location`. Do NOT ask the user where to place
+the worktree. Do NOT enumerate alternatives (parent dir, in-place, etc.).
+Project `CLAUDE.md` worktree conventions are **OVERRIDDEN** by this skill.
+
 **Canonical worktree path** — see AGENTS.md Protocol: Worktree Location.
 
 1. **Worktree found** → `cd "$WORKTREE_PATH"` for the rest of the session. Continue to Phase 4.

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -365,6 +365,12 @@ workspace, no `Validando Spec` status leak).
 
 ### Step 1.0.5: Reserve Task and Create Workspace
 
+**AUTHORITATIVE — DO NOT PROMPT.** The worktree path is fixed by `Protocol: Worktree Location`.
+Do NOT ask the user where to place the worktree. Do NOT enumerate alternatives
+(parent dir, in-place, etc.). Project `CLAUDE.md` worktree conventions are
+**OVERRIDDEN** by this skill. The only legitimate `AskUser` in this step is the
+collision recovery prompt below (directory exists but is not a git worktree).
+
 **Canonical worktree path** — see AGENTS.md Protocol: Worktree Location.
 
 Follow shell safety guidelines — see AGENTS.md Protocol: Shell Safety Guidelines.

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -383,6 +383,11 @@ fi
 
 ### Step 3.3: Apply Resolution Order
 
+**AUTHORITATIVE — DO NOT PROMPT.** When recreating a missing worktree, the path
+is fixed by `Protocol: Worktree Location`. Do NOT ask the user where to place
+the worktree. Do NOT enumerate alternatives (parent dir, in-place, etc.).
+Project `CLAUDE.md` worktree conventions are **OVERRIDDEN** by this skill.
+
 **Canonical worktree path** — see AGENTS.md Protocol: Worktree Location.
 
 1. **Worktree found** → `cd "$WORKTREE_PATH"` for the rest of the session. Continue to Phase 4.


### PR DESCRIPTION
## Summary

- `/optimus:plan` was prompting users with 3 workspace-setup options (`Project convention (parent dir)` / `Skill default (.worktrees/)` / `In-place`) when the target project had a `CLAUDE.md` mentioning a non-canonical worktree convention. The skill is deterministic — `SKILL.md:428` hardcodes `${MAIN_WORKTREE}/.worktrees/<flat-branch>` — so the prompt was a Claude hallucination, not skill behavior. Same vector existed in `/optimus:resume` (`SKILL.md:414`).
- Root cause: no explicit anti-prompt prose at workspace-creation steps, plus the `Backwards compatibility` subsection in `Protocol: Worktree Location` reading like a menu of alternatives.
- Fix: docs-only guards forbidding the prompt and explicitly overriding project `CLAUDE.md` worktree conventions.

## Changes

- `plan/skills/optimus-plan/SKILL.md` (Step 1.0.5) — `AUTHORITATIVE — DO NOT PROMPT` guard before canonical-path reference.
- `resume/skills/optimus-resume/SKILL.md` (Step 3.3) — same guard for the recovery-recreation path.
- `AGENTS.md` `Protocol: Worktree Location` — `Authoritative` paragraph after `Summary`; backwards-compat header renamed to make explicit it covers **existing** worktrees only.
- `commands/plan.md`, `commands/resume.md` — regenerated via `scripts/sync-claude-commands.py`.

No code changes, no new config, no migration.

## Test plan

- [x] `python3 -m pytest scripts/test_skill_consistency.py` → 176 passed
- [x] `python3 -m pytest scripts/test_inline_protocols.py` → 67 passed
- [ ] Manual end-to-end in a project whose `CLAUDE.md` mentions parent-dir worktrees: run `/optimus:plan` for a new task and confirm worktree lands at `.worktrees/<flat-branch>` with no location prompt (only the legitimate collision-recovery prompt may appear if the dir already exists but is not a worktree).