### PR TITLE
fix(stage-skills): inline _optimus_mark_session — drop relative-path script call

### DIFF
--- a/build/skills/optimus-build/SKILL.md
+++ b/build/skills/optimus-build/SKILL.md
@@ -84,11 +84,6 @@ answering**. The core rules are summarized at the bottom of this file; the
 full guardrails (Scope Discipline, Error Handling, Communication, Dry-Run
 Mode) live in `rules.md`.
 
-Shared scripts (canonical helpers):
-- `scripts/runtime/optimus-mark-session.sh` — iTerm2 badge + tab color
-- `scripts/runtime/optimus-state-read.sh` — JSON read of state.json
-- `scripts/runtime/optimus-task-gate.sh` — status-gate validation
-
 ## Phases
 
 Run phases in order. Before each phase, **`Read` the phase file**, then execute
@@ -97,7 +92,7 @@ its steps.
 1. **Phase 1 — Load Context & Question Everything.** Read `phases/01-load-context.md`.
    Covers GitHub CLI check, tasks.md validation, task ID resolution, session
    state, terminal marking
-   (`bash scripts/runtime/optimus-mark-session.sh mark BUILD ...`), status
+   (iTerm2 badge + tab color via inline helper), status
    validation (`Validando Spec` or `Em Andamento`), dependency checks, workspace
    verification, default-branch refusal, PR title validation, ring droid
    requirement check, project structure discovery (Makefile lint/test HARD
@@ -114,7 +109,7 @@ its steps.
 3. **Phase 3 — Post-Execution.** Read `phases/03-post-execution.md`. Test-gap
    cross-reference with future tasks, final summary, commit (only after
    explicit user approval), and optional push. On completion, clears the iTerm2
-   marker via `bash scripts/runtime/optimus-mark-session.sh clear`.
+   marker via the inline `_optimus_clear_session` helper (defined in the phase file).
 
 ## Rules Summary
 

--- a/build/skills/optimus-build/phases/01-load-context.md
+++ b/build/skills/optimus-build/phases/01-load-context.md
@@ -66,14 +66,66 @@ if [ -z "$TASK_TITLE" ]; then
   TASK_TITLE="(title unavailable)"
 fi
 
-# Canonical helper (badge + tab color). Silent no-op outside iTerm2/macOS.
-bash scripts/runtime/optimus-mark-session.sh mark BUILD "$TASK_ID" "$TASK_TITLE"
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session BUILD "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-bash scripts/runtime/optimus-mark-session.sh clear
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```
 
 ## Step 1.3: Validate and Update Task Status

--- a/build/skills/optimus-build/phases/03-post-execution.md
+++ b/build/skills/optimus-build/phases/03-post-execution.md
@@ -46,5 +46,26 @@ Offer to push commits — see AGENTS.md Protocol: Push Commits.
 On completion, clear the iTerm2 marker:
 
 ```bash
-bash scripts/runtime/optimus-mark-session.sh clear
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```

--- a/done/skills/optimus-done/SKILL.md
+++ b/done/skills/optimus-done/SKILL.md
@@ -61,11 +61,6 @@ request from the user, **you MUST `Read` `rules.md` BEFORE answering**. The
 core rules are summarized at the bottom of this file; the full guardrails live
 in `rules.md`.
 
-Shared scripts (canonical helpers):
-- `scripts/runtime/optimus-mark-session.sh` — iTerm2 badge + tab color
-- `scripts/runtime/optimus-state-read.sh` — JSON read of state.json
-- `scripts/runtime/optimus-task-gate.sh` — status-gate validation
-
 ## Phases
 
 Run phases in order. Before each phase, **`Read` the phase file**, then execute
@@ -75,7 +70,7 @@ its steps.
    Covers GitHub CLI check, optimus-tasks.md validation, workspace resolution
    (current-branch rule), default-branch refusal, task ID resolution, session-state
    handling (done-specific: no resume/redo), terminal marking
-   (`bash scripts/runtime/optimus-mark-session.sh mark DONE ...`), status validation
+   (iTerm2 badge + tab color via inline helper), status validation
    (`Validando Impl` required), dependency checks, and divergence warning.
 
 2. **Phase 2 — Close Gates (4 sequential HARD BLOCKS).** Read `phases/02-close-gates.md`.
@@ -91,7 +86,7 @@ its steps.
    worktree and branch (local + remote). User decides what to keep. Partial-state
    contract: failed remote deletion flags `pending_remote_delete` in state.json
    for later retry. On completion, clears the iTerm2 marker via
-   `bash scripts/runtime/optimus-mark-session.sh clear`.
+   the inline `_optimus_clear_session` helper (defined in the phase file).
 
 <a id="step-resolve-current-workspace"></a>
 **Anchor reference:** other skills point at the workspace-resolution step via

--- a/done/skills/optimus-done/phases/01-identify-and-validate.md
+++ b/done/skills/optimus-done/phases/01-identify-and-validate.md
@@ -100,14 +100,66 @@ if [ -z "$TASK_TITLE" ]; then
   TASK_TITLE="(title unavailable)"
 fi
 
-# Canonical helper (badge + tab color). Silent no-op outside iTerm2/macOS.
-bash scripts/runtime/optimus-mark-session.sh mark DONE "$TASK_ID" "$TASK_TITLE"
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session DONE "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-bash scripts/runtime/optimus-mark-session.sh clear
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```
 
 ## Step 1.1: Validate Task Status

--- a/done/skills/optimus-done/phases/04-cleanup.md
+++ b/done/skills/optimus-done/phases/04-cleanup.md
@@ -192,5 +192,26 @@ push failed.
 On completion, clear the iTerm2 marker:
 
 ```bash
-bash scripts/runtime/optimus-mark-session.sh clear
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```

--- a/plan/skills/optimus-plan/SKILL.md
+++ b/plan/skills/optimus-plan/SKILL.md
@@ -84,11 +84,6 @@ Templates referenced by phases:
 - `templates/validation-dimensions.md` — the 8 dimensions Phase 3 must cover
 - `templates/output-format.md` — the final Validation Report layout
 
-Shared scripts (canonical helpers):
-- `scripts/runtime/optimus-mark-session.sh` — iTerm2 badge + tab color
-- `scripts/runtime/optimus-state-read.sh` — JSON read of state.json
-- `scripts/runtime/optimus-task-gate.sh` — status-gate validation
-
 ## Phases
 
 Run phases in order. Before each phase, **`Read` the phase file**, then execute
@@ -96,7 +91,7 @@ its steps.
 
 1. **Phase 1 — Setup, Task Identification, Workspace.** Read `phases/01-setup.md`.
    Covers GitHub CLI check, optimus-tasks.md validation, task ID resolution,
-   terminal marking (`bash scripts/runtime/optimus-mark-session.sh mark PLAN ...`),
+   terminal marking (iTerm2 badge + tab color via inline helper),
    status/dependency validation, abandoned-workspace recovery, missing-spec
    self-heal, worktree creation, divergence warning, stats increment.
 
@@ -122,7 +117,7 @@ its steps.
 
 9. **Phase 9 — Push Commits (optional).** Read `phases/09-push.md`.
    On completion, clear the iTerm2 marker:
-   `bash scripts/runtime/optimus-mark-session.sh clear`.
+   the inline `_optimus_clear_session` helper (defined in the phase file).
 
 ## Rules Summary
 

--- a/plan/skills/optimus-plan/phases/01-setup.md
+++ b/plan/skills/optimus-plan/phases/01-setup.md
@@ -69,14 +69,66 @@ if [ -z "$TASK_TITLE" ]; then
   TASK_TITLE="(title unavailable)"
 fi
 
-# Canonical helper (badge + tab color). Silent no-op outside iTerm2/macOS.
-bash scripts/runtime/optimus-mark-session.sh mark PLAN "$TASK_ID" "$TASK_TITLE"
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session PLAN "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-bash scripts/runtime/optimus-mark-session.sh clear
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```
 
 > **Note:** the script is a silent no-op outside iTerm2/macOS or when the

--- a/plan/skills/optimus-plan/phases/09-push.md
+++ b/plan/skills/optimus-plan/phases/09-push.md
@@ -10,5 +10,26 @@ Offer to push commits — see AGENTS.md Protocol: Push Commits.
 On successful push completion, clear the iTerm2 marker:
 
 ```bash
-bash scripts/runtime/optimus-mark-session.sh clear
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```

--- a/resume/skills/optimus-resume/SKILL.md
+++ b/resume/skills/optimus-resume/SKILL.md
@@ -81,11 +81,6 @@ For deviations, ambiguous instructions, or any "let me just cd manually" request
 guardrails AND the explicit override of the inlined `Protocol: State Management` destructive
 fallback (Resume STOPs on corruption, never `rm -f`s state.json).
 
-Shared scripts (canonical helpers):
-- `scripts/runtime/optimus-mark-session.sh` — iTerm2 badge + tab color
-- `scripts/runtime/optimus-state-read.sh` — JSON read of state.json
-- `scripts/runtime/optimus-task-gate.sh` — status-gate validation
-
 ## Phases
 
 Run phases in order. Before each phase, **`Read` the phase file**, then execute its steps.
@@ -94,7 +89,7 @@ Run phases in order. Before each phase, **`Read` the phase file**, then execute 
 2. **Phase 2 — Identify Task.** Read `phases/02-identify-task.md`. Resolve task ID (provided or auto-detected from state.json), parse metadata from optimus-tasks.md, refuse terminal statuses (`DONE`/`Cancelado`), informational dependency check (populate `BLOCKING_DEPS`).
 3. **Phase 3 — Resolve Workspace.** Read `phases/03-resolve-workspace.md`. Derive expected branch, look up worktree, apply resolution order. Recovery path (Step 3.3) is the ONLY place that may write to state.json (user-confirmed Reset to Pendente).
 4. **Phase 4 — Set Terminal Title and Report.** Read `phases/04-report.md`. Terminal marking via `bash scripts/runtime/optimus-mark-session.sh mark RESUME ...`. Collect read-only telemetry (git/PR/session/stats). Print `<json-render>` summary with absolute-path `cd` callout. Next-stage recommendation table (status × PR state).
-5. **Phase 5 — Offer Next Stage.** Read `phases/05-next-stage.md`. AskUser to invoke the next stage. Dependency-aware and PR-state-aware option suppression. On delegation, restore terminal via `bash scripts/runtime/optimus-mark-session.sh clear`.
+5. **Phase 5 — Offer Next Stage.** Read `phases/05-next-stage.md`. AskUser to invoke the next stage. Dependency-aware and PR-state-aware option suppression. On delegation, restore terminal via the inline `_optimus_clear_session` helper (defined in the phase file).
 
 ## Rules Summary
 

--- a/resume/skills/optimus-resume/phases/04-report.md
+++ b/resume/skills/optimus-resume/phases/04-report.md
@@ -14,14 +14,66 @@ invocation is a fresh shell, so calling without substitution renders a bare
 Identification.
 
 ```bash
-# Canonical helper (badge + tab color). Silent no-op outside iTerm2/macOS.
-bash scripts/runtime/optimus-mark-session.sh mark RESUME "$TASK_ID" "$TASK_TITLE"
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session RESUME "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On exit or after Phase 5 delegates to another stage skill**, restore the title:
 
 ```bash
-bash scripts/runtime/optimus-mark-session.sh clear
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```
 
 ## Step 4.2: Collect Worktree Telemetry

--- a/review/skills/optimus-review/SKILL.md
+++ b/review/skills/optimus-review/SKILL.md
@@ -91,23 +91,18 @@ core rules are summarized at the bottom of this file; the full guardrails
 No False Positives, User Authority, Communication, Dry-Run Mode) live in
 `rules.md`.
 
-Shared scripts (canonical helpers):
-- `scripts/runtime/optimus-mark-session.sh` — iTerm2 badge + tab color
-- `scripts/runtime/optimus-state-read.sh` — JSON read of state.json
-- `scripts/runtime/optimus-task-gate.sh` — status-gate validation
-
 ## Phases
 
 Run phases in order. Before each phase, **`Read` the phase file**, then execute
 its steps.
 
-1. **Phase 1 — Load Context.** Read `phases/01-load-context.md`. GH CLI, tasks.md, workspace, default-branch refusal, terminal marking (`bash scripts/runtime/optimus-mark-session.sh mark REVIEW ...`), status validation (`Em Andamento` → `Validando Impl`), deps, project structure, doc-brief, changed-files, scope.
+1. **Phase 1 — Load Context.** Read `phases/01-load-context.md`. GH CLI, tasks.md, workspace, default-branch refusal, terminal marking (iTerm2 badge + tab color via inline helper), status validation (`Em Andamento` → `Validando Impl`), deps, project structure, doc-brief, changed-files, scope.
 2. **Phase 2 — Static Analysis and Coverage.** Read `phases/02-static-analysis.md`. Lint/vet/format in parallel, unit tests with coverage, gap analysis.
 3. **Phase 3 — Parallel Agent Dispatch.** Read `phases/03-agent-dispatch.md`. Agent roster, prompt template, per-agent instructions, severity classification.
 4. **Phase 4 — Consolidate and Present.** Read `phases/04-consolidate-and-present.md`. Merge, dedupe, sort, overview table.
 5. **Phase 5 — Resolve Findings (Interactive).** Read `phases/05-resolve-findings.md`. **HARD BLOCK on Tell-me-more — anti-rationalization block carried verbatim.**
 6. **Phase 6 — Apply Fixes.** Read `phases/06-apply-fixes.md`. Batch-apply approved fixes, re-run tests, summary.
-7. **Phase 7 — Finalize.** Read `phases/07-finalize.md`. Convergence loop (opt-in), Re-run Guard, integration tests, validation summary, optional push + PR. Clears iTerm2 marker via `bash scripts/runtime/optimus-mark-session.sh clear`.
+7. **Phase 7 — Finalize.** Read `phases/07-finalize.md`. Convergence loop (opt-in), Re-run Guard, integration tests, validation summary, optional push + PR. Clears iTerm2 marker via the inline `_optimus_clear_session` helper (defined in the phase file).
 
 ## Rules Summary
 

--- a/review/skills/optimus-review/phases/01-load-context.md
+++ b/review/skills/optimus-review/phases/01-load-context.md
@@ -78,14 +78,66 @@ if [ -z "$TASK_TITLE" ]; then
   TASK_TITLE="(title unavailable)"
 fi
 
-# Canonical helper (badge + tab color). Silent no-op outside iTerm2/macOS.
-bash scripts/runtime/optimus-mark-session.sh mark REVIEW "$TASK_ID" "$TASK_TITLE"
+_optimus_mark_session() {
+  local stage="$1" task_id="$2" title="$3"
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  local badge_b64
+  badge_b64=$(printf '%s %s\n%s' "$stage" "$task_id" "$title" | base64 | tr -d '\n')
+  _optimus_emit "$(printf '\e]1337;SetBadgeFormat=%s\a' "$badge_b64")"
+  local r g b
+  case "$stage" in
+    PLAN)   r=66;  g=135; b=245 ;;
+    BUILD)  r=34;  g=197; b=94  ;;
+    REVIEW) r=234; g=179; b=8   ;;
+    DONE)   r=148; g=163; b=184 ;;
+    *)      r=168; g=85;  b=247 ;;
+  esac
+  _optimus_emit "$(printf '\e]6;1;bg;red;brightness;%d\a\e]6;1;bg;green;brightness;%d\a\e]6;1;bg;blue;brightness;%d\a' "$r" "$g" "$b")"
+}
+_optimus_mark_session REVIEW "$TASK_ID" "$TASK_TITLE"
 ```
 
 **On stage completion or exit**, restore the title:
 
 ```bash
-bash scripts/runtime/optimus-mark-session.sh clear
+_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session
 ```
 
 ### Step 1.0.8: Validate and Update Task Status

--- a/review/skills/optimus-review/phases/07-finalize.md
+++ b/review/skills/optimus-review/phases/07-finalize.md
@@ -1,6 +1,27 @@
 # Phase 7: Finalize (Convergence, Re-run Guard, Integration, Summary, Push, PR)
 
-Loaded by `SKILL.md` after fixes are applied. Covers convergence loop (rounds 2-5, opt-in), Re-run Guard, integration tests, validation summary, optional push, and optional PR creation. On completion, clears iTerm2 marker via `bash scripts/runtime/optimus-mark-session.sh clear`.
+Loaded by `SKILL.md` after fixes are applied. Covers convergence loop (rounds 2-5, opt-in), Re-run Guard, integration tests, validation summary, optional push, and optional PR creation. On completion, clears iTerm2 marker via `_optimus_clear_session() {
+  [ "$LC_TERMINAL" = "iTerm2" ] || [ "$TERM_PROGRAM" = "iTerm.app" ] || return 0
+  local pid="$PPID" target_tty=""
+  for _ in 1 2 3 4; do
+    [ -z "$pid" ] || [ "$pid" = "1" ] && break
+    target_tty=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$target_tty" in
+      ""|"?"|"??") pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' '); target_tty="" ;;
+      *) break ;;
+    esac
+  done
+  _optimus_emit_clear() {
+    if [ -n "$target_tty" ] && [ -w "/dev/$target_tty" ]; then
+      printf '%s' "$1" > "/dev/$target_tty" 2>/dev/null || printf '%s' "$1"
+    else
+      printf '%s' "$1"
+    fi
+  }
+  _optimus_emit_clear "$(printf '\e]1337;SetBadgeFormat=\a')"
+  _optimus_emit_clear "$(printf '\e]6;1;bg;*;default\a')"
+}
+_optimus_clear_session`.
 
 Execute the opt-in convergence loop — see AGENTS.md "Common Patterns > Protocol: Convergence Loop (Full Roster Model — Opt-In, Gated)".
 


### PR DESCRIPTION
## The bug

The script-wrapper form introduced by #78 (`bash scripts/runtime/optimus-mark-session.sh mark BUILD ...`) uses a **relative path** that does **NOT resolve** when the agent runs from cwd=user-project (the realistic deployment).

Per platform:

- **Droid:** `scripts/runtime/` ships only at the repo root, but each Droid plugin (`build@optimus`, `plan@optimus`, ...) installs from its own subdirectory (`./build`, `./plan`, ...). The script is **completely absent** from the installed plugin tree — `find ~/.factory/plugins/cache/optimus/build -name 'optimus-mark-session.sh'` returns zero.
- **Claude Code:** the single `optimus@optimus` plugin DOES include `scripts/runtime/` at its install path, but the relative invocation can't reach it from the user's cwd.
- **OpenCode:** symlinks back to the repo source — same relative-path failure from cwd=user-project. This is where the bug was first surfaced ("optimus-mark-session.sh could not be found in the current worktree").

## The fix

Revert the script-wrapper invocations to the inline `_optimus_mark_session()` / `_optimus_clear_session()` function bodies (canonical form from `AGENTS.md` Protocol: Terminal Identification). The inline function is self-contained — each Bash tool invocation defines it fresh in the same shell where it's called, so cwd is irrelevant.

| | Before (#78) | After (this PR) |
|---|---|---|
| Form | `bash scripts/runtime/optimus-mark-session.sh mark BUILD ...` | inline `_optimus_mark_session() { ... } ; _optimus_mark_session BUILD ...` |
| Works on Claude Code? | Only from cwd=plugin-install (rare) | Yes — self-contained |
| Works on Droid? | No (script not in plugin) | Yes — self-contained |
| Works on OpenCode? | Only from cwd=optimus-repo (rare) | Yes — self-contained |

Substitutions: 5 mark calls + 14 clear calls across 14 files.

## Trade-off accepted

This restores ~60 lines of inline bash duplication across the 6 stage skills (plan, build, done, review, resume — batch was never migrated). The size impact on each `SKILL.md` is **negligible** (the inline blocks live in `phases/01-*.md` files, not in the index), and total SKILL.md sizes are essentially unchanged from #78/#79's final state.

The `scripts/runtime/*.sh` files **stay in the repo** as canonical standalone CLI helpers — useful for debugging, scripted use, and future re-introduction with a portable resolver (e.g., absolute path discovered at skill-load time). They're just no longer invoked from skill prose.

## Cleanup

- Removed the "Shared scripts (canonical helpers):" blocks from each SKILL.md Operating Mode section — those scripts are NOT invoked by skill prose, so listing them was misleading.
- Rewrote "terminal marking (\`bash scripts/runtime/...\`)" references in the Phases indexes to "terminal marking (iTerm2 badge + tab color via inline helper)".

## Tests

- **Suite:** 238/238 passing.
- `TestTerminalIdentificationCallSiteSelfContained` (existing regression test) re-validates that every stage skill's setup phase contains an inline `_optimus_mark_session() {` definition in the same bash block as the call — exactly the invariant the inline form satisfies.

## Test plan

- [ ] CI green on the branch.
- [ ] After merge, run `/optimus:sync` to propagate to all 3 platforms.
- [ ] On OpenCode (the platform where this bug was hit), run `/optimus-build T-X` — the agent should mark the iTerm2 session WITHOUT erroring "optimus-mark-session.sh not found".
- [ ] On Claude Code, run `/optimus:plan T-X` — same behavior (the inline form was canonical for ~2 years before #78).
- [ ] On Droid, run `/build T-X` — verify the iTerm2 marker appears (this platform was actually most affected — the script was never even installed).