### PR TITLE
fix(skills): forbid droid sub-agents from re-running verification commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3639,6 +3639,25 @@ elsewhere, related test files, existing conventions).
 beyond its core domain. These are defined in Protocol: Per-Droid Quality Checklists below.
 Skills that dispatch review droids MUST reference this protocol in their agent prompts.
 
+**Verification scope:** Every droid prompt MUST also include the universal verification-scope
+block, telling sub-agents NOT to re-run lint/test/coverage commands the orchestrator has
+already executed:
+
+```
+Verification scope (MANDATORY):
+  Static analysis (lint, vet, format) and tests (unit, integration, coverage)
+  have already been run by the orchestrator. Results are in this prompt or in
+  the log files referenced under .optimus/logs/.
+  - Do NOT run verification commands yourself. Forbidden: `go test`, `npm test`,
+    `npm run test`, `pytest`, `make test`, `make lint`, `make test-coverage`,
+    `make test-integration`, `golangci-lint`, `go vet`, `goimports`, `gofmt`,
+    `prettier`, `eslint`, `tsc`, or any equivalent.
+  - If you need test/coverage details, Read the log files referenced in this
+    prompt — do not regenerate them.
+  - Use Read, Grep, and Glob to inspect source files. Reserve Bash for read-only
+    git inspection (`git log`, `git blame`, `git diff`) when needed.
+```
+
 **Cross-cutting analysis:** Every droid prompt MUST include the universal cross-cutting
 section:
 1. What would break in production under load with this code?

--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -499,6 +499,23 @@ After ALL subtasks are complete:
    Each droid receives all files changed by this task + project rules + task spec.
    Include per-droid quality checklists — see AGENTS.md Protocol: Per-Droid Quality Checklists.
 
+   **Each review droid prompt MUST include this verification-scope block verbatim:**
+
+   ```
+   Verification scope (MANDATORY):
+     Static analysis (lint, vet, format) and tests (unit, integration, coverage)
+     have already been run by the orchestrator. Results are in this prompt or in
+     the log files referenced under .optimus/logs/.
+     - Do NOT run verification commands yourself. Forbidden: `go test`, `npm test`,
+       `npm run test`, `pytest`, `make test`, `make lint`, `make test-coverage`,
+       `make test-integration`, `golangci-lint`, `go vet`, `goimports`, `gofmt`,
+       `prettier`, `eslint`, `tsc`, or any equivalent.
+     - If you need test/coverage details, Read the log files referenced in this
+       prompt — do not regenerate them.
+     - Use Read, Grep, and Glob to inspect source files. Reserve Bash for read-only
+       git inspection (`git log`, `git blame`, `git diff`) when needed.
+   ```
+
    **Spec Compliance agent** (`ring-dev-team-qa-analyst`) must additionally (beyond the protocol):
    1. List every acceptance criterion from the Ring source (via `TaskSpec` column) and mark PASS/FAIL/PARTIAL
    2. List every test ID and verify a corresponding test exists

--- a/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
+++ b/coderabbit-review/skills/optimus-coderabbit-review/SKILL.md
@@ -348,6 +348,19 @@ IMPORTANT: You have access to Read, Grep, and Glob tools. USE THEM to:
   - Discover test patterns, error handling conventions, and architectural styles
   - Explore related files not listed above when needed for context
 
+Verification scope (MANDATORY):
+  Static analysis (lint, vet, format) and tests (unit, integration, coverage)
+  have already been run by the orchestrator. Results are in this prompt or in
+  the log files referenced under .optimus/logs/.
+  - Do NOT run verification commands yourself. Forbidden: `go test`, `npm test`,
+    `npm run test`, `pytest`, `make test`, `make lint`, `make test-coverage`,
+    `make test-integration`, `golangci-lint`, `go vet`, `goimports`, `gofmt`,
+    `prettier`, `eslint`, `tsc`, or any equivalent.
+  - If you need test/coverage details, Read the log files referenced in this
+    prompt — do not regenerate them.
+  - Use Read, Grep, and Glob to inspect source files. Reserve Bash for read-only
+    git inspection (`git log`, `git blame`, `git diff`) when needed.
+
 Cross-cutting analysis (MANDATORY for all agents):
   1. What would break in production under load with this code?
   2. What's MISSING that should be here? (not just what's wrong)

--- a/deep-review/skills/optimus-deep-review/SKILL.md
+++ b/deep-review/skills/optimus-deep-review/SKILL.md
@@ -195,6 +195,19 @@ Required output format:
   If no issues found, state "PASS — no issues in [domain]"
   Include a "What Was Done Well" section acknowledging good practices.
 
+Verification scope (MANDATORY):
+  Static analysis (lint, vet, format) and tests (unit, integration, coverage)
+  have already been run by the orchestrator. Results are in this prompt or in
+  the log files referenced under .optimus/logs/.
+  - Do NOT run verification commands yourself. Forbidden: `go test`, `npm test`,
+    `npm run test`, `pytest`, `make test`, `make lint`, `make test-coverage`,
+    `make test-integration`, `golangci-lint`, `go vet`, `goimports`, `gofmt`,
+    `prettier`, `eslint`, `tsc`, or any equivalent.
+  - If you need test/coverage details, Read the log files referenced in this
+    prompt — do not regenerate them.
+  - Use Read, Grep, and Glob to inspect source files. Reserve Bash for read-only
+    git inspection (`git log`, `git blame`, `git diff`) when needed.
+
 Cross-cutting analysis (MANDATORY for all agents):
   1. What would break in production under load with this code?
   2. What's MISSING that should be here? (not just what's wrong)
@@ -432,8 +445,8 @@ project rules (re-read fresh from disk). Do NOT include the findings ledger in a
 prompts — the orchestrator handles dedup using strict matching (same file + same line
 range ±5 + same category).
 
-Include the scope from Phase 1, plus the cross-cutting analysis instructions (same 5
-items from Phase 2 prompt).
+Include the scope from Phase 1, plus the same items from the Phase 2 prompt (both the
+Verification scope block and the Cross-cutting analysis 5 items).
 
 **Failure handling:** If a dispatched agent slot fails (Task tool error, ring droid
 unavailable), do NOT count as zero findings. Ask the user via `AskUser` whether to

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -799,6 +799,19 @@ Required output:
   For each finding: severity, category, description, recommendation
   If no issues: "PASS — [domain] validation clean"
 
+Verification scope (MANDATORY):
+  Static analysis (lint, vet, format) and tests (unit, integration, coverage)
+  have already been run by the orchestrator. Results are in this prompt or in
+  the log files referenced under .optimus/logs/.
+  - Do NOT run verification commands yourself. Forbidden: `go test`, `npm test`,
+    `npm run test`, `pytest`, `make test`, `make lint`, `make test-coverage`,
+    `make test-integration`, `golangci-lint`, `go vet`, `goimports`, `gofmt`,
+    `prettier`, `eslint`, `tsc`, or any equivalent.
+  - If you need test/coverage details, Read the log files referenced in this
+    prompt — do not regenerate them.
+  - Use Read, Grep, and Glob to inspect source files. Reserve Bash for read-only
+    git inspection (`git log`, `git blame`, `git diff`) when needed.
+
 Cross-cutting analysis (MANDATORY for all agents):
   1. What would break in production under load if this spec is implemented as-is?
   2. What's MISSING from the spec that should be there? (not just what's wrong)
@@ -929,8 +942,8 @@ orchestrator handles dedup using strict matching (same file + same line range ±
 category).
 
 Include analysis instructions: cross-reference (Step 2.1), test gaps (Step 2.2),
-observability (Step 2.3), DoD, ambiguities. Include the cross-cutting analysis instructions
-(same 5 items from Step 2.4 prompt).
+observability (Step 2.3), DoD, ambiguities. Include the same items from the Step 2.4 prompt
+(both the Verification scope block and the Cross-cutting analysis 5 items).
 
 **Failure handling:** If a fresh sub-agent dispatch fails (Task tool error, ring droid
 unavailable), do NOT count as zero findings. Ask the user via `AskUser` whether to

--- a/pr-check/skills/optimus-pr-check/SKILL.md
+++ b/pr-check/skills/optimus-pr-check/SKILL.md
@@ -771,6 +771,19 @@ For EACH evaluated comment, provide:
     - Engineering quality: Maintainability, testability, reliability impact
   - Recommendation with tradeoffs
 
+Verification scope (MANDATORY):
+  Static analysis (lint, vet, format) and tests (unit, integration, coverage)
+  have already been run by the orchestrator. Results are in this prompt or in
+  the log files referenced under .optimus/logs/.
+  - Do NOT run verification commands yourself. Forbidden: `go test`, `npm test`,
+    `npm run test`, `pytest`, `make test`, `make lint`, `make test-coverage`,
+    `make test-integration`, `golangci-lint`, `go vet`, `goimports`, `gofmt`,
+    `prettier`, `eslint`, `tsc`, or any equivalent.
+  - If you need test/coverage details, Read the log files referenced in this
+    prompt — do not regenerate them.
+  - Use Read, Grep, and Glob to inspect source files. Reserve Bash for read-only
+    git inspection (`git log`, `git blame`, `git diff`) when needed.
+
 Cross-cutting analysis — apply ONLY to existing comments (use these questions to
 decide AGREE / CONTEST / ALREADY FIXED, NOT to surface new findings):
   1. What would break in production under load with this code?
@@ -807,6 +820,19 @@ For EACH new finding, provide:
     - Project focus: MVP-critical or gold-plating?
     - Engineering quality: Maintainability, testability, reliability impact
   - Recommendation with tradeoffs
+
+Verification scope (MANDATORY):
+  Static analysis (lint, vet, format) and tests (unit, integration, coverage)
+  have already been run by the orchestrator. Results are in this prompt or in
+  the log files referenced under .optimus/logs/.
+  - Do NOT run verification commands yourself. Forbidden: `go test`, `npm test`,
+    `npm run test`, `pytest`, `make test`, `make lint`, `make test-coverage`,
+    `make test-integration`, `golangci-lint`, `go vet`, `goimports`, `gofmt`,
+    `prettier`, `eslint`, `tsc`, or any equivalent.
+  - If you need test/coverage details, Read the log files referenced in this
+    prompt — do not regenerate them.
+  - Use Read, Grep, and Glob to inspect source files. Reserve Bash for read-only
+    git inspection (`git log`, `git blame`, `git diff`) when needed.
 
 Cross-cutting analysis (MANDATORY for all agents in diff mode):
   1. What would break in production under load with this code?
@@ -1306,8 +1332,8 @@ the orchestrator handles dedup using strict matching (same file + same line rang
 same category).
 
 Include existing PR comments from all sources (reuse data from Phase 1 — do NOT re-fetch
-Codacy/DeepSource comments, they only update after push). Include the cross-cutting
-analysis instructions (same 5 items from Step 3.3 prompt).
+Codacy/DeepSource comments, they only update after push). Include the same items from the
+Step 3.3 prompt (both the Verification scope block and the Cross-cutting analysis 5 items).
 
 **Failure handling:** If a fresh sub-agent dispatch fails (Task tool error, ring droid
 unavailable), do NOT count as zero findings. Ask the user via `AskUser` whether to

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -503,6 +503,19 @@ Required output format:
   If no issues found, state "PASS — no issues in [domain]"
   Always include a "What Was Done Well" section acknowledging good practices.
 
+Verification scope (MANDATORY):
+  Static analysis (lint, vet, format) and tests (unit, integration, coverage)
+  have already been run by the orchestrator. Results are in this prompt or in
+  the log files referenced under .optimus/logs/.
+  - Do NOT run verification commands yourself. Forbidden: `go test`, `npm test`,
+    `npm run test`, `pytest`, `make test`, `make lint`, `make test-coverage`,
+    `make test-integration`, `golangci-lint`, `go vet`, `goimports`, `gofmt`,
+    `prettier`, `eslint`, `tsc`, or any equivalent.
+  - If you need test/coverage details, Read the log files referenced in this
+    prompt — do not regenerate them.
+  - Use Read, Grep, and Glob to inspect source files. Reserve Bash for read-only
+    git inspection (`git log`, `git blame`, `git diff`) when needed.
+
 Cross-cutting analysis (MANDATORY for all agents):
   1. What would break in production under load with this code?
   2. What's MISSING that should be here? (not just what's wrong)
@@ -796,7 +809,7 @@ caching purpose. Agents may consult full pre-dev docs only if a finding requires
 reference. The orchestrator handles dedup using strict matching (same file + same line
 range ±5 + same category).
 
-Include the cross-cutting analysis instructions (same 5 items from Phase 3 prompt).
+Include the same items from the Phase 3 prompt (both the Verification scope block and the Cross-cutting analysis 5 items).
 
 **Failure handling:** If a fresh sub-agent dispatch fails (Task tool error, ring droid
 unavailable), do NOT count as zero findings. Ask the user via `AskUser` whether to

--- a/scripts/test_skill_consistency.py
+++ b/scripts/test_skill_consistency.py
@@ -717,6 +717,46 @@ class TestMakefileConvention:
         )
 
 
+# --- Verification scope: droid prompts must forbid re-running lint/test ---
+
+# Skills whose droid prompt templates MUST instruct sub-agents NOT to re-run
+# verification commands (lint, test, coverage) the orchestrator already ran.
+SKILLS_WITH_VERIFICATION_SCOPE = [
+    "review", "pr-check", "coderabbit-review",
+    "deep-review", "build", "plan",
+]
+
+
+class TestVerificationScope:
+    """Every consumer-skill droid prompt template must include a Verification scope block.
+
+    The orchestrator runs lint/test/coverage once; sub-agents should not
+    re-run them (wastes tokens in the agent's isolated context). The
+    `Verification scope (MANDATORY)` block in each droid prompt template
+    enforces this contract.
+    """
+
+    def test_skills_have_verification_scope_block(self):
+        """Each consumer SKILL.md must contain 'Verification scope (MANDATORY)'."""
+        violations = []
+        for skill in SKILLS_WITH_VERIFICATION_SCOPE:
+            content = _read_skill(skill)
+            if "Verification scope (MANDATORY)" not in content:
+                violations.append(skill)
+        assert violations == [], (
+            "Skills missing 'Verification scope (MANDATORY)' block in droid "
+            "prompt template:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+
+    def test_agents_md_documents_verification_scope(self):
+        """AGENTS.md must document the Verification scope contract for skill authors."""
+        content = AGENTS_MD.read_text()
+        assert "Verification scope" in content, (
+            "AGENTS.md missing 'Verification scope' guidance for droid prompts"
+        )
+
+
 # --- Convergence model: Full Roster, opt-in gated ---
 
 


### PR DESCRIPTION
## Summary

- Skills (`review`, `pr-check`, `coderabbit-review`, `deep-review`, `build`, `plan`) already wrap `make`/`test`/`lint` in `_optimus_quiet_run` to keep the orchestrator's context clean. But the ring droids those skills dispatch have Bash access and may decide to run `go test ./...`, `make lint`, `pytest`, etc. on their own — bloating each droid's isolated context with verbose output the user pays tokens for.
- Add a **Verification scope (MANDATORY)** block to every droid prompt template that explicitly lists the forbidden commands (`go test`, `npm test`, `pytest`, `make test`, `make lint`, `golangci-lint`, `go vet`, `goimports`, `gofmt`, `prettier`, `eslint`, `tsc`, etc.) and points droids at `.optimus/logs/` when they need test/coverage details.
- AGENTS.md gains the same block alongside the existing **Cross-cutting analysis** rule, so it acts as the single source of truth for future skills.
- New `TestVerificationScope` class in `scripts/test_skill_consistency.py` (2 tests) asserts the block stays in every consumer skill and in AGENTS.md.

## Carve-out

`build` Step 2.2 (TDD implementation droids) is intentionally left untouched — those droids legitimately run tests as part of TDD. Only the Step 2.3 review-dispatch roster (8 review droids) received the new block.

## Files changed

| File | Change |
|---|---|
| `AGENTS.md` | New `**Verification scope:**` block before Cross-cutting (~L3640) |
| `review/SKILL.md` | Phase 3 prompt + convergence reference (L809) |
| `pr-check/SKILL.md` | Findings-mode + diff-mode prompts + Phase 10 ref |
| `coderabbit-review/SKILL.md` | Droid prompt (L351) |
| `deep-review/SKILL.md` | Phase 3 + convergence ref (L448) |
| `plan/SKILL.md` | Step 2.4 + convergence ref (L945) |
| `build/SKILL.md` | Step 2.3 review-dispatch only (Step 2.2 TDD untouched) |
| `scripts/test_skill_consistency.py` | New `TestVerificationScope` class |

8 files, +161 −7.

## Test plan

- [x] `python3 -m pytest scripts/test_skill_consistency.py -k verification_scope -v` — 2 passed
- [x] `python3 -m pytest scripts/test_skill_consistency.py` — 195 passed
- [x] `make lint` — clean
- [x] `python3 scripts/inline-protocols.py` — no SKILL.md drift
- [ ] Spot-check a real `/optimus:review` run and confirm dispatched droids no longer execute verification commands