### PR TITLE
docs(readme): iTerm2 Subtitle setup for per-session title surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,44 @@ keeps it up to date as new commands are added.
 Run `/optimus-sync` (or `make sync-plugins`) to sync all plugins — installs new,
 updates existing, removes orphaned. Works for both Droid and Claude Code simultaneously.
 
+### iTerm2 setup (optional, Claude Code only)
+
+When running under Claude Code in iTerm2 on macOS, every `/optimus:*` invocation
+emits OSC escape sequences so you can identify which stage and task each tab is
+running at a glance. Most surfaces work automatically with no setup:
+
+| Surface | Setup needed |
+|---|---|
+| Badge overlay (`STAGE` + task ID) | None |
+| Tab background color (per stage) | None |
+| Tab strip label (`OPTIMUS:<CMD> <ARG>`) | None |
+| macOS window title bar | None |
+| **Per-session subtitle** (strip above each pane) | **One-time profile tweak** |
+
+The per-session subtitle requires a profile-level setting because iTerm2 only
+renders the user variable when its title format explicitly references it:
+
+1. iTerm2 → Settings (Cmd+,) → Profiles → *[your profile]* → General
+2. In the **Subtitle** field (placeholder: "Interpolated string"), paste:
+   ```
+   \(user.optimus)
+   ```
+3. Close the Settings window — iTerm2 saves the profile change immediately.
+   New tabs/windows using that profile pick it up automatically.
+
+After that, the subtitle shows `OPTIMUS:<STAGE> <TASK-ID>` whenever a stage
+skill runs. It stays empty until a `/optimus:*` prompt fires the hook.
+
+**Notes:**
+- The setup is per-profile, per-machine. It survives restarts but does not sync
+  across machines.
+- Non-iTerm2 terminals (Terminal.app, Alacritty, Ghostty, …) silently ignore
+  the OSC sequences without breaking anything.
+- The Droid (Factory) packaging does not ship the hook; this is Claude Code only.
+- iTerm2 3.6.x exposes Subtitle as a free-text field in the Profile General
+  panel; older versions may expose a "Customize…" button on the Title dropdown
+  instead — either path accepts the same `\(user.optimus)` interpolation.
+
 ## Quick Start
 
 1. **Import tasks:** `/optimus-import` — creates `optimus-tasks.md` from Ring pre-dev artifacts


### PR DESCRIPTION
## Summary
Adds a new \"iTerm2 setup (optional, Claude Code only)\" subsection to the README, immediately under Install → Staying up to date. Documents the one-time profile tweak needed to get the per-session subtitle reflecting `\(user.optimus)`.

## Why
After #74 and #75 shipped the UserPromptSubmit hook with badge + tab color + tab strip label + window title + SetUserVar emission, fresh installs get **5 of 6** visual surfaces working automatically. The 6th surface — the per-session subtitle (the strip above each pane) — requires a one-time profile-level setting (`\(user.optimus)` in the Subtitle field) because iTerm2 only renders user variables when the title format explicitly references them.

This step wasn't documented anywhere outside of PR #75's body. Anyone installing the plugin fresh hits the same dead-end I did during development: badge works, tab color works, tab strip changes, but the subtitle still shows the auto-detected job name (e.g. `caffeinate (claude)`).

## What was added
- Table mapping surface → setup needed (5 \"None\", 1 \"One-time profile tweak\").
- Three-step config: Settings → Profiles → General → Subtitle field → paste `\(user.optimus)`.
- Notes on scope (per-profile, per-machine, doesn't sync), other terminals (silent no-op), Droid (not shipped — Claude Code only), and the iTerm2 3.6.x UI difference (Subtitle field vs older \"Customize…\" dropdown).

## Test plan
- [x] Markdown renders cleanly (no broken table, no stray backticks)
- [ ] After this lands, a user on a fresh machine following the README can reach the working subtitle state without trial-and-error.