### PR TITLE
fix(skills): inline badge function body at call site (real fix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1604,6 +1604,8 @@ Skills reference this as: "Execute session state protocol from AGENTS.md using s
 
 ### Protocol: Terminal Identification
 
+<!-- inline-mode: omit -->
+
 **Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
 
 **Referenced by:** all stage agents (1-4), batch

--- a/batch/skills/optimus-batch/SKILL.md
+++ b/batch/skills/optimus-batch/SKILL.md
@@ -144,7 +144,43 @@ starting the next task.
 
 For each task in the execution order:
 
-Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage=`BATCH` and include the current task ID and title (e.g., `_optimus_mark_session BATCH "T-003" "User Auth JWT"`). Update the marker each time the task changes.
+Mark terminal session (iTerm2 badge + tab color). Substitute `$TASK_ID` and `$TASK_TITLE` for the current task and re-run this block each time you advance to a new task. The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
+
+```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session BATCH "$TASK_ID" "$TASK_TITLE"
+```
 
 ### Step 2.1: Stage Dispatch
 
@@ -231,7 +267,34 @@ After completing a task (all stages done), re-evaluate the remaining task pool:
 
 ## Phase 3: Batch Summary
 
-After all tasks are processed (or the user stops), restore the terminal session via `_optimus_clear_session` (see Protocol: Terminal Identification for the function definition):
+After all tasks are processed (or the user stops), restore the terminal session (body inlined for the same reason as the mark block above):
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+Then present the summary:
 
 ```markdown
 ## Batch Execution Summary
@@ -302,114 +365,6 @@ If this command fails (exit code != 0), **STOP** immediately:
 ```
 GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before proceeding.
 ```
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -132,15 +132,68 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `BUILD`:
+Then execute the title-setter NOW. Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session BUILD "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On stage completion or exit**, restore the title:
+**On stage completion or exit**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -620,114 +673,6 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 - If no PR exists, skip.
 
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/batch.md
+++ b/commands/batch.md
@@ -100,7 +100,43 @@ starting the next task.
 
 For each task in the execution order:
 
-Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage=`BATCH` and include the current task ID and title (e.g., `_optimus_mark_session BATCH "T-003" "User Auth JWT"`). Update the marker each time the task changes.
+Mark terminal session (iTerm2 badge + tab color). Substitute `$TASK_ID` and `$TASK_TITLE` for the current task and re-run this block each time you advance to a new task. The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
+
+```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session BATCH "$TASK_ID" "$TASK_TITLE"
+```
 
 ### Step 2.1: Stage Dispatch
 
@@ -187,7 +223,34 @@ After completing a task (all stages done), re-evaluate the remaining task pool:
 
 ## Phase 3: Batch Summary
 
-After all tasks are processed (or the user stops), restore the terminal session via `_optimus_clear_session` (see Protocol: Terminal Identification for the function definition):
+After all tasks are processed (or the user stops), restore the terminal session (body inlined for the same reason as the mark block above):
+
+```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
+```
+
+Then present the summary:
 
 ```markdown
 ## Batch Execution Summary
@@ -258,114 +321,6 @@ If this command fails (exit code != 0), **STOP** immediately:
 ```
 GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before proceeding.
 ```
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/build.md
+++ b/commands/build.md
@@ -70,15 +70,68 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `BUILD`:
+Then execute the title-setter NOW. Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session BUILD "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On stage completion or exit**, restore the title:
+**On stage completion or exit**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -558,114 +611,6 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 - If no PR exists, skip.
 
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/done.md
+++ b/commands/done.md
@@ -105,15 +105,68 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `DONE`:
+Then execute the title-setter NOW. Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session DONE "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On stage completion or exit**, restore the title:
+**On stage completion or exit**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -587,114 +640,6 @@ If this command fails (exit code != 0), **STOP** immediately:
 ```
 GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before proceeding.
 ```
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -75,15 +75,68 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `PLAN`:
+Then execute the title-setter NOW. Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session PLAN "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On stage completion or exit**, restore the title:
+**On stage completion or exit**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -1006,114 +1059,6 @@ If this command fails (exit code != 0), **STOP** immediately:
 ```
 GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before proceeding.
 ```
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/resume.md
+++ b/commands/resume.md
@@ -465,15 +465,68 @@ If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
 
 ### Step 4.1: Set Terminal Title
 
-Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `RESUME`:
+Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session RESUME "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On exit or after Phase 5 delegates to another stage skill**, restore the title:
+**On exit or after Phase 5 delegates to another stage skill**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -686,113 +739,5 @@ The agent MUST NOT use these excuses to skip or reorder steps:
 
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
-
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/commands/review.md
+++ b/commands/review.md
@@ -88,15 +88,68 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `REVIEW`:
+Then execute the title-setter NOW. Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session REVIEW "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On stage completion or exit**, restore the title:
+**On stage completion or exit**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -997,114 +1050,6 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 - If no PR exists, skip.
 
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -148,15 +148,68 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `DONE`:
+Then execute the title-setter NOW. Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session DONE "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On stage completion or exit**, restore the title:
+**On stage completion or exit**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -630,114 +683,6 @@ If this command fails (exit code != 0), **STOP** immediately:
 ```
 GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before proceeding.
 ```
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -136,15 +136,68 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `PLAN`:
+Then execute the title-setter NOW. Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session PLAN "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On stage completion or exit**, restore the title:
+**On stage completion or exit**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -1067,114 +1120,6 @@ If this command fails (exit code != 0), **STOP** immediately:
 ```
 GitHub CLI (gh) is not authenticated. Run `gh auth login` to authenticate before proceeding.
 ```
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -524,15 +524,68 @@ If the user invoked a dry-run (e.g., "dry-run resume T-XXX", "preview resume"):
 
 ### Step 4.1: Set Terminal Title
 
-Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `RESUME`:
+Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session RESUME "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On exit or after Phase 5 delegates to another stage skill**, restore the title:
+**On exit or after Phase 5 delegates to another stage skill**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -745,113 +798,5 @@ The agent MUST NOT use these excuses to skip or reorder steps:
 
 The following protocols are referenced by this skill. They are
 extracted from the Optimus AGENTS.md to make this plugin self-contained.
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
-
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -153,15 +153,68 @@ if [ -z "$TASK_TITLE" ]; then
 fi
 ```
 
-Then execute the title-setter NOW. Mark terminal session — see AGENTS.md Protocol: Terminal Identification. Use stage label `REVIEW`:
+Then execute the title-setter NOW. Mark terminal session (iTerm2 badge + tab color). The function body is inlined here on purpose: each Bash tool invocation is a fresh shell, so a definition pasted in another code block does NOT survive into this one. See AGENTS.md Protocol: Terminal Identification. The canonical body of the function lives there.
 
 ```bash
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
 _optimus_mark_session REVIEW "$TASK_ID" "$TASK_TITLE"
 ```
 
-**On stage completion or exit**, restore the title:
+**On stage completion or exit**, restore the title (body inlined for the same reason as above):
 
 ```bash
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
 _optimus_clear_session
 ```
 
@@ -1062,114 +1115,6 @@ If a PR exists, validate its title follows **Conventional Commits 1.0.0**:
 - If no PR exists, skip.
 
 Skills reference this as: "Validate PR title — see AGENTS.md Protocol: PR Title Validation."
-
-
-### Protocol: Terminal Identification
-
-**Summary:** `_optimus_mark_session <stage> <task_id> <title>` marks the current iTerm2 session with two **focus-independent** signals: an iTerm2 Badge (OSC 1337 SetBadgeFormat) — large semi-transparent overlay text always visible (incl. Mission Control thumbnails and Dock previews) — and a Tab Color (OSC 6 SetColors) tinting the tab per stage (PLAN=blue, BUILD=green, REVIEW=yellow, DONE=gray, RESUME/BATCH=purple). Used by stage skills so users running multiple Optimus sessions can identify each at a glance, even with the window unfocused or backgrounded. Replaces the previous AppleScript title approach which only updated reliably when the iTerm2 tab had focus and required TCC permission. Helper writes to the parent shell's controlling TTY; silent no-op outside iTerm2/macOS. Companion `_optimus_clear_session` resets badge and tab color at stage completion. See full bash function in AGENTS.md.
-
-**Referenced by:** all stage agents (1-4), batch
-
-After the task ID is identified and confirmed, set the terminal title to show the
-current stage and task. This allows users running multiple agents in parallel terminals
-to identify each terminal at a glance.
-
-**Mark session (after task ID is known):**
-
-```bash
-_optimus_mark_session() {
-  # iTerm2 Badge + Tab Color marker. Both signals are focus-independent:
-  # the Badge (OSC 1337 SetBadgeFormat) renders a large semi-transparent
-  # overlay visible in Mission Control and Dock previews even when the
-  # window is unfocused. Tab Color (OSC 6) tints the tab itself, visible
-  # in the tab bar regardless of which tab is active. Replaces the
-  # previous AppleScript title approach, which only worked reliably with
-  # focus and required TCC permission. The Execute tool runs bash without
-  # a controlling TTY, so we resolve the parent process's TTY via ps and
-  # write escape sequences directly to it; iTerm2 interprets OSC 1337
-  # and OSC 6 immediately. Silent no-op outside iTerm2/macOS or when the
-  # parent TTY cannot be resolved (Docker/CI).
-  # $1 = stage label (PLAN|BUILD|REVIEW|DONE|RESUME|BATCH)
-  # $2 = task id     (e.g. T-003)
-  # $3 = task title  (e.g. "User Auth JWT")
-  local stage="$1" task_id="$2" title="$3"
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-
-  _optimus_emit() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-
-  local badge_b64
-  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
-  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
-
-  local r g b
-  case "$stage" in
-    PLAN)   r=66;  g=135; b=245 ;;  # blue
-    BUILD)  r=34;  g=197; b=94  ;;  # green
-    REVIEW) r=234; g=179; b=8   ;;  # yellow
-    DONE)   r=148; g=163; b=184 ;;  # gray
-    *)      r=168; g=85;  b=247 ;;  # purple (RESUME/BATCH)
-  esac
-  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
-}
-_optimus_mark_session "<STAGE>" "$TASK_ID" "$TASK_TITLE"
-```
-
-Example: stage `PLAN`, task `T-003`, title `User Auth JWT` produces a blue tab and an overlay badge reading "PLAN T-003 / User Auth JWT".
-
-**Why escape sequences over AppleScript:** Badge and tab color render immediately on receipt, regardless of focus, in iTerm2 sessions including "divorced" ones. The Execute tool runs `bash -c` without a controlling TTY, so we resolve the parent shell's TTY via `ps` and write the escape sequences there. No TCC prompt, no AppleScript permission dance.
-
-**Restore at stage completion or exit:**
-
-```bash
-_optimus_clear_session() {
-  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
-  local pid="$PPID" target_tty=""
-  for _ in 1 2 3 4; do
-    [ -z "$pid" ] || [ "$pid" = "1" ] && break
-    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
-    case "$target_tty" in
-      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
-      *) break ;;
-    esac
-  done
-  _optimus_emit_clear() {
-    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
-      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
-    else
-      printf '%s' "$1"
-    fi
-  }
-  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
-  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
-}
-_optimus_clear_session
-```
-
-**NOTE:** This helper is iTerm2-on-macOS only. Outside iTerm2 (Terminal.app, Ghostty, Warp, Alacritty) or outside macOS, both functions are silent no-ops — users on other terminals see no visual marker.
-
-**Troubleshooting iTerm2:**
-
-1. **Badge invisible despite call succeeding** — Open iTerm2 Preferences > Profiles > [your profile] > Badge. Badge font/color is configured per-profile; if the badge font color matches the background, increase contrast. Default semi-transparent rendering should always be visible.
-2. **Tab color appears wrong or doesn't change** — Some iTerm2 themes lock tab background colors. Check Preferences > Appearance > Tabs > "Tab style". `Compact` or `Minimal` styles render tab colors most reliably.
-3. **No badge or color in some sessions** — The helper requires the parent process to have a controlling TTY. Inside Docker/CI without a TTY, the function silently no-ops; this is expected.
-
-Skills reference this as: "Mark terminal session — see AGENTS.md Protocol: Terminal Identification."
 
 
 <!-- INLINE-PROTOCOLS:END -->

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -27,6 +27,7 @@ improving navigability.
 """
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -2859,28 +2860,127 @@ class TestDiscoverReviewDroidsDenyList:
         assert "BEFORE final selection" in section or "BEFORE final" in section
 
 
-class TestTerminalIdentificationNotPastedInBody:
-    """F12f: After consolidating `_optimus_mark_session` / `_optimus_clear_session`,
-    no SKILL body should contain a manual definition. The functions come from
-    the inlined block via the `AGENTS.md Protocol: Terminal Identification`
-    reference."""
+class TestTerminalIdentificationCallSiteSelfContained:
+    """Regression guard: each ``_optimus_mark_session`` / ``_optimus_clear_session``
+    call site MUST live in the same fenced bash block as the function definition.
 
-    def test_no_set_title_definition_in_skill_bodies(self):
-        violations = []
-        for skill_path in _all_skill_files():
-            content = skill_path.read_text()
-            body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
-            if (
-                "_optimus_mark_session() {" in body
-                or "_optimus_clear_session() {" in body
-            ):
-                violations.append(str(skill_path.relative_to(REPO_ROOT)))
-        assert violations == [], (
-            "These SKILL.md files still contain a body-level "
-            "`_optimus_mark_session()` or `_optimus_clear_session()` "
-            "definition; move it to the inlined `Protocol: Terminal "
-            "Identification` block:\n"
-            + "\n".join(violations)
+    Why this test exists: previous attempts inlined the function body via the
+    ``Protocol: Terminal Identification`` block (appended at end of SKILL.md by
+    the inliner) but the call site was a separate bash block earlier in the
+    file. Each Bash tool invocation is a fresh shell, so the definition in one
+    code block did NOT survive into the call's code block — every badge call
+    silently failed with `command not found` (exit 127). This test catches
+    that regression by parsing each fenced bash block and asserting that any
+    block containing a positional call also contains the function definition.
+    """
+
+    @staticmethod
+    def _bash_blocks(content: str) -> list[str]:
+        """Return the contents of every ```bash ... ``` fenced block in the file body
+        (excluding the appendix after INLINE-PROTOCOLS:START, which is reference
+        documentation only — the agent does not execute appendix code)."""
+        body = content.split("<!-- INLINE-PROTOCOLS:START -->", 1)[0]
+        blocks: list[str] = []
+        in_block = False
+        current: list[str] = []
+        for line in body.splitlines():
+            stripped = line.strip()
+            if not in_block and stripped == "```bash":
+                in_block = True
+                current = []
+            elif in_block and stripped == "```":
+                blocks.append("\n".join(current))
+                in_block = False
+                current = []
+            elif in_block:
+                current.append(line)
+        return blocks
+
+    # Match a positional call: `_optimus_mark_session WORD ...` or
+    # `_optimus_clear_session` on its own. Excludes the function-definition
+    # form `_optimus_mark_session() {`.
+    _MARK_CALL_RE = re.compile(
+        r"(?m)^\s*_optimus_mark_session\s+[A-Z]+\b"
+    )
+    _CLEAR_CALL_RE = re.compile(
+        r"(?m)^\s*_optimus_clear_session\s*$"
+    )
+
+    # `resume` is intentionally not part of the legacy TITLE_SKILLS (which only
+    # tracks pre-RESUME stages), but its mark/clear call site follows the exact
+    # same self-containment requirement, so this class adds it back in.
+    BADGE_SKILLS = TITLE_SKILLS + ["resume"]
+
+    @pytest.mark.parametrize("skill", BADGE_SKILLS)
+    def test_mark_call_block_contains_definition(self, skill):
+        content = _read_skill(skill)
+        blocks = self._bash_blocks(content)
+        call_blocks = [b for b in blocks if self._MARK_CALL_RE.search(b)]
+        assert call_blocks, (
+            f"{skill}: no fenced bash block contains a positional call to "
+            f"_optimus_mark_session — the call site is missing entirely."
+        )
+        offenders = [
+            b for b in call_blocks if "_optimus_mark_session() {" not in b
+        ]
+        assert not offenders, (
+            f"{skill}: a fenced bash block calls _optimus_mark_session "
+            f"without defining it in the same block. Each Bash tool "
+            f"invocation is a fresh shell — the definition MUST live in "
+            f"the same block as the call.\n"
+            f"Offending block (first 200 chars):\n{offenders[0][:200]}"
+        )
+
+    @pytest.mark.parametrize("skill", BADGE_SKILLS)
+    def test_clear_call_block_contains_definition(self, skill):
+        content = _read_skill(skill)
+        blocks = self._bash_blocks(content)
+        call_blocks = [b for b in blocks if self._CLEAR_CALL_RE.search(b)]
+        assert call_blocks, (
+            f"{skill}: no fenced bash block contains a bare "
+            f"_optimus_clear_session call — the cleanup site is missing."
+        )
+        offenders = [
+            b for b in call_blocks if "_optimus_clear_session() {" not in b
+        ]
+        assert not offenders, (
+            f"{skill}: a fenced bash block calls _optimus_clear_session "
+            f"without defining it in the same block. Each Bash tool "
+            f"invocation is a fresh shell — the definition MUST live in "
+            f"the same block as the call.\n"
+            f"Offending block (first 200 chars):\n{offenders[0][:200]}"
+        )
+
+    @pytest.mark.parametrize("skill", BADGE_SKILLS)
+    def test_mark_call_block_executes_successfully(self, skill, tmp_path):
+        """End-to-end: extract the call-site block and run it in a fresh shell.
+        With LC_TERMINAL=iTerm2 set the function does its work; without it
+        returns 0 silently. Either way exit code MUST be 0 — anything else
+        (notably 127 = command-not-found) means the body was not inlined."""
+        content = _read_skill(skill)
+        blocks = self._bash_blocks(content)
+        call_blocks = [b for b in blocks if self._MARK_CALL_RE.search(b)]
+        assert call_blocks, f"{skill}: missing mark call block"
+        script = tmp_path / "block.sh"
+        script.write_text(call_blocks[0])
+        # Provide TASK_ID/TASK_TITLE so the call site has values for its
+        # positional placeholders. Force LC_TERMINAL unset so the function
+        # silently returns 0 without trying to touch the (unavailable) parent
+        # TTY of the test runner — we are validating the function is DEFINED
+        # and CALLABLE, not its iTerm2 side-effect.
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "TASK_ID": "T-TEST",
+            "TASK_TITLE": "Test Title",
+        }
+        result = subprocess.run(
+            ["bash", str(script)], env=env, capture_output=True, text=True
+        )
+        assert result.returncode == 0, (
+            f"{skill}: bash block at call site exited {result.returncode} "
+            f"(expected 0). 127 = command not found = the function body is "
+            f"not inlined in the same block as the call.\n"
+            f"stderr: {result.stderr[:500]}"
         )
 
 
@@ -3616,12 +3716,7 @@ class TestProtocolInlineModeMarker:
         "Quiet Command Execution",
         "Convergence Loop (Full Roster Model — Opt-In, Gated)",
         # Phase 3:
-        # Note: "Terminal Identification" was previously listed here in omit
-        # mode, but the omit marker hid the bash function body from consumer
-        # SKILL.md files — at runtime the badge call hit `command not found`
-        # because the body was never inlined. Reverted to full-body inlining
-        # (no marker) so the function definition reaches the executed shell.
-        # `test_helper_has_applescript_layer` covers the full-body invariant.
+        "Terminal Identification",
         "Per-Droid Quality Checklists",
         # Phase 4:
         "Coverage Measurement",


### PR DESCRIPTION
## Summary

- PR #67 was incomplete. It made the inliner inject the function body into SKILL.md but the body landed in the appendix block (~line 638), while the call sat at the top of the file (~line 138). Each Bash tool invocation is a fresh shell, so the definition in the appendix never reached the call's shell.
- Reproduced: `bash -c '_optimus_mark_session BUILD ...'` returns exit 127 (`command not found`).
- Real fix: at every call site (mark + clear, in 6 stage skills) the bash block now contains the full function definition immediately followed by the call. Each block is self-sufficient.

## Why this matters

The user reported 10+ failed attempts to make the badge appear during real Optimus execution. The PR #67 commit message claimed "tests pass + badge mechanism proven to work" — both true, but the tests didn't catch this category of bug because they only checked for textual presence, not for *colocation* of definition and call inside the same fenced bash block.

## Test plan

- [x] `python3 -m pytest scripts/` → 378 passed
- [x] New regression tests:
  - `test_mark_call_block_contains_definition` (per stage)
  - `test_clear_call_block_contains_definition` (per stage)
  - `test_mark_call_block_executes_successfully` (per stage — actually runs the block via subprocess and asserts exit 0)
- [x] Manual smoke: extracted the call-site block from the edited build SKILL.md and ran it in a fresh bash → exit 0, badge "BUILD T-FINAL / End-to-End Smoke" appeared in iTerm2.
- [ ] Real end-to-end: invoke `/optimus:plan T-XXX` (or any stage) on a real task after sync. Badge should appear.

## Trade-off

~50 lines of bash duplicated 6× (mark + clear in each stage skill). The function is stable and the duplication is guarded by the new structural+execution tests. The DRY mechanism (Protocol: Terminal Identification in AGENTS.md) is now documentation-only (`<!-- inline-mode: omit -->` re-added) — kept as canonical reference.