### PR TITLE
feat(hooks): mirror badge content in iTerm2 session/tab title

### DIFF
--- a/hooks/optimus-skill-loader.sh
+++ b/hooks/optimus-skill-loader.sh
@@ -216,6 +216,37 @@ if [ -n "$stage" ]; then
     badge_b64="$(printf 'OPTIMUS:%s\n%s' "$cmd_upper" "$badge_line2" | base64 | tr -d '\n')"
     printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64" > "/dev/$target_tty" 2>/dev/null || true
 
+    # Title text: single-line "OPTIMUS:<CMD> <ARG>" (omit trailing space
+    # when no arg). Emitted on two channels because iTerm2 surfaces them
+    # differently:
+    #
+    #   1. OSC 1337;SetTabName  — user-set name; shows in the tab strip
+    #      and survives shell prompt redraws (precmd in oh-my-zsh themes
+    #      doesn't write here).
+    #
+    #   2. OSC 0  — icon + window title; this is the channel iTerm2 uses
+    #      to compute the per-session title bar (the strip above each
+    #      pane that normally shows "caffeinate (claude)" or similar
+    #      auto-detected job names). SetTabName alone does NOT override
+    #      the session title bar — OSC 0 does.
+    if [ -n "$task_arg" ]; then
+      title_text="OPTIMUS:${cmd_upper} ${task_arg}"
+    else
+      title_text="OPTIMUS:${cmd_upper}"
+    fi
+    title_b64="$(printf '%s' "$title_text" | base64 | tr -d '\n')"
+    printf '\e]1337;SetTabName=%s\a' "$title_b64" > "/dev/$target_tty" 2>/dev/null || true
+    printf '\e]0;%s\a' "$title_text" > "/dev/$target_tty" 2>/dev/null || true
+
+    # SetUserVar exposes the title content as \(user.optimus) so iTerm2
+    # profiles configured with a custom Title format like
+    #   \(user.optimus)
+    # can render the stage + task ID. SetUserVar values must be base64.
+    # The variable persists across the session and is empty until a
+    # /optimus:* prompt fires the hook.
+    optimus_var_b64="$(printf '%s' "$title_text" | base64 | tr -d '\n')"
+    printf '\e]1337;SetUserVar=optimus=%s\a' "$optimus_var_b64" > "/dev/$target_tty" 2>/dev/null || true
+
     # Tab color: stage → RGB. Matches the canonical mapping inside the
     # SKILL.md files so the stub and the final mark_session call agree.
     case "$stage" in


### PR DESCRIPTION
## Summary
Extends the UserPromptSubmit hook (merged in #74) to also set the iTerm2 **session/tab/window title** to `OPTIMUS:<CMD> <ARG>` — same content as the badge, single-line.

## Why
After #74, users get a per-stage tab background color and a badge overlay, but the per-session title bar still shows iTerm2's auto-detected job name (e.g. `caffeinate (claude)`). Several tabs side-by-side become hard to tell apart at a glance because the colored backgrounds blend together when nothing else differentiates them. The badge helps but is hidden in Mission Control thumbnails at small sizes. A title with the stage + task ID nails the remaining ambiguity.

## What changed
Three escape sequences emitted from the hook for each `/optimus:*` invocation, in addition to the existing badge + tab color:

| Sequence | Surface it controls |
|---|---|
| `OSC 1337;SetTabName=<b64>` | Tab strip label (top of window) |
| `OSC 0;<text>` | macOS window title bar + icon name |
| `OSC 1337;SetUserVar=optimus=<b64>` | Custom user var, referenced via `\(user.optimus)` in profile Title |

The three are needed because iTerm2 surfaces them on different chrome — which one a user sees depends entirely on their profile's Title configuration.

## Title content format

Single-line, no newline (titles don't render newlines):

| Prompt | Title |
|---|---|
| `/optimus:plan T-99` | `OPTIMUS:PLAN T-99` |
| `/optimus:build T-006` | `OPTIMUS:BUILD T-006` |
| `/optimus:prc 42` | `OPTIMUS:PRC 42` |
| `/optimus:plan` (no arg) | `OPTIMUS:PLAN` (no trailing space, no `loading…` filler) |

## Required user setup (one-time, per profile)

To get the title content shown in the **per-session title bar** (the strip above each pane), users must configure their iTerm2 profile:

1. **iTerm2 → Settings (Cmd+,) → Profiles → [profile] → General**
2. Find the **Title** section
3. Click `Customize…` if you see that button; otherwise (this is the case in iTerm2 3.6.x betas) the Title field accepts the format string directly — just type it in
4. Set the format to:
   ```
   \(user.optimus)
   ```
   Or, to keep additional context:
   ```
   \(user.optimus) — \(session.path)
   ```

Without this tweak, only `SetTabName` (tab strip) and `OSC 0` (macOS window title bar) reflect the value. The per-session title bar continues to show the auto-detected job name because iTerm2 uses the profile's title format and ignores `OSC 0` for that surface when the format is `Job` or `Job + Path`.

## Verification

After install + profile config:

```
/optimus:plan T-99 verify
```

Expected:
- **Tab strip label**: `OPTIMUS:PLAN T-99`
- **macOS window title** (titlebar): `OPTIMUS:PLAN T-99`
- **Per-session title bar** (above pane): `OPTIMUS:PLAN T-99` (only if profile uses `\(user.optimus)`)
- **Badge overlay**: `OPTIMUS:PLAN` / `T-99` (unchanged)
- **Tab background**: blue (unchanged)

## Test plan
- [x] Inline harness: 5 new title cases all emit correct base64-encoded escape bytes
- [x] Visual verification against `/dev/ttys013` in development session
- [x] Non-stage skills (`/optimus:help`, `/optimus:report`) emit no title sequences (gated on `[ -n "$stage" ]`)
- [x] Alias `/optimus:sp T-1` produces `OPTIMUS:SP T-1` (preserves typed form, matching badge behavior)
- [ ] After plugin install + profile customization, real-world `/optimus:plan` shows the title on all three surfaces

## Out-of-scope follow-ups
- Update `_optimus_clear_session` (in AGENTS.md + 9 SKILL.md files) to also clear the new title channels with empty values. Skipped here for the same reason as #74's badge-clear: SKILL.md truncation prevents the clear function from firing reliably anyway.
- Documentation: add a one-paragraph note in `AGENTS.md` "Protocol: Terminal Identification" describing the title channel alongside badge + color, plus the required profile configuration.
- README.md: add a small Setup section pointing users to the profile customization step so they don't need to find it in the PR body.