### PR TITLE
fix(skills): re-inline Terminal Identification body so badge actually displays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1604,8 +1604,6 @@ Skills reference this as: "Execute session state protocol from AGENTS.md using s
 
 ### Protocol: Terminal Identification
 
-<!-- inline-mode: omit -->
-
 **Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
 
 **Referenced by:** all stage agents (1-4), batch

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -304,4 +304,112 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -622,4 +622,112 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -260,4 +260,112 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/build.md
+++ b/commands/build.md
@@ -560,4 +560,112 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/done.md
+++ b/commands/done.md
@@ -589,4 +589,112 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1008,4 +1008,112 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -687,4 +687,112 @@ The agent MUST NOT use these excuses to skip or reorder steps:
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/review.md
+++ b/commands/review.md
@@ -999,4 +999,112 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -632,4 +632,112 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -1069,4 +1069,112 @@ GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before
 ```
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -746,4 +746,112 @@ The agent MUST NOT use these excuses to skip or reorder steps:
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -1064,4 +1064,112 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
 
 
+### Protocol: Terminal Identification
+
+**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
+
+**Referenced by:** all stage agents (1-4), batch
+
+After the task ID is identified and confirmed, set the terminal title to show the
+current stage and task. This allows users running multiple agents in parallel terminals
+to identify each terminal at a glance.
+
+**Mark session (after task ID is known):**
+
+```bash
+_optimus_mark_session() {
+  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
+  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
+  # overlay visible in Mission Control and Dock previews even when the
+  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
+  # in the tab bar regardless of which tab is active. Replaces the
+  # previous AppleScript title approach, which only worked reliably with
+  # focus and required TCC permission. The Execute tool runs bash without
+  # a controlling TTY, so we resolve the parent process's TTY via ps and
+  # write escape sequences directly to it; iTerm2 interprets OSC 1337
+  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
+  # parent TTY cannot be resolved (Docker/CI).
+  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
+  # $2 = task id     (e.g. T-003)
+  # $3 = task title  (e.g. "User Auth JWT")
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;  # blue
+    BUILD)  r=34;  g=197; b=94  ;;  # green
+    REVIEW) r=234; g=179; b=8   ;;  # yellow
+    DONE)   r=148; g=163; b=184 ;;  # gray
+    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
+```
+
+Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
+
+**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
+
+**Restore at stage completion or exit:**
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
+
+**Troubleshooting iTerm2:**
+
+1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
+2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
+3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
+
+Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
+
+
 <!-- INLINE-PROTOCOLS:END -->

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -3616,7 +3616,12 @@ class TestProtocolInlineModeMarker:
         "Quiet Command Execution",
         "Convergence Loop (Full Roster Model — Opt-In, Gated)",
         # Phase 3:
-        "Terminal Identification",
+        # Note: "Terminal Identification" was previously listed here in omit
+        # mode, but the omit marker hid the bash function body from consumer
+        # SKILL.md files — at runtime the badge call hit `command not found`
+        # because the body was never inlined. Reverted to full-body inlining
+        # (no marker) so the function definition reaches the executed shell.
+        # `test_helper_has_applescript_layer` covers the full-body invariant.
         "Per-Droid Quality Checklists",
         # Phase 4:
         "Coverage Measurement",


### PR DESCRIPTION
## Summary

- The badge call (`_optimus_mark_session ...`) in each stage SKILL.md was hitting `command not found` at runtime because the function body was never inlined.
- Root cause: `Protocol: Terminal Identification` in `AGENTS.md` carried `<!-- inline-mode: omit -->`, which makes `scripts/inline-protocols.py` emit nothing into consumer SKILLs (only the back-reference comment).
- Fix: drop the omit marker so the inliner injects the full function definition. Diagnostic confirmed the OSC 1337 mechanism itself works fine from Claude Code's Bash tool (env vars propagate, parent TTY resolves, write succeeds) — the bug was purely about the body never reaching the executed shell.

## Test plan

- [x] `python3 -m pytest scripts/` → 364 passed
- [x] Static check: `grep -c SetBadgeFormat */skills/*/SKILL.md` returns ≥1 in each of plan/build/review/done/batch/resume (currently 4 each)
- [ ] Manual smoke in iTerm2: run `/optimus:build T-XXX` (or any other stage) on a real task and confirm badge appears (`BUILD T-XXX / <title>`) and tab color matches stage
- [ ] Same in another terminal (e.g. Terminal.app): confirm silent no-op, no errors

## Notes

Trade-off accepted: this re-introduces ~108 lines of inlined bash per stage SKILL.md, partially reverting the Phase 9 omit-mode token reduction (issue #34) for this protocol only. Other `omit`-mode protocols are untouched. Cross-terminal coverage (Terminal.app / Linux / etc.) remains an open follow-up if desired — not blocked by this fix.